### PR TITLE
Align inertial sensor constructors with Sideband signature

### DIFF
--- a/reticulum_telemetry_hub/lxmf_telemetry/model/persistance/sensors/acceleration.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/model/persistance/sensors/acceleration.py
@@ -18,8 +18,23 @@ class Acceleration(Sensor):
     y: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     z: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
 
-    def __init__(self) -> None:
-        super().__init__(stale_time=1)
+    def __init__(
+        self,
+        stale_time: float | None = 1,
+        data: Any | None = None,
+        active: bool = False,
+        synthesized: bool = False,
+        last_update: float = 0,
+        last_read: float = 0,
+    ) -> None:
+        super().__init__(
+            stale_time=stale_time,
+            data=data,
+            active=active,
+            synthesized=synthesized,
+            last_update=last_update,
+            last_read=last_read,
+        )
         self.sid = SID_ACCELERATION
 
     def pack(self):  # type: ignore[override]

--- a/reticulum_telemetry_hub/lxmf_telemetry/model/persistance/sensors/angular_velocity.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/model/persistance/sensors/angular_velocity.py
@@ -18,8 +18,23 @@ class AngularVelocity(Sensor):
     y: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     z: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
 
-    def __init__(self) -> None:
-        super().__init__(stale_time=1)
+    def __init__(
+        self,
+        stale_time: float | None = 1,
+        data: Any | None = None,
+        active: bool = False,
+        synthesized: bool = False,
+        last_update: float = 0,
+        last_read: float = 0,
+    ) -> None:
+        super().__init__(
+            stale_time=stale_time,
+            data=data,
+            active=active,
+            synthesized=synthesized,
+            last_update=last_update,
+            last_read=last_read,
+        )
         self.sid = SID_ANGULAR_VELOCITY
 
     def pack(self):  # type: ignore[override]

--- a/reticulum_telemetry_hub/lxmf_telemetry/model/persistance/sensors/gravity.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/model/persistance/sensors/gravity.py
@@ -18,8 +18,23 @@ class Gravity(Sensor):
     y: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     z: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
 
-    def __init__(self) -> None:
-        super().__init__(stale_time=1)
+    def __init__(
+        self,
+        stale_time: float | None = 1,
+        data: Any | None = None,
+        active: bool = False,
+        synthesized: bool = False,
+        last_update: float = 0,
+        last_read: float = 0,
+    ) -> None:
+        super().__init__(
+            stale_time=stale_time,
+            data=data,
+            active=active,
+            synthesized=synthesized,
+            last_update=last_update,
+            last_read=last_read,
+        )
         self.sid = SID_GRAVITY
 
     def pack(self):  # type: ignore[override]

--- a/reticulum_telemetry_hub/lxmf_telemetry/model/persistance/sensors/magnetic_field.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/model/persistance/sensors/magnetic_field.py
@@ -18,8 +18,23 @@ class MagneticField(Sensor):
     y: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     z: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
 
-    def __init__(self) -> None:
-        super().__init__(stale_time=1)
+    def __init__(
+        self,
+        stale_time: float | None = 1,
+        data: Any | None = None,
+        active: bool = False,
+        synthesized: bool = False,
+        last_update: float = 0,
+        last_read: float = 0,
+    ) -> None:
+        super().__init__(
+            stale_time=stale_time,
+            data=data,
+            active=active,
+            synthesized=synthesized,
+            last_update=last_update,
+            last_read=last_read,
+        )
         self.sid = SID_MAGNETIC_FIELD
 
     def pack(self):  # type: ignore[override]


### PR DESCRIPTION
## Summary
- update the acceleration, angular velocity, gravity, and magnetic field sensor models to accept the full Sideband constructor signature
- keep their three-axis pack/unpack logic while continuing to register the appropriate sensor IDs

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f383913083258ce5a6cea04802d7)