### PR TITLE
Ensure topic patching preserves creation timestamp

### DIFF
--- a/reticulum_telemetry_hub/api/service.py
+++ b/reticulum_telemetry_hub/api/service.py
@@ -67,15 +67,24 @@ class ReticulumTelemetryHubAPI:
 
     def patch_topic(self, topic_id: str, **updates) -> Topic:
         topic = self.retrieve_topic(topic_id)
+        update_fields = {}
         if "topic_name" in updates or "TopicName" in updates:
             topic.topic_name = updates.get("topic_name") or updates.get("TopicName")
+            update_fields["topic_name"] = topic.topic_name
         if "topic_path" in updates or "TopicPath" in updates:
             topic.topic_path = updates.get("topic_path") or updates.get("TopicPath")
+            update_fields["topic_path"] = topic.topic_path
         if "topic_description" in updates or "TopicDescription" in updates:
             topic.topic_description = updates.get("topic_description") or updates.get(
                 "TopicDescription"
             )
-        return self._storage.create_topic(topic)
+            update_fields["topic_description"] = topic.topic_description
+        if not update_fields:
+            return topic
+        updated_topic = self._storage.update_topic(topic.topic_id, **update_fields)
+        if not updated_topic:
+            raise KeyError(f"Topic '{topic_id}' not found")
+        return updated_topic
 
     def subscribe_topic(
         self,

--- a/reticulum_telemetry_hub/api/service.py
+++ b/reticulum_telemetry_hub/api/service.py
@@ -75,9 +75,11 @@ class ReticulumTelemetryHubAPI:
             topic.topic_path = updates.get("topic_path") or updates.get("TopicPath")
             update_fields["topic_path"] = topic.topic_path
         if "topic_description" in updates or "TopicDescription" in updates:
-            topic.topic_description = updates.get("topic_description") or updates.get(
-                "TopicDescription"
-            )
+            if "topic_description" in updates:
+                description = updates["topic_description"]
+            else:
+                description = updates["TopicDescription"]
+            topic.topic_description = description or ""
             update_fields["topic_description"] = topic.topic_description
         if not update_fields:
             return topic

--- a/reticulum_telemetry_hub/api/storage.py
+++ b/reticulum_telemetry_hub/api/storage.py
@@ -115,6 +115,32 @@ class HubStorage:
                 topic_description=record.description or "",
             )
 
+    def update_topic(
+        self,
+        topic_id: str,
+        *,
+        topic_name: Optional[str] = None,
+        topic_path: Optional[str] = None,
+        topic_description: Optional[str] = None,
+    ) -> Optional[Topic]:
+        with self._Session() as session:
+            record = session.get(TopicRecord, topic_id)
+            if not record:
+                return None
+            if topic_name is not None:
+                record.name = topic_name
+            if topic_path is not None:
+                record.path = topic_path
+            if topic_description is not None:
+                record.description = topic_description
+            session.commit()
+            return Topic(
+                topic_id=record.id,
+                topic_name=record.name,
+                topic_path=record.path,
+                topic_description=record.description or "",
+            )
+
     # ------------------------------------------------------------------ #
     # Subscriber helpers
     # ------------------------------------------------------------------ #

--- a/tests/test_rth_api.py
+++ b/tests/test_rth_api.py
@@ -1,4 +1,5 @@
 from reticulum_telemetry_hub.api import ReticulumTelemetryHubAPI, Topic, Subscriber
+from reticulum_telemetry_hub.api.storage import TopicRecord
 from reticulum_telemetry_hub.config import HubConfigurationManager
 def make_config_manager(tmp_path):
     storage = tmp_path / "storage"
@@ -79,3 +80,19 @@ def test_persistence_between_instances(tmp_path):
     assert api2.retrieve_topic(topic.topic_id).topic_name == "Ops"
     clients = api2.list_clients()
     assert any(c.identity == "identity42" for c in clients)
+
+
+def test_patch_topic_preserves_created_at(tmp_path):
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+    topic = api.create_topic(Topic(topic_name="Status", topic_path="/status"))
+
+    with api._storage._Session() as session:
+        original_record = session.get(TopicRecord, topic.topic_id)
+        original_created_at = original_record.created_at
+
+    api.patch_topic(topic.topic_id, topic_description="Updated status")
+
+    with api._storage._Session() as session:
+        updated_record = session.get(TopicRecord, topic.topic_id)
+        assert updated_record.description == "Updated status"
+        assert updated_record.created_at == original_created_at

--- a/tests/test_rth_api.py
+++ b/tests/test_rth_api.py
@@ -39,6 +39,18 @@ def test_topic_crud(tmp_path):
     assert deleted.topic_id == topic.topic_id
 
 
+def test_patch_topic_allows_clearing_description(tmp_path):
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+    topic = api.create_topic(
+        Topic(topic_name="Status", topic_path="/status", topic_description="System status")
+    )
+
+    api.patch_topic(topic.topic_id, topic_description="")
+    updated = api.retrieve_topic(topic.topic_id)
+
+    assert updated.topic_description == ""
+
+
 def test_subscriber_management(tmp_path):
     api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
     topic = api.create_topic(Topic(topic_name="Alerts", topic_path="/alerts"))


### PR DESCRIPTION
## Summary
- add a dedicated `update_topic` helper that mutates existing topic rows without recreating them
- call the new helper from `ReticulumTelemetryHubAPI.patch_topic` so partial updates preserve metadata
- add a regression test to ensure `created_at` stays unchanged after patching

## Testing
- pytest tests/test_rth_api.py -k topic


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a199432a083259868335459b299c1)