### PR TITLE
Simplify telemetry stream payloads

### DIFF
--- a/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
@@ -258,7 +258,6 @@ class TelemetryController:
                             peer_hash,
                             round(tel.time.timestamp()),
                             packb(tel_data, use_bin_type=True),
-                            ['account', b'\x00\x00\x00', b'\xff\xff\xff'],
                         ]
                     )
             message.fields[LXMF.FIELD_TELEMETRY_STREAM] = packb(
@@ -315,6 +314,9 @@ class TelemetryController:
                 sensor = sid_mapping[sid]()
                 sensor.unpack(tel_data[sid])
                 tel.sensors.append(sensor)
+        time_value = tel_data.get(SID_TIME)
+        if isinstance(time_value, (int, float)):
+            tel.time = datetime.fromtimestamp(int(time_value))
         return tel
 
     def _humanize_telemetry(self, tel_data: dict) -> dict:

--- a/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
@@ -132,11 +132,24 @@ class TelemetryController:
             return self._load_telemetry(ses, start_time, end_time)
 
     def save_telemetry(
-        self, telemetry_data: dict, peer_dest, timestamp: Optional[datetime] = None
+        self, telemetry_data: dict | bytes, peer_dest, timestamp: Optional[datetime] = None
     ) -> None:
         """Save the telemetry data."""
         tel = self._deserialize_telemeter(telemetry_data, peer_dest)
-        if timestamp is not None:
+
+        payload = telemetry_data
+        if isinstance(payload, (bytes, bytearray)):
+            try:
+                payload = unpackb(payload, strict_map_key=False)
+            except Exception:  # pragma: no cover - defensive decoding
+                payload = None
+
+        has_sensor_timestamp = False
+        if isinstance(payload, dict):
+            time_value = payload.get(SID_TIME)
+            has_sensor_timestamp = isinstance(time_value, (int, float))
+
+        if not has_sensor_timestamp and timestamp is not None:
             tel.time = timestamp
         with self._session_cls() as ses:
             ses.add(tel)
@@ -178,18 +191,32 @@ class TelemetryController:
                 message.fields[LXMF.FIELD_TELEMETRY_STREAM], strict_map_key=False
             )
             for tel_data in tels_data:
-                tel_entry = list(tel_data)
-                peer_hash = tel_entry.pop(0)
+                if not isinstance(tel_data, (list, tuple)) or len(tel_data) != 3:
+                    RNS.log(
+                        "Telemetry stream entries must include peer hash, timestamp, and payload; skipping"
+                    )
+                    continue
+
+                peer_hash, raw_timestamp, payload = tel_data
+                if not isinstance(peer_hash, (bytes, bytearray)):
+                    RNS.log("Telemetry stream entry missing peer hash bytes; skipping")
+                    continue
+
                 peer_dest = RNS.hexrep(peer_hash, False)
+
                 timestamp = None
-                if tel_entry:
-                    raw_timestamp = tel_entry.pop(0)
-                    if raw_timestamp is not None:
-                        timestamp = datetime.fromtimestamp(raw_timestamp)
-                payload = tel_entry.pop(0) if tel_entry else None
+                if isinstance(raw_timestamp, (int, float)):
+                    timestamp = datetime.fromtimestamp(raw_timestamp)
+                elif raw_timestamp is not None:
+                    RNS.log(
+                        "Telemetry stream timestamp must be numeric or null; skipping entry"
+                    )
+                    continue
+
                 if not payload:
                     RNS.log("Telemetry payload missing; skipping entry")
                     continue
+
                 readable = self._humanize_telemetry(payload)
                 RNS.log(f"Telemetry stream from {peer_dest} at {timestamp}: {readable}")
                 self.save_telemetry(payload, peer_dest, timestamp)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 
 from typing import Dict
 
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.sensor_enum import (
+    SID_CONNECTION_MAP,
+    SID_LXMF_PROPAGATION,
+    SID_RNS_TRANSPORT,
+    SID_TIME,
+)
+
 from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.connection_map import (
     ConnectionMap,
 )
@@ -11,11 +18,6 @@ from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.lxmf_propa
 )
 from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.rns_transport import (
     RNSTransport,
-)
-from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.sensor_enum import (
-    SID_CONNECTION_MAP,
-    SID_LXMF_PROPAGATION,
-    SID_RNS_TRANSPORT,
 )
 
 
@@ -179,7 +181,7 @@ def create_connection_map_sensor() -> ConnectionMap:
     return sensor
 
 
-def build_complex_telemeter_payload() -> Dict[int, dict]:
+def build_complex_telemeter_payload(*, timestamp: int | None = None) -> Dict[int, dict | int]:
     """Return a telemetry payload covering complex/nested sensors."""
 
     sensors = [
@@ -192,6 +194,8 @@ def build_complex_telemeter_payload() -> Dict[int, dict]:
         packed = sensor.pack()
         if packed is not None:
             payload[sensor.sid] = packed
+    if timestamp is not None:
+        payload[SID_TIME] = int(timestamp)
     return payload
 
 


### PR DESCRIPTION
## Summary
- update telemetry stream responses to only include the peer hash, timestamp, and packed telemeter payloads
- ensure telemetry ingestion sets the stored timestamp from the SID_TIME reading and adjust tests to reflect the streamlined format

## Testing
- `pytest tests/test_lxmf_telemetry.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c718d4e588325b00e73d774de4b8e)