### PR TITLE
Fix storage_dir identity path

### DIFF
--- a/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
@@ -110,7 +110,7 @@ class TelemetryController:
             telemeter_data[sensor.sid] = sensor_data
         return telemeter_data
 
-    def _deserialize_telemeter(self, tel_data: dict, peer_dest: str) -> Telemeter:
+    def _deserialize_telemeter(self, tel_data: dict, peer_dest: str = "") -> Telemeter:
         """Deserialize the telemeter data."""
         tel = Telemeter(peer_dest)
         for sid in tel_data:

--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -302,9 +302,9 @@ if __name__ == "__main__":
 
     args = ap.parse_args()
 
-    if args.storage_dir:
-        storage_path = args.storage_dir
-        identity_path = os.path.join(STORAGE_PATH, "identity")
+    # Use the provided storage directory (or default) for both storage and identity paths
+    storage_path = args.storage_dir
+    identity_path = os.path.join(storage_path, "identity")
 
     reticulum_server = ReticulumTelemetryHub(
         args.display_name, storage_path, identity_path


### PR DESCRIPTION
## Summary
- ensure custom `--storage_dir` affects both storage and identity paths
- make telemetry deserialiser `peer_dest` optional to satisfy tests

## Testing
- `pytest -q` *(fails: Location sensor unpack error)*

------
https://chatgpt.com/codex/tasks/task_e_6841aa8128c88325ad9faf3e7cd5b797