### PR TITLE
Fix FieldTelemetryStream class name

### DIFF
--- a/reticulum_telemetry_hub/lxmf_telemetry/model/fields/field_telemetry_stream.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/model/fields/field_telemetry_stream.py
@@ -1,7 +1,7 @@
 from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.telemeter import Telemeter
 
 
-class FieldTelmetryStream():
+class FieldTelemetryStream:
 
     telemeters: list[Telemeter]
     


### PR DESCRIPTION
## Summary
- fix misspelled class name FieldTelemetryStream

## Testing
- `pytest -q` *(fails: TelemetryController._deserialize_telemeter() missing 1 required positional argument)*

------
https://chatgpt.com/codex/tasks/task_e_6841aa7e4b6483258a575cae46870c8a