### PR TITLE
Add comprehensive tests and fix telemetry serialization

### DIFF
--- a/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
@@ -6,6 +6,9 @@ from msgpack import packb, unpackb
 from reticulum_telemetry_hub.lxmf_telemetry.model.persistance import Base
 from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.sensor import Sensor
 from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.telemeter import Telemeter
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.lxmf_propagation import (
+    LXMFPropagation,
+)
 
 from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.sensor_mapping import sid_mapping
 from sqlalchemy import create_engine
@@ -13,7 +16,7 @@ from sqlalchemy.orm import sessionmaker, Session, joinedload
 
 _engine = create_engine("sqlite:///telemetry.db")
 Base.metadata.create_all(_engine)
-Session_cls = sessionmaker(bind=_engine)
+Session_cls = sessionmaker(bind=_engine, expire_on_commit=False)
 
 
 class TelemetryController:
@@ -24,18 +27,31 @@ class TelemetryController:
     def __init__(self) -> None:
         pass
 
+    def _load_telemetry(
+        self,
+        session: Session,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+    ) -> list[Telemeter]:
+        query = session.query(Telemeter)
+        if start_time:
+            query = query.filter(Telemeter.time >= start_time)
+        if end_time:
+            query = query.filter(Telemeter.time <= end_time)
+        tels = query.options(
+            joinedload(Telemeter.sensors),
+            joinedload(Telemeter.sensors.of_type(LXMFPropagation)).joinedload(
+                LXMFPropagation.peers
+            ),
+        ).all()
+        return tels
+
     def get_telemetry(
         self, start_time: Optional[datetime] = None, end_time: Optional[datetime] = None
     ) -> list[Telemeter]:
         """Get the telemetry data."""
         with Session_cls() as ses:
-            query = ses.query(Telemeter)
-            if start_time:
-                query = query.filter(Telemeter.time >= start_time)
-            if end_time:
-                query = query.filter(Telemeter.time <= end_time)
-            tels = query.options(joinedload(Telemeter.sensors)).all()
-            return tels
+            return self._load_telemetry(ses, start_time, end_time)
 
     def save_telemetry(
         self, telemetry_data: dict, peer_dest, timestamp: Optional[datetime] = None
@@ -84,31 +100,34 @@ class TelemetryController:
         """Handle the incoming command."""
         if TelemetryController.TELEMETRY_REQUEST in command:
             timebase = command[TelemetryController.TELEMETRY_REQUEST]
-            tels = self.get_telemetry(start_time=datetime.fromtimestamp(timebase))
-            packed_tels = []
-            dest = RNS.Destination(
-                message.source.identity,
-                RNS.Destination.OUT,
-                RNS.Destination.SINGLE,
-                "lxmf",
-                "delivery",
-            )
-            message = LXMF.LXMessage(
-                    dest,
-                    my_lxm_dest,
-                    "Telemetry data",
-                    desired_method=LXMF.LXMessage.DIRECT,
+            with Session_cls() as ses:
+                tels = self._load_telemetry(
+                    ses, start_time=datetime.fromtimestamp(timebase)
                 )
-            for tel in tels:
-                tel_data = self._serialize_telemeter(tel)
-                packed_tels.append(
-                    [
-                        bytes.fromhex(tel.peer_dest),
-                        round(tel.time.timestamp()),
-                        packb(tel_data),
-                        ['account', b'\x00\x00\x00', b'\xff\xff\xff'],
-                    ]
+                packed_tels = []
+                dest = RNS.Destination(
+                    message.source.identity,
+                    RNS.Destination.OUT,
+                    RNS.Destination.SINGLE,
+                    "lxmf",
+                    "delivery",
                 )
+                message = LXMF.LXMessage(
+                        dest,
+                        my_lxm_dest,
+                        "Telemetry data",
+                        desired_method=LXMF.LXMessage.DIRECT,
+                    )
+                for tel in tels:
+                    tel_data = self._serialize_telemeter(tel)
+                    packed_tels.append(
+                        [
+                            bytes.fromhex(tel.peer_dest),
+                            round(tel.time.timestamp()),
+                            packb(tel_data),
+                            ['account', b'\x00\x00\x00', b'\xff\xff\xff'],
+                        ]
+                    )
             message.fields[LXMF.FIELD_TELEMETRY_STREAM] = packb(
                 packed_tels, use_bin_type=True
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+"""Pytest fixtures shared across telemetry tests."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from reticulum_telemetry_hub.lxmf_telemetry import telemetry_controller as tc_mod
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance import Base
+from reticulum_telemetry_hub.lxmf_telemetry.telemetry_controller import TelemetryController
+
+
+@pytest.fixture
+def session_factory():
+    """Provide an isolated in-memory database and session factory per test."""
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    old_engine = tc_mod._engine
+    old_session_cls = tc_mod.Session_cls
+    tc_mod._engine = engine
+    tc_mod.Session_cls = SessionLocal
+
+    try:
+        yield SessionLocal
+    finally:
+        tc_mod._engine = old_engine
+        tc_mod.Session_cls = old_session_cls
+        engine.dispose()
+
+
+@pytest.fixture
+def telemetry_controller(session_factory):
+    """Return a ``TelemetryController`` bound to the in-memory database."""
+
+    return TelemetryController()
+

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,212 @@
+"""Test helpers for constructing representative telemetry sensors and payloads."""
+from __future__ import annotations
+
+from typing import Dict
+
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.connection_map import (
+    ConnectionMap,
+)
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.lxmf_propagation import (
+    LXMFPropagation,
+)
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.rns_transport import (
+    RNSTransport,
+)
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.sensor_enum import (
+    SID_CONNECTION_MAP,
+    SID_LXMF_PROPAGATION,
+    SID_RNS_TRANSPORT,
+)
+
+
+PEER_HASH_A = b"\xaa" * 16
+PEER_HASH_B = b"\xbb" * 16
+
+
+def create_rns_transport_sensor() -> RNSTransport:
+    """Return an ``RNSTransport`` populated with nested Sideband payload data."""
+
+    sensor = RNSTransport()
+    sensor.unpack(
+        {
+            "transport_enabled": True,
+            "transport_identity": b"\x01" * 16,
+            "transport_uptime": 4242,
+            "traffic_rxb": 10_000,
+            "traffic_txb": 20_000,
+            "speed_rx": 128.5,
+            "speed_tx": 256.75,
+            "speed_rx_inst": 130.0,
+            "speed_tx_inst": 260.0,
+            "memory_used": 12_345_678,
+            "interface_count": 2,
+            "link_count": 7,
+            "interfaces": [
+                {"name": "if0", "state": "up"},
+                {"name": "if1", "state": "down"},
+            ],
+            "path_table": [
+                {
+                    "interface": "if0",
+                    "via": b"\xaa" * 8,
+                    "hash": b"\xbb" * 16,
+                    "hops": 1,
+                }
+            ],
+            "ifstats": {
+                "rxb": 10_000,
+                "txb": 20_000,
+                "rxs": 500.0,
+                "txs": 600.0,
+                "interfaces": [
+                    {"name": "if0", "paths": 2},
+                    {"name": "if1", "paths": 0},
+                ],
+            },
+            "custom_metric": 99.9,
+        }
+    )
+    return sensor
+
+
+def create_lxmf_propagation_sensor() -> LXMFPropagation:
+    """Return an ``LXMFPropagation`` sensor with multiple peers and aggregates."""
+
+    sensor = LXMFPropagation()
+    sensor.unpack(
+        {
+            "destination_hash": b"\x10" * 16,
+            "identity_hash": b"\x20" * 16,
+            "uptime": 12_345,
+            "delivery_limit": 42.5,
+            "propagation_limit": 256.0,
+            "autopeer_maxdepth": 3,
+            "from_static_only": True,
+            "messagestore": {"count": 5, "bytes": 4096, "limit": 8192},
+            "clients": {
+                "client_propagation_messages_received": 7,
+                "client_propagation_messages_served": 9,
+            },
+            "unpeered_propagation_incoming": 2,
+            "unpeered_propagation_rx_bytes": 1_024,
+            "static_peers": 1,
+            "max_peers": 10,
+            "peers": {
+                PEER_HASH_A: {
+                    "type": "propagator",
+                    "state": "active",
+                    "alive": True,
+                    "last_heard": 1_234.5,
+                    "next_sync_attempt": 2_345.6,
+                    "last_sync_attempt": 1_111.0,
+                    "sync_backoff": 10.0,
+                    "peering_timebase": 42.0,
+                    "ler": 0.75,
+                    "str": 0.5,
+                    "transfer_limit": 512,
+                    "network_distance": 2,
+                    "rx_bytes": 2_048,
+                    "tx_bytes": 4_096,
+                    "messages": {
+                        "offered": 3,
+                        "outgoing": 2,
+                        "incoming": 1,
+                        "unhandled": 0,
+                    },
+                },
+                PEER_HASH_B: {
+                    "type": "propagator",
+                    "state": "down",
+                    "alive": False,
+                    "last_heard": 3_210.1,
+                    "next_sync_attempt": None,
+                    "last_sync_attempt": 2_222.0,
+                    "sync_backoff": 20.0,
+                    "peering_timebase": 84.0,
+                    "ler": 0.55,
+                    "str": 0.25,
+                    "transfer_limit": 256,
+                    "network_distance": 4,
+                    "rx_bytes": 512,
+                    "tx_bytes": 256,
+                    "messages": {
+                        "offered": 1,
+                        "outgoing": 0,
+                        "incoming": 0,
+                        "unhandled": 1,
+                    },
+                },
+            },
+        }
+    )
+    sensor.unpeered_incoming = 2
+    sensor.unpeered_rx_bytes = 1_024
+    sensor.static_peers = 1
+    sensor.max_peers = 10
+    return sensor
+
+
+def create_connection_map_sensor() -> ConnectionMap:
+    """Return a ``ConnectionMap`` with multiple maps and signal updates."""
+
+    sensor = ConnectionMap()
+    sensor.ensure_map("main", "Main Map")
+    sensor.add_point(
+        "main",
+        "deadbeef",
+        latitude=44.0,
+        longitude=-63.0,
+        altitude=10.0,
+        point_type="peer",
+        name="Gateway",
+        signal_strength=-42,
+        snr=12.5,
+    )
+    sensor.add_point("main", "deadbeef", signal_strength=-40)
+
+    sensor.ensure_map("backup", "Backup Map")
+    sensor.add_point(
+        "backup",
+        "feedface",
+        latitude=45.0,
+        longitude=-62.0,
+        altitude=12.0,
+        point_type="peer",
+        name="Repeater",
+        signal_strength=-55,
+        snr=10.0,
+    )
+    return sensor
+
+
+def build_complex_telemeter_payload() -> Dict[int, dict]:
+    """Return a telemetry payload covering complex/nested sensors."""
+
+    sensors = [
+        create_rns_transport_sensor(),
+        create_lxmf_propagation_sensor(),
+        create_connection_map_sensor(),
+    ]
+    payload: Dict[int, dict] = {}
+    for sensor in sensors:
+        packed = sensor.pack()
+        if packed is not None:
+            payload[sensor.sid] = packed
+    return payload
+
+
+def build_rns_transport_payload() -> dict:
+    return create_rns_transport_sensor().pack() or {}
+
+
+def build_lxmf_propagation_payload() -> dict:
+    return create_lxmf_propagation_sensor().pack() or {}
+
+
+def build_connection_map_payload() -> dict:
+    return create_connection_map_sensor().pack() or {}
+
+
+def complex_sensor_sids() -> tuple[int, int, int]:
+    return SID_RNS_TRANSPORT, SID_LXMF_PROPAGATION, SID_CONNECTION_MAP
+


### PR DESCRIPTION
## Summary
- add reusable factory helpers and pytest fixtures for constructing complex telemetry sensors
- extend telemetry controller tests to cover msgpack round-trips for RNSTransport, LXMFPropagation, and ConnectionMap sensors
- ensure the telemetry controller loads nested relationships inside an active session when serializing command replies

## Testing
- pytest tests/test_lxmf_telemetry.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176ab4f5888325a7cc5efda8121a21)