### PR TITLE
Add propagation telemetry observers to embedded LXMD

### DIFF
--- a/reticulum_telemetry_hub/embedded_lxmd/embedded.py
+++ b/reticulum_telemetry_hub/embedded_lxmd/embedded.py
@@ -2,13 +2,23 @@ from __future__ import annotations
 
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Optional
+from datetime import datetime
+from typing import Any, Optional
 
 import LXMF
 import RNS
+from msgpack import packb
 
 from reticulum_telemetry_hub.config.manager import HubConfigurationManager
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.lxmf_propagation import (
+    LXMFPropagation,
+)
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.sensor_enum import (
+    SID_LXMF_PROPAGATION,
+)
+from reticulum_telemetry_hub.lxmf_telemetry.telemetry_controller import TelemetryController
 
 
 @dataclass
@@ -43,16 +53,25 @@ class EmbeddedLxmd:
     DEFERRED_JOBS_DELAY = 10
     JOBS_INTERVAL_SECONDS = 5
 
+    PROPAGATION_UPTIME_GRANULARITY = 30
+
     def __init__(
         self,
         router: LXMF.LXMRouter,
         destination: RNS.Destination,
         config_manager: Optional[HubConfigurationManager] = None,
+        telemetry_controller: Optional[TelemetryController] = None,
     ) -> None:
         self.router = router
         self.destination = destination
         self.config_manager = config_manager or HubConfigurationManager()
         self.config = EmbeddedLxmdConfig.from_manager(self.config_manager)
+        self.telemetry_controller = telemetry_controller
+        self._propagation_observers: list[Callable[[dict[str, Any]], None]] = []
+        self._propagation_snapshot: bytes | None = None
+        self._propagation_lock = threading.Lock()
+        if self.telemetry_controller is not None:
+            self.add_propagation_observer(self._persist_propagation_snapshot)
         self._stop_event = threading.Event()
         self._threads: list[threading.Thread] = []
         self._started = False
@@ -88,6 +107,14 @@ class EmbeddedLxmd:
             thread.join(timeout=1)
         self._threads.clear()
         self._started = False
+        self._maybe_emit_propagation_update(force=True)
+
+    def add_propagation_observer(
+        self, observer: Callable[[dict[str, Any]], None]
+    ) -> None:
+        """Register a callback notified whenever propagation state changes."""
+
+        self._propagation_observers.append(observer)
 
     # ------------------------------------------------------------------ #
     # private helpers
@@ -115,6 +142,224 @@ class EmbeddedLxmd:
                 RNS.LOG_ERROR,
             )
 
+    def _baseline_propagation_payload(self) -> dict[str, Any]:
+        peers = getattr(self.router, "peers", {}) or {}
+        static_peers = getattr(self.router, "static_peers", []) or []
+        destination_hash = getattr(
+            getattr(self.router, "propagation_destination", None), "hash", None
+        )
+        identity_hash = getattr(getattr(self.router, "identity", None), "hash", None)
+
+        total_peers = len(peers)
+        return {
+            "destination_hash": destination_hash,
+            "identity_hash": identity_hash,
+            "uptime": None,
+            "delivery_limit": getattr(
+                self.router, "delivery_per_transfer_limit", None
+            ),
+            "propagation_limit": getattr(
+                self.router, "propagation_per_transfer_limit", None
+            ),
+            "autopeer_maxdepth": getattr(self.router, "autopeer_maxdepth", None),
+            "from_static_only": getattr(self.router, "from_static_only", None),
+            "messagestore": None,
+            "clients": None,
+            "unpeered_propagation_incoming": getattr(
+                self.router, "unpeered_propagation_incoming", None
+            ),
+            "unpeered_propagation_rx_bytes": getattr(
+                self.router, "unpeered_propagation_rx_bytes", None
+            ),
+            "static_peers": len(static_peers),
+            "total_peers": total_peers,
+            "active_peers": 0,
+            "unreachable_peers": total_peers,
+            "max_peers": getattr(self.router, "max_peers", None),
+            "peered_propagation_rx_bytes": 0,
+            "peered_propagation_tx_bytes": 0,
+            "peered_propagation_offered": 0,
+            "peered_propagation_outgoing": 0,
+            "peered_propagation_incoming": 0,
+            "peered_propagation_unhandled": 0,
+            "peered_propagation_max_unhandled": 0,
+            "peers": {},
+        }
+
+    def _normalize_propagation_stats(self, stats: dict[str, Any] | None) -> dict[str, Any]:
+        payload = self._baseline_propagation_payload()
+        if not stats:
+            return payload
+
+        payload.update(
+            {
+                "destination_hash": stats.get("destination_hash")
+                or payload["destination_hash"],
+                "identity_hash": stats.get("identity_hash")
+                or payload["identity_hash"],
+                "uptime": stats.get("uptime"),
+                "delivery_limit": stats.get("delivery_limit"),
+                "propagation_limit": stats.get("propagation_limit"),
+                "autopeer_maxdepth": stats.get("autopeer_maxdepth"),
+                "from_static_only": stats.get("from_static_only"),
+                "messagestore": stats.get("messagestore"),
+                "clients": stats.get("clients"),
+                "unpeered_propagation_incoming": stats.get(
+                    "unpeered_propagation_incoming"
+                ),
+                "unpeered_propagation_rx_bytes": stats.get(
+                    "unpeered_propagation_rx_bytes"
+                ),
+                "static_peers": stats.get("static_peers", payload["static_peers"]),
+                "max_peers": stats.get("max_peers", payload["max_peers"]),
+            }
+        )
+
+        peers_payload: dict[bytes, dict[str, Any]] = {}
+        active = 0
+        rx_sum = tx_sum = offered_sum = outgoing_sum = incoming_sum = unhandled_sum = 0
+        max_unhandled = 0
+
+        peer_stats = stats.get("peers") or {}
+        for peer_hash, peer_data in sorted(peer_stats.items(), key=lambda item: item[0]):
+            if not isinstance(peer_hash, (bytes, bytearray, memoryview)):
+                continue
+            key = bytes(peer_hash)
+            messages = peer_data.get("messages") or {}
+            peers_payload[key] = {
+                "type": peer_data.get("type"),
+                "state": peer_data.get("state"),
+                "alive": peer_data.get("alive"),
+                "last_heard": peer_data.get("last_heard"),
+                "next_sync_attempt": peer_data.get("next_sync_attempt"),
+                "last_sync_attempt": peer_data.get("last_sync_attempt"),
+                "sync_backoff": peer_data.get("sync_backoff"),
+                "peering_timebase": peer_data.get("peering_timebase"),
+                "ler": peer_data.get("ler"),
+                "str": peer_data.get("str"),
+                "transfer_limit": peer_data.get("transfer_limit"),
+                "network_distance": peer_data.get("network_distance"),
+                "rx_bytes": peer_data.get("rx_bytes"),
+                "tx_bytes": peer_data.get("tx_bytes"),
+                "messages": {
+                    "offered": messages.get("offered"),
+                    "outgoing": messages.get("outgoing"),
+                    "incoming": messages.get("incoming"),
+                    "unhandled": messages.get("unhandled"),
+                },
+            }
+
+            if peer_data.get("alive"):
+                active += 1
+
+            rx_sum += peer_data.get("rx_bytes") or 0
+            tx_sum += peer_data.get("tx_bytes") or 0
+            offered = messages.get("offered") or 0
+            outgoing = messages.get("outgoing") or 0
+            incoming = messages.get("incoming") or 0
+            unhandled = messages.get("unhandled") or 0
+
+            offered_sum += offered
+            outgoing_sum += outgoing
+            incoming_sum += incoming
+            unhandled_sum += unhandled
+            if unhandled > max_unhandled:
+                max_unhandled = unhandled
+
+        total_peers = stats.get("total_peers")
+        if total_peers is None:
+            total_peers = len(peers_payload)
+
+        payload.update(
+            {
+                "peers": peers_payload,
+                "total_peers": total_peers,
+                "active_peers": active,
+                "unreachable_peers": max(total_peers - active, 0),
+                "peered_propagation_rx_bytes": rx_sum,
+                "peered_propagation_tx_bytes": tx_sum,
+                "peered_propagation_offered": offered_sum,
+                "peered_propagation_outgoing": outgoing_sum,
+                "peered_propagation_incoming": incoming_sum,
+                "peered_propagation_unhandled": unhandled_sum,
+                "peered_propagation_max_unhandled": max_unhandled,
+            }
+        )
+
+        return payload
+
+    def _build_propagation_payload(self) -> dict[str, Any] | None:
+        try:
+            stats = self.router.compile_stats()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            RNS.log(
+                f"Failed to compile LXMF propagation stats: {exc}",
+                RNS.LOG_ERROR,
+            )
+            return None
+
+        return self._normalize_propagation_stats(stats)
+
+    def _maybe_emit_propagation_update(self, *, force: bool = False) -> None:
+        if not self._propagation_observers:
+            return
+
+        payload = self._build_propagation_payload()
+        if payload is None:
+            return
+
+        comparison_payload = dict(payload)
+        uptime = comparison_payload.get("uptime")
+        if uptime is not None:
+            comparison_payload["uptime"] = int(uptime) // self.PROPAGATION_UPTIME_GRANULARITY
+
+        packed = packb(comparison_payload, use_bin_type=True)
+
+        with self._propagation_lock:
+            if not force and packed == self._propagation_snapshot:
+                return
+            self._propagation_snapshot = packed
+
+        self._notify_propagation_observers(payload)
+
+    def _notify_propagation_observers(self, payload: dict[str, Any]) -> None:
+        for observer in list(self._propagation_observers):
+            try:
+                observer(payload)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                RNS.log(
+                    f"Propagation observer failed: {exc}",
+                    RNS.LOG_ERROR,
+                )
+
+    def _persist_propagation_snapshot(self, payload: dict[str, Any]) -> None:
+        if self.telemetry_controller is None:
+            return
+
+        sensor = LXMFPropagation()
+        sensor.unpack(payload)
+        packed_payload = sensor.pack()
+        if packed_payload is None:
+            return
+
+        peer_hash = (
+            RNS.hexrep(self.destination.hash, False)
+            if hasattr(self.destination, "hash")
+            else ""
+        )
+
+        try:
+            self.telemetry_controller.save_telemetry(
+                {SID_LXMF_PROPAGATION: packed_payload},
+                peer_hash,
+                datetime.utcnow(),
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            RNS.log(
+                f"Failed to persist propagation telemetry: {exc}",
+                RNS.LOG_ERROR,
+            )
+
     def _deferred_start_jobs(self) -> None:
         if self._stop_event.wait(self.DEFERRED_JOBS_DELAY):
             return
@@ -126,11 +371,13 @@ class EmbeddedLxmd:
             self._announce_propagation()
             self._last_node_announce = self._last_peer_announce
 
+        self._maybe_emit_propagation_update(force=True)
         self._start_thread(self._jobs)
 
     def _jobs(self) -> None:
         interval = self.config.announce_interval_seconds
         while not self._stop_event.wait(self.JOBS_INTERVAL_SECONDS):
+            self._maybe_emit_propagation_update()
             now = time.monotonic()
             if (
                 self._last_peer_announce is None

--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -151,6 +151,7 @@ class ReticulumTelemetryHub:
                 router=self.lxm_router,
                 destination=self.my_lxmf_dest,
                 config_manager=self.config_manager,
+                telemetry_controller=self.tel_controller,
             )
             self.embedded_lxmd.start()
         else:

--- a/tests/test_embedded_lxmd.py
+++ b/tests/test_embedded_lxmd.py
@@ -1,0 +1,181 @@
+"""Tests for EmbeddedLxmd propagation telemetry hooks."""
+from __future__ import annotations
+
+import threading
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import RNS
+
+from reticulum_telemetry_hub.embedded_lxmd.embedded import EmbeddedLxmd
+from reticulum_telemetry_hub.lxmf_telemetry import telemetry_controller as tc_mod
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.lxmf_propagation import (
+    LXMFPropagation,
+)
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.telemeter import Telemeter
+
+
+class DummyConfigManager:
+    """Provide the minimal configuration structure expected by EmbeddedLxmd."""
+
+    def __init__(self, *, enable_node: bool = True, interval_minutes: int = 1) -> None:
+        lxmf_router = SimpleNamespace(
+            enable_node=enable_node, announce_interval_minutes=interval_minutes
+        )
+        self.config = SimpleNamespace(lxmf_router=lxmf_router)
+
+
+class DummyDestination:
+    def __init__(self, hash_value: bytes) -> None:
+        self.hash = hash_value
+
+
+class DummyRouter:
+    """Router stub exposing the propagation attributes accessed by EmbeddedLxmd."""
+
+    def __init__(self, stats: dict[str, Any] | None) -> None:
+        self._stats = stats
+        self.identity = SimpleNamespace(hash=b"\x33" * 16)
+        self.propagation_destination = SimpleNamespace(hash=b"\x44" * 16)
+        self.delivery_per_transfer_limit = 1024
+        self.propagation_per_transfer_limit = 2048
+        self.autopeer_maxdepth = 3
+        self.from_static_only = False
+        self.unpeered_propagation_incoming = 0
+        self.unpeered_propagation_rx_bytes = 0
+        self.static_peers: list[bytes] = []
+        self.peers: dict[bytes, Any] = {}
+        self.max_peers = 5
+        self._enabled = False
+        self.announce_calls: list[bytes] = []
+        self.announce_propagation_count = 0
+
+    def enable_propagation(self) -> None:
+        self._enabled = True
+
+    def announce(self, destination_hash: bytes) -> None:
+        self.announce_calls.append(destination_hash)
+
+    def announce_propagation_node(self) -> None:
+        self.announce_propagation_count += 1
+
+    def compile_stats(self) -> dict[str, Any] | None:
+        return self._stats
+
+    def set_stats(self, stats: dict[str, Any] | None) -> None:
+        self._stats = stats
+
+
+@pytest.mark.usefixtures("session_factory")
+def test_embedded_lxmd_persists_propagation_stats(telemetry_controller):
+    stats = {
+        "destination_hash": b"\xaa" * 16,
+        "identity_hash": b"\xbb" * 16,
+        "uptime": 42.0,
+        "delivery_limit": 4096,
+        "propagation_limit": 2048,
+        "autopeer_maxdepth": 4,
+        "from_static_only": True,
+        "messagestore": {"count": 3, "bytes": 1024, "limit": 2048},
+        "clients": {
+            "client_propagation_messages_received": 1,
+            "client_propagation_messages_served": 2,
+        },
+        "unpeered_propagation_incoming": 1,
+        "unpeered_propagation_rx_bytes": 16,
+        "static_peers": 1,
+        "max_peers": 5,
+        "peers": {
+            b"peer-a": {
+                "type": "static",
+                "state": "active",
+                "alive": True,
+                "last_heard": 123,
+                "next_sync_attempt": 456,
+                "last_sync_attempt": 111,
+                "sync_backoff": 0,
+                "peering_timebase": 22,
+                "ler": 10,
+                "str": 5,
+                "transfer_limit": 128,
+                "network_distance": 1,
+                "rx_bytes": 64,
+                "tx_bytes": 32,
+                "messages": {
+                    "offered": 2,
+                    "outgoing": 1,
+                    "incoming": 1,
+                    "unhandled": 0,
+                },
+            }
+        },
+    }
+    router = DummyRouter(stats)
+    destination = DummyDestination(b"\x11" * 16)
+    embedded = EmbeddedLxmd(
+        router,
+        destination,
+        config_manager=DummyConfigManager(),
+        telemetry_controller=telemetry_controller,
+    )
+
+    embedded._maybe_emit_propagation_update(force=True)
+
+    with tc_mod.Session_cls() as session:
+        telemeter = session.query(Telemeter).one()
+        assert telemeter.peer_dest == RNS.hexrep(destination.hash, False)
+        sensor = session.query(LXMFPropagation).one()
+        payload = sensor.pack()
+
+    assert payload is not None
+    assert payload["from_static_only"] is True
+    assert payload["total_peers"] == 1
+    assert payload["active_peers"] == 1
+    assert payload["peered_propagation_rx_bytes"] == 64
+    assert b"peer-a" in payload["peers"]
+
+
+@pytest.mark.usefixtures("session_factory")
+def test_embedded_lxmd_deduplicates_snapshots(telemetry_controller):
+    stats = {
+        "destination_hash": b"\xaa" * 16,
+        "identity_hash": b"\xbb" * 16,
+        "uptime": 100.0,
+        "delivery_limit": 4096,
+        "propagation_limit": 2048,
+        "autopeer_maxdepth": 4,
+        "from_static_only": False,
+        "messagestore": None,
+        "clients": None,
+        "unpeered_propagation_incoming": 0,
+        "unpeered_propagation_rx_bytes": 0,
+        "static_peers": 0,
+        "max_peers": 5,
+        "peers": {},
+        "total_peers": 0,
+    }
+    router = DummyRouter(stats)
+    destination = DummyDestination(b"\x22" * 16)
+    embedded = EmbeddedLxmd(
+        router,
+        destination,
+        config_manager=DummyConfigManager(),
+        telemetry_controller=telemetry_controller,
+    )
+
+    calls: list[datetime] = []
+    lock = threading.Lock()
+
+    def observer(payload: dict[str, Any]) -> None:
+        with lock:
+            calls.append(datetime.utcnow())
+
+    embedded.add_propagation_observer(observer)
+
+    embedded._maybe_emit_propagation_update(force=True)
+    embedded._maybe_emit_propagation_update()
+
+    with lock:
+        assert len(calls) == 1


### PR DESCRIPTION
## Summary
- add propagation state observers to EmbeddedLxmd that persist LXMFPropagation telemetry snapshots
- expose telemetry controller to the embedded router wiring
- add regression tests ensuring propagation snapshots are persisted once per change

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918766be5988325bcb58c3ba32e811d)