### PR TITLE
Add coverage configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+source = reticulum_telemetry_hub
+omit =
+    tests/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ lxmf = "^0.4.4"
 msgpack = "^1.0.8"
 sqlalchemy = "^2.0.32"
 pytest = "^8.3.2"
+pytest-cov = "^6.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=reticulum_telemetry_hub --cov-report=term-missing


### PR DESCRIPTION
## Summary
- configure coverage with `.coveragerc`
- enable pytest-cov via `pytest.ini`
- install `pytest-cov` dependency

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842044583048325b87c4848947ed0a4