### PR TITLE
Fix LXMF connection handling and extend telemetry tests

### DIFF
--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -175,7 +175,7 @@ class ReticulumTelemetryHub:
         Args:
             message (str): Message to send
         """
-        for connection in self.connections:
+        for connection in self.connections.values():
             response = LXMF.LXMessage(
                 connection,
                 self.my_lxmf_dest,
@@ -229,8 +229,9 @@ class ReticulumTelemetryHub:
             elif choice == "telemetry":
                 connection_hash = input("Enter the connection hash: ")
                 found = False
-                for connection in self.connections:
-                    if connection.hexhash == connection_hash:
+                normalized_hash = connection_hash.strip().lower().replace(":", "")
+                for conn_hash, connection in self.connections.items():
+                    if conn_hash.hex() == normalized_hash:
                         message = LXMF.LXMessage(
                             connection,
                             self.my_lxmf_dest,

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -4,6 +4,9 @@ from pathlib import Path
 from reticulum_telemetry_hub.reticulum_server.__main__ import ReticulumTelemetryHub
 from reticulum_telemetry_hub.reticulum_server.command_manager import CommandManager
 from reticulum_telemetry_hub.reticulum_server.constants import PLUGIN_COMMAND
+from reticulum_telemetry_hub.lxmf_telemetry.telemetry_controller import (
+    TelemetryController,
+)
 
 
 def make_message(dest, source, command):
@@ -41,3 +44,51 @@ def test_join_and_list_clients(tmp_path):
     assert sent
     reply = sent[-1]
     assert reply.content_as_string() == RNS.prettyhexrep(client_dest.identity.hash)
+
+
+def test_send_message_uses_connection_values(tmp_path):
+    hub = ReticulumTelemetryHub("TestHub", str(tmp_path), tmp_path / "identity")
+    sent = []
+    hub.lxm_router.handle_outbound = lambda m: sent.append(m)
+
+    dest_one = RNS.Destination(
+        RNS.Identity(), RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"
+    )
+    dest_two = RNS.Destination(
+        RNS.Identity(), RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"
+    )
+
+    hub.connections = {
+        dest_one.identity.hash: dest_one,
+        dest_two.identity.hash: dest_two,
+    }
+
+    hub.send_message("Hello")
+
+    assert len(sent) == 2
+    destinations = {msg.destination_hash for msg in sent}
+    assert destinations == {dest_one.identity.hash, dest_two.identity.hash}
+    assert all(msg.content_as_string() == "Hello" for msg in sent)
+
+
+def test_interactive_loop_requests_telemetry_for_known_connection(monkeypatch, tmp_path):
+    hub = ReticulumTelemetryHub("TestHub", str(tmp_path), tmp_path / "identity")
+    sent = []
+    hub.lxm_router.handle_outbound = lambda m: sent.append(m)
+
+    dest = RNS.Destination(
+        RNS.Identity(), RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"
+    )
+    hub.connections = {dest.identity.hash: dest}
+
+    inputs = iter(["telemetry", dest.identity.hash.hex(), "exit"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    hub.interactive_loop()
+
+    assert len(sent) == 1
+    telemetry_message = sent[0]
+    assert telemetry_message.destination_hash == dest.identity.hash
+    assert telemetry_message.fields[LXMF.FIELD_COMMANDS][0][
+        TelemetryController.TELEMETRY_REQUEST
+    ] == 1000000000


### PR DESCRIPTION
## Summary
- ensure broadcast messages iterate over stored LXMF destinations rather than connection hashes
- update the interactive telemetry loop to resolve destinations from the connection mapping by hash
- extend the command manager test suite to cover broadcasting and telemetry requests when connections are stored in a dict

## Testing
- pytest --override-ini=addopts= *(fails: missing RNS and LXMF modules in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6537c62348325ac0ddedfd0a01454