### PR TITLE
Update comment for connection dict

### DIFF
--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -82,7 +82,7 @@ class ReticulumTelemetryHub:
     def __init__(self, display_name: str, storage_path: Path, identity_path: Path):
         self.ret = RNS.Reticulum()  # Initialize Reticulum
         self.tel_controller = TelemetryController()  # Initialize telemetry controller
-        self.connections = {}  # List to store connections
+        self.connections = {}  # Dictionary of connections keyed by peer hash
 
         identity = self.load_or_generate_identity(
             identity_path


### PR DESCRIPTION
## Summary
- clarify `self.connections` comment that it stores a dictionary keyed by peer hash

## Testing
- `pytest -q` *(fails: TelemetryController._deserialize_telemeter() missing 1 required positional argument: 'peer_dest')*

------
https://chatgpt.com/codex/tasks/task_e_6841aa8418ec83258edf7a8da4076498