### PR TITLE
Allow configuring telemetry storage

### DIFF
--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -133,7 +133,9 @@ class ReticulumTelemetryHub:
         else:
             self.ret = RNS.Reticulum(loglevel=self.loglevel)
             RNS.loglevel = self.loglevel
-        self.tel_controller = TelemetryController()
+
+        telemetry_db_path = self.storage_path / "telemetry.db"
+        self.tel_controller = TelemetryController(db_path=telemetry_db_path)
         self.config_manager: HubConfigurationManager | None = None
         self.embedded_lxmd: EmbeddedLxmd | None = None
         self._shutdown = False

--- a/tests/test_lxmf_telemetry.py
+++ b/tests/test_lxmf_telemetry.py
@@ -25,11 +25,11 @@ from tests.factories import (
     create_rns_transport_sensor,
 )
 
-def test_deserialize_lxmf():
+def test_deserialize_lxmf(telemetry_controller):
     with open("sample.bin", "rb") as f:
         tel_data = unpackb(f.read(), strict_map_key=False)
 
-    tel = TelemetryController()._deserialize_telemeter(tel_data, "test")
+    tel = telemetry_controller._deserialize_telemeter(tel_data, "test")
 
     expected_order = [sid for sid in sid_mapping if sid in tel_data]
 


### PR DESCRIPTION
## Summary
- make `TelemetryController` accept an injected SQLAlchemy engine or database path and have the hub pass a storage-specific path so each instance writes to its own telemetry.db
- rework the pytest fixtures and coverage tests to provision in-memory engines via the new constructor and update embedded telemetry tests to query via the shared session factory

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919dd66cf188325ae1270293a227120)