### PR TITLE
Add embedded LXMD runtime and CLI integration

### DIFF
--- a/reticulum_telemetry_hub/embedded_lxmd/__init__.py
+++ b/reticulum_telemetry_hub/embedded_lxmd/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for running the LXMF daemon in-process."""
+
+from .embedded import EmbeddedLxmd
+
+__all__ = ["EmbeddedLxmd"]

--- a/reticulum_telemetry_hub/embedded_lxmd/embedded.py
+++ b/reticulum_telemetry_hub/embedded_lxmd/embedded.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import LXMF
+import RNS
+
+from reticulum_telemetry_hub.config.manager import HubConfigurationManager
+
+
+@dataclass
+class EmbeddedLxmdConfig:
+    """Runtime configuration for the embedded LXMD service."""
+
+    enable_propagation_node: bool
+    announce_interval_seconds: int
+
+    @classmethod
+    def from_manager(cls, manager: HubConfigurationManager) -> "EmbeddedLxmdConfig":
+        lxmf_config = manager.config.lxmf_router
+        interval = max(1, int(lxmf_config.announce_interval_minutes) * 60)
+        return cls(
+            enable_propagation_node=lxmf_config.enable_node,
+            announce_interval_seconds=interval,
+        )
+
+
+class EmbeddedLxmd:
+    """Run the LXMF router propagation loop within the current process.
+
+    The stock ``lxmd`` daemon starts a couple of helper threads that periodically
+    announces the delivery destination and, when configured, runs the propagation
+    node loop. When the hub is executed in *embedded* mode those responsibilities
+    need to run side-by-side with the main application instead of being spawned
+    as a separate process. ``EmbeddedLxmd`` mirrors the subset of ``lxmd``'s
+    behaviour that ReticulumTelemetryHub relies on and provides an explicit
+    lifecycle so the threads can be shut down gracefully.
+    """
+
+    DEFERRED_JOBS_DELAY = 10
+    JOBS_INTERVAL_SECONDS = 5
+
+    def __init__(
+        self,
+        router: LXMF.LXMRouter,
+        destination: RNS.Destination,
+        config_manager: Optional[HubConfigurationManager] = None,
+    ) -> None:
+        self.router = router
+        self.destination = destination
+        self.config_manager = config_manager or HubConfigurationManager()
+        self.config = EmbeddedLxmdConfig.from_manager(self.config_manager)
+        self._stop_event = threading.Event()
+        self._threads: list[threading.Thread] = []
+        self._started = False
+        self._last_peer_announce: float | None = None
+        self._last_node_announce: float | None = None
+
+    def start(self) -> None:
+        """Start the embedded propagation threads if not already running."""
+
+        if self._started:
+            return
+
+        if self.config.enable_propagation_node:
+            try:
+                self.router.enable_propagation()
+            except Exception as exc:  # pragma: no cover - defensive logging
+                RNS.log(
+                    f"Failed to enable LXMF propagation node in embedded mode: {exc}",
+                    RNS.LOG_ERROR,
+                )
+
+        self._started = True
+        self._start_thread(self._deferred_start_jobs)
+
+    def stop(self) -> None:
+        """Request the helper threads to stop and wait for them to finish."""
+
+        if not self._started:
+            return
+
+        self._stop_event.set()
+        for thread in self._threads:
+            thread.join(timeout=1)
+        self._threads.clear()
+        self._started = False
+
+    # ------------------------------------------------------------------ #
+    # private helpers
+    # ------------------------------------------------------------------ #
+    def _start_thread(self, target) -> None:
+        thread = threading.Thread(target=target, daemon=True)
+        thread.start()
+        self._threads.append(thread)
+
+    def _announce_delivery(self) -> None:
+        try:
+            self.router.announce(self.destination.hash)
+        except Exception as exc:  # pragma: no cover - logging guard
+            RNS.log(
+                f"Failed to announce embedded LXMF destination: {exc}",
+                RNS.LOG_ERROR,
+            )
+
+    def _announce_propagation(self) -> None:
+        try:
+            self.router.announce_propagation_node()
+        except Exception as exc:  # pragma: no cover - logging guard
+            RNS.log(
+                f"Failed to announce embedded propagation node: {exc}",
+                RNS.LOG_ERROR,
+            )
+
+    def _deferred_start_jobs(self) -> None:
+        if self._stop_event.wait(self.DEFERRED_JOBS_DELAY):
+            return
+
+        self._announce_delivery()
+        self._last_peer_announce = time.monotonic()
+
+        if self.config.enable_propagation_node:
+            self._announce_propagation()
+            self._last_node_announce = self._last_peer_announce
+
+        self._start_thread(self._jobs)
+
+    def _jobs(self) -> None:
+        interval = self.config.announce_interval_seconds
+        while not self._stop_event.wait(self.JOBS_INTERVAL_SECONDS):
+            now = time.monotonic()
+            if (
+                self._last_peer_announce is None
+                or now - self._last_peer_announce >= interval
+            ):
+                self._announce_delivery()
+                self._last_peer_announce = now
+
+            if not self.config.enable_propagation_node:
+                continue
+
+            if (
+                self._last_node_announce is None
+                or now - self._last_node_announce >= interval
+            ):
+                self._announce_propagation()
+                self._last_node_announce = now
+
+    # Allow usage as a context manager for convenience
+    def __enter__(self) -> "EmbeddedLxmd":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()

--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -34,6 +34,9 @@ import LXMF
 import RNS
 import argparse
 from pathlib import Path
+
+from reticulum_telemetry_hub.config.manager import HubConfigurationManager
+from reticulum_telemetry_hub.embedded_lxmd import EmbeddedLxmd
 from reticulum_telemetry_hub.lxmf_telemetry.telemetry_controller import (
     TelemetryController,
 )
@@ -93,9 +96,18 @@ class ReticulumTelemetryHub:
     storage_path: Path
     identity_path: Path
     tel_controller: TelemetryController
+    config_manager: HubConfigurationManager | None
+    embedded_lxmd: EmbeddedLxmd | None
     _shared_lxm_router: LXMF.LXMRouter | None = None
 
-    def __init__(self, display_name: str, storage_path: Path, identity_path: Path):
+    def __init__(
+        self,
+        display_name: str,
+        storage_path: Path,
+        identity_path: Path,
+        *,
+        embedded: bool = False,
+    ):
         # Normalize paths early so downstream helpers can rely on Path objects.
         self.storage_path = Path(storage_path)
         self.identity_path = Path(identity_path)
@@ -106,6 +118,9 @@ class ReticulumTelemetryHub:
         # to avoid triggering the single-instance guard in the RNS library.
         self.ret = RNS.Reticulum.get_instance() or RNS.Reticulum()
         self.tel_controller = TelemetryController()
+        self.config_manager: HubConfigurationManager | None = None
+        self.embedded_lxmd: EmbeddedLxmd | None = None
+        self._shutdown = False
         self.connections: dict[bytes, RNS.Destination] = {}
 
         identity = self.load_or_generate_identity(self.identity_path)
@@ -129,6 +144,18 @@ class ReticulumTelemetryHub:
         self.lxm_router.set_message_storage_limit(megabytes=5)
         self.lxm_router.register_delivery_callback(self.delivery_callback)
         RNS.Transport.register_announce_handler(AnnounceHandler(self.identities))
+
+        if embedded:
+            self.config_manager = HubConfigurationManager(storage_path=self.storage_path)
+            self.embedded_lxmd = EmbeddedLxmd(
+                router=self.lxm_router,
+                destination=self.my_lxmf_dest,
+                config_manager=self.config_manager,
+            )
+            self.embedded_lxmd.start()
+        else:
+            self.config_manager = None
+            self.embedded_lxmd = None
 
     def command_handler(self, commands: list, message: LXMF.LXMessage):
         """Handles commands received from the client and sends responses back.
@@ -293,6 +320,14 @@ class ReticulumTelemetryHub:
             self.my_lxmf_dest.announce()
             time.sleep(60)
 
+    def shutdown(self):
+        if self._shutdown:
+            return
+        self._shutdown = True
+        if self.embedded_lxmd is not None:
+            self.embedded_lxmd.stop()
+            self.embedded_lxmd = None
+
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument(
@@ -300,6 +335,13 @@ if __name__ == "__main__":
     )
     ap.add_argument("--headless", action="store_true", help="Run in headless mode")
     ap.add_argument("--display_name", help="Display name for the server", default="RTH")
+    ap.add_argument(
+        "--embedded",
+        "--embedded-lxmd",
+        dest="embedded",
+        action="store_true",
+        help="Run the LXMF router/propagation threads in-process.",
+    )
 
     args = ap.parse_args()
 
@@ -318,10 +360,15 @@ if __name__ == "__main__":
 
 
     reticulum_server = ReticulumTelemetryHub(
-        args.display_name, storage_path, identity_path
+        args.display_name, storage_path, identity_path, embedded=args.embedded
     )
 
-    if not args.headless:
-        reticulum_server.interactive_loop()
-    else:
-        reticulum_server.headless_loop()
+    try:
+        if not args.headless:
+            reticulum_server.interactive_loop()
+        else:
+            reticulum_server.headless_loop()
+    except KeyboardInterrupt:
+        RNS.log("Received interrupt, shutting down", RNS.LOG_INFO)
+    finally:
+        reticulum_server.shutdown()


### PR DESCRIPTION
## Summary
- add an EmbeddedLxmd helper that boots the LXMF propagation threads inside the hub process
- update ReticulumTelemetryHub to manage the embedded daemon lifecycle and expose a shutdown hook
- extend the CLI with an --embedded flag and ensure we shut down cleanly on exit

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917cf5873248325b462cedabebce620)