### PR TITLE
Ensure telemetry stream is msgpack encoded

### DIFF
--- a/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
@@ -93,7 +93,9 @@ class TelemetryController:
                         ['account', b'\x00\x00\x00', b'\xff\xff\xff'],
                     ]
                 )
-            message.fields[LXMF.FIELD_TELEMETRY_STREAM] = packed_tels
+            message.fields[LXMF.FIELD_TELEMETRY_STREAM] = packb(
+                packed_tels, use_bin_type=True
+            )
             print("+--- Sending telemetry data---------------------------------")
             print(f"| Telemetry data: {packed_tels}")
             print(f"| Message: {message}")

--- a/tests/test_lxmf_telemetry.py
+++ b/tests/test_lxmf_telemetry.py
@@ -1,4 +1,13 @@
-from msgpack import unpackb
+import time
+
+import LXMF
+import RNS
+from msgpack import packb, unpackb
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from reticulum_telemetry_hub.lxmf_telemetry import telemetry_controller as tc_mod
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance import Base
 from reticulum_telemetry_hub.lxmf_telemetry.telemetry_controller import TelemetryController
 import pytest
 
@@ -12,3 +21,35 @@ def test_deserialize_lxmf():
     location = next(s for s in tel.sensors if hasattr(s, "latitude"))
     assert pytest.approx(location.latitude, rel=1e-6) == 44.657059
     assert pytest.approx(location.longitude, rel=1e-6) == -63.596294
+
+
+def test_handle_command_stream_is_msgpack_encoded(tmp_path):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    tc_mod._engine = engine
+    tc_mod.Session_cls = sessionmaker(bind=engine)
+
+    controller = TelemetryController()
+
+    src_identity = RNS.Identity()
+    dst_identity = RNS.Identity()
+    src = RNS.Destination(src_identity, RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery")
+    dst = RNS.Destination(dst_identity, RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery")
+
+    with open("sample.bin", "rb") as f:
+        tel_data = unpackb(f.read(), strict_map_key=False)
+
+    packed = packb(tel_data, use_bin_type=True)
+    message = LXMF.LXMessage(dst, src, fields={LXMF.FIELD_TELEMETRY: packed})
+    assert controller.handle_message(message)
+
+    command_msg = LXMF.LXMessage(src, dst)
+    cmd = {TelemetryController.TELEMETRY_REQUEST: int(time.time())}
+
+    reply = controller.handle_command(cmd, command_msg, dst)
+    stream = reply.fields[LXMF.FIELD_TELEMETRY_STREAM]
+
+    assert isinstance(stream, (bytes, bytearray))
+    unpacked = unpackb(stream, strict_map_key=False)
+    assert isinstance(unpacked, list)
+    assert unpacked


### PR DESCRIPTION
## Summary
- encode telemetry stream fields with msgpack using binary type support before sending replies
- add a regression test that ensures the telemetry stream returned by handle_command can be decoded

## Testing
- pytest tests/test_lxmf_telemetry.py

------
https://chatgpt.com/codex/tasks/task_e_68e657f125d88325b966a9187b6d2c3a