### PR TITLE
Add topic/subscriber command handlers to CommandManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ celerybeat.pid
 .venv
 env/
 venv/
+venv_linux/
 ENV/
 env.bak/
 venv.bak/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.5.2"
-description = "Reticulum-Telemetry-Hub (RTH) is designed to manage a complete TCP node across a Reticulum-based network. 
-The RTH  enable communication and data sharing between clients like Sideband or Meshchat, enhancing situational awareness and operational efficiency in distributed networks."
+version = "0.6.0"
+description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"
 packages = [

--- a/reticulum_telemetry_hub/reticulum_server/command_manager.py
+++ b/reticulum_telemetry_hub/reticulum_server/command_manager.py
@@ -6,7 +6,7 @@ import json
 import RNS
 import LXMF
 
-from reticulum_telemetry_hub.api.models import Client
+from reticulum_telemetry_hub.api.models import Client, Subscriber, Topic
 from reticulum_telemetry_hub.api.service import ReticulumTelemetryHubAPI
 
 from .constants import PLUGIN_COMMAND
@@ -76,8 +76,30 @@ class CommandManager:
                 return self._handle_list_clients(message)
             if name == self.CMD_GET_APP_INFO:
                 return self._handle_get_app_info(message)
-            # The remaining commands are currently placeholders
-            # and can be implemented as needed.
+            if name == self.CMD_LIST_TOPIC:
+                return self._handle_list_topics(message)
+            if name == self.CMD_CREATE_TOPIC:
+                return self._handle_create_topic(command, message)
+            if name == self.CMD_RETRIEVE_TOPIC:
+                return self._handle_retrieve_topic(command, message)
+            if name == self.CMD_DELETE_TOPIC:
+                return self._handle_delete_topic(command, message)
+            if name == self.CMD_PATCH_TOPIC:
+                return self._handle_patch_topic(command, message)
+            if name == self.CMD_SUBSCRIBE_TOPIC:
+                return self._handle_subscribe_topic(command, message)
+            if name == self.CMD_LIST_SUBSCRIBER:
+                return self._handle_list_subscribers(message)
+            if name == self.CMD_CREATE_SUBSCRIBER:
+                return self._handle_create_subscriber(command, message)
+            if name == self.CMD_ADD_SUBSCRIBER:
+                return self._handle_create_subscriber(command, message)
+            if name == self.CMD_RETRIEVE_SUBSCRIBER:
+                return self._handle_retrieve_subscriber(command, message)
+            if name in (self.CMD_DELETE_SUBSCRIBER, self.CMD_REMOVE_SUBSCRIBER):
+                return self._handle_delete_subscriber(command, message)
+            if name == self.CMD_PATCH_SUBSCRIBER:
+                return self._handle_patch_subscriber(command, message)
         # Delegate to telemetry controller for telemetry related commands
         return self.tel_controller.handle_command(command, message, self.my_lxmf_dest)
 
@@ -118,20 +140,135 @@ class CommandManager:
         )
 
     def _handle_list_clients(self, message: LXMF.LXMessage) -> LXMF.LXMessage:
-        dest = self._create_dest(message.source.identity)
         clients = self.api.list_clients()
         client_hashes = [self._format_client_entry(client) for client in clients]
-        return LXMF.LXMessage(
-            dest,
-            self.my_lxmf_dest,
-            ",".join(client_hashes) or "",
-            desired_method=LXMF.LXMessage.DIRECT,
-        )
+        return self._reply(message, ",".join(client_hashes) or "")
 
     def _handle_get_app_info(self, message: LXMF.LXMessage) -> LXMF.LXMessage:
-        dest = self._create_dest(message.source.identity)
         info = "ReticulumTelemetryHub"
-        return LXMF.LXMessage(dest, self.my_lxmf_dest, info, desired_method=LXMF.LXMessage.DIRECT)
+        return self._reply(message, info)
+
+    def _handle_list_topics(self, message: LXMF.LXMessage) -> LXMF.LXMessage:
+        topics = self.api.list_topics()
+        content_lines = self._format_topic_list(topics)
+        content_lines.append(self._topic_subscribe_hint())
+        return self._reply(message, "\n".join(content_lines))
+
+    def _handle_create_topic(self, command: dict, message: LXMF.LXMessage) -> LXMF.LXMessage:
+        topic = Topic.from_dict(command)
+        if not topic.topic_name or not topic.topic_path:
+            return self._reply(message, "TopicName and TopicPath are required")
+        created = self.api.create_topic(topic)
+        payload = json.dumps(created.to_dict(), sort_keys=True)
+        return self._reply(message, f"Topic created: {payload}")
+
+    def _handle_retrieve_topic(self, command: dict, message: LXMF.LXMessage) -> LXMF.LXMessage:
+        topic_id = self._extract_topic_id(command)
+        if not topic_id:
+            return self._reply(message, "TopicID is required")
+        try:
+            topic = self.api.retrieve_topic(topic_id)
+        except KeyError as exc:
+            return self._reply(message, str(exc))
+        payload = json.dumps(topic.to_dict(), sort_keys=True)
+        return self._reply(message, payload)
+
+    def _handle_delete_topic(self, command: dict, message: LXMF.LXMessage) -> LXMF.LXMessage:
+        topic_id = self._extract_topic_id(command)
+        if not topic_id:
+            return self._reply(message, "TopicID is required")
+        try:
+            topic = self.api.delete_topic(topic_id)
+        except KeyError as exc:
+            return self._reply(message, str(exc))
+        payload = json.dumps(topic.to_dict(), sort_keys=True)
+        return self._reply(message, f"Topic deleted: {payload}")
+
+    def _handle_patch_topic(self, command: dict, message: LXMF.LXMessage) -> LXMF.LXMessage:
+        topic_id = self._extract_topic_id(command)
+        if not topic_id:
+            return self._reply(message, "TopicID is required")
+        updates = {k: v for k, v in command.items() if k != PLUGIN_COMMAND}
+        try:
+            topic = self.api.patch_topic(topic_id, **updates)
+        except KeyError as exc:
+            return self._reply(message, str(exc))
+        payload = json.dumps(topic.to_dict(), sort_keys=True)
+        return self._reply(message, f"Topic updated: {payload}")
+
+    def _handle_subscribe_topic(self, command: dict, message: LXMF.LXMessage) -> LXMF.LXMessage:
+        topic_id = self._extract_topic_id(command)
+        if not topic_id:
+            return self._reply(message, "TopicID is required")
+        destination = self._identity_hex(message.source.identity)
+        reject_tests = command.get("RejectTests") or command.get("reject_tests")
+        metadata = command.get("Metadata") or command.get("metadata") or {}
+        try:
+            subscriber = self.api.subscribe_topic(
+                topic_id,
+                destination=destination,
+                reject_tests=reject_tests,
+                metadata=metadata,
+            )
+        except KeyError as exc:
+            return self._reply(message, str(exc))
+        payload = json.dumps(subscriber.to_dict(), sort_keys=True)
+        return self._reply(message, f"Subscribed: {payload}")
+
+    def _handle_list_subscribers(self, message: LXMF.LXMessage) -> LXMF.LXMessage:
+        subscribers = self.api.list_subscribers()
+        lines = self._format_subscriber_list(subscribers)
+        return self._reply(message, "\n".join(lines))
+
+    def _handle_create_subscriber(
+        self, command: dict, message: LXMF.LXMessage
+    ) -> LXMF.LXMessage:
+        subscriber = Subscriber.from_dict(command)
+        if not subscriber.destination:
+            subscriber.destination = self._identity_hex(message.source.identity)
+        created = self.api.create_subscriber(subscriber)
+        payload = json.dumps(created.to_dict(), sort_keys=True)
+        return self._reply(message, f"Subscriber created: {payload}")
+
+    def _handle_retrieve_subscriber(
+        self, command: dict, message: LXMF.LXMessage
+    ) -> LXMF.LXMessage:
+        subscriber_id = self._extract_subscriber_id(command)
+        if not subscriber_id:
+            return self._reply(message, "SubscriberID is required")
+        try:
+            subscriber = self.api.retrieve_subscriber(subscriber_id)
+        except KeyError as exc:
+            return self._reply(message, str(exc))
+        payload = json.dumps(subscriber.to_dict(), sort_keys=True)
+        return self._reply(message, payload)
+
+    def _handle_delete_subscriber(
+        self, command: dict, message: LXMF.LXMessage
+    ) -> LXMF.LXMessage:
+        subscriber_id = self._extract_subscriber_id(command)
+        if not subscriber_id:
+            return self._reply(message, "SubscriberID is required")
+        try:
+            subscriber = self.api.delete_subscriber(subscriber_id)
+        except KeyError as exc:
+            return self._reply(message, str(exc))
+        payload = json.dumps(subscriber.to_dict(), sort_keys=True)
+        return self._reply(message, f"Subscriber deleted: {payload}")
+
+    def _handle_patch_subscriber(
+        self, command: dict, message: LXMF.LXMessage
+    ) -> LXMF.LXMessage:
+        subscriber_id = self._extract_subscriber_id(command)
+        if not subscriber_id:
+            return self._reply(message, "SubscriberID is required")
+        updates = {k: v for k, v in command.items() if k != PLUGIN_COMMAND}
+        try:
+            subscriber = self.api.patch_subscriber(subscriber_id, **updates)
+        except KeyError as exc:
+            return self._reply(message, str(exc))
+        payload = json.dumps(subscriber.to_dict(), sort_keys=True)
+        return self._reply(message, f"Subscriber updated: {payload}")
 
     @staticmethod
     def _identity_hex(identity: RNS.Identity) -> str:
@@ -148,4 +285,70 @@ class CommandManager:
         except (ValueError, TypeError):
             identity_value = client.identity
         return f"{identity_value}|{metadata_str}"
+
+    def _reply(self, message: LXMF.LXMessage, content: str) -> LXMF.LXMessage:
+        dest = self._create_dest(message.source.identity)
+        return LXMF.LXMessage(
+            dest,
+            self.my_lxmf_dest,
+            content,
+            desired_method=LXMF.LXMessage.DIRECT,
+        )
+
+    @staticmethod
+    def _extract_topic_id(command: dict) -> Optional[str]:
+        return (
+            command.get("TopicID")
+            or command.get("topic_id")
+            or command.get("id")
+            or command.get("ID")
+        )
+
+    @staticmethod
+    def _extract_subscriber_id(command: dict) -> Optional[str]:
+        return (
+            command.get("SubscriberID")
+            or command.get("subscriber_id")
+            or command.get("id")
+            or command.get("ID")
+        )
+
+    @staticmethod
+    def _format_topic_entry(index: int, topic: Topic) -> str:
+        description = f" - {topic.topic_description}" if topic.topic_description else ""
+        topic_id = topic.topic_id or "<unassigned>"
+        return (
+            f"{index}. {topic.topic_name} [{topic.topic_path}] (ID: {topic_id}){description}"
+        )
+
+    def _format_topic_list(self, topics: List[Topic]) -> List[str]:
+        if not topics:
+            return ["No topics registered yet."]
+        return [self._format_topic_entry(idx, topic) for idx, topic in enumerate(topics, start=1)]
+
+    def _topic_subscribe_hint(self) -> str:
+        example = json.dumps(
+            {"Command": self.CMD_SUBSCRIBE_TOPIC, "TopicID": "<TopicID>"},
+            sort_keys=True,
+        )
+        return f"Send the command payload {example} to subscribe to a topic from the list above."
+
+    @staticmethod
+    def _format_subscriber_entry(index: int, subscriber: Subscriber) -> str:
+        metadata = subscriber.metadata or {}
+        metadata_str = json.dumps(metadata, sort_keys=True)
+        topic_id = subscriber.topic_id or "<any>"
+        subscriber_id = subscriber.subscriber_id or "<pending>"
+        return (
+            f"{index}. {subscriber.destination} subscribed to {topic_id} "
+            f"(SubscriberID: {subscriber_id}) metadata={metadata_str}"
+        )
+
+    def _format_subscriber_list(self, subscribers: List[Subscriber]) -> List[str]:
+        if not subscribers:
+            return ["No subscribers registered yet."]
+        return [
+            self._format_subscriber_entry(idx, subscriber)
+            for idx, subscriber in enumerate(subscribers, start=1)
+        ]
 

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -1,6 +1,8 @@
 import LXMF
 import RNS
 
+from reticulum_telemetry_hub.api.models import Subscriber, Topic
+
 from reticulum_telemetry_hub.reticulum_server.__main__ import ReticulumTelemetryHub
 from reticulum_telemetry_hub.reticulum_server.command_manager import CommandManager
 from reticulum_telemetry_hub.reticulum_server.constants import PLUGIN_COMMAND
@@ -9,16 +11,34 @@ from reticulum_telemetry_hub.lxmf_telemetry.telemetry_controller import (
 )
 
 
-def make_message(dest, source, command):
+def make_message(dest, source, command, **command_fields):
+    payload = {PLUGIN_COMMAND: command}
+    payload.update(command_fields)
     msg = LXMF.LXMessage(
         dest,
         source,
-        fields={LXMF.FIELD_COMMANDS: [{PLUGIN_COMMAND: command}]},
+        fields={LXMF.FIELD_COMMANDS: [payload]},
         desired_method=LXMF.LXMessage.DIRECT,
     )
     msg.pack()
     msg.signature_validated = True
     return msg
+
+
+def make_command_manager(api):
+    class DummyTelemetryController:
+        def handle_command(self, command, message, dest):
+            return None
+
+    server_dest = RNS.Destination(
+        RNS.Identity(),
+        RNS.Destination.IN,
+        RNS.Destination.SINGLE,
+        "lxmf",
+        "delivery",
+    )
+    manager = CommandManager({}, DummyTelemetryController(), server_dest, api)
+    return manager, server_dest
 
 
 def test_join_and_list_clients(tmp_path):
@@ -177,3 +197,98 @@ def test_delivery_callback_handles_commands_and_broadcasts():
     assert any("node-a > broadcast" in payload for payload in broadcast_payloads)
     assert len(router_messages) == 1 + len(hub.connections)
     assert telemetry_calls == [incoming]
+
+
+def test_list_topics_includes_hint():
+    topics = [
+        Topic(topic_name="Alerts", topic_path="/alerts", topic_description="Status", topic_id="abc"),
+        Topic(topic_name="Updates", topic_path="/updates", topic_id="def"),
+    ]
+
+    class DummyAPI:
+        def list_topics(self):
+            return topics
+
+    manager, server_dest = make_command_manager(DummyAPI())
+    client_dest = RNS.Destination(
+        RNS.Identity(), RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"
+    )
+    message = make_message(server_dest, client_dest, CommandManager.CMD_LIST_TOPIC)
+    command = message.fields[LXMF.FIELD_COMMANDS][0]
+
+    reply = manager.handle_command(command, message)
+    payload = reply.content_as_string()
+    assert "1. Alerts" in payload
+    assert CommandManager.CMD_SUBSCRIBE_TOPIC in payload
+    assert "TopicID" in payload
+
+
+def test_create_topic_uses_api_payload():
+    captured = {}
+
+    class DummyAPI:
+        def create_topic(self, topic):
+            captured["topic"] = topic
+            topic.topic_id = "topic-1"
+            return topic
+
+    manager, server_dest = make_command_manager(DummyAPI())
+    client_dest = RNS.Destination(
+        RNS.Identity(), RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"
+    )
+    message = make_message(
+        server_dest,
+        client_dest,
+        CommandManager.CMD_CREATE_TOPIC,
+        TopicName="News",
+        TopicPath="/news",
+        TopicDescription="Latest",
+    )
+    command = message.fields[LXMF.FIELD_COMMANDS][0]
+
+    reply = manager.handle_command(command, message)
+    assert captured["topic"].topic_name == "News"
+    assert captured["topic"].topic_path == "/news"
+    payload = reply.content_as_string()
+    assert "Topic created" in payload
+    assert "topic-1" in payload
+
+
+def test_subscribe_topic_uses_source_identity():
+    captured = {}
+
+    class DummyAPI:
+        def subscribe_topic(self, topic_id, destination, reject_tests=None, metadata=None):
+            captured["topic_id"] = topic_id
+            captured["destination"] = destination
+            captured["reject_tests"] = reject_tests
+            captured["metadata"] = metadata
+            return Subscriber(
+                destination=destination,
+                topic_id=topic_id,
+                subscriber_id="sub-1",
+                metadata=metadata or {},
+            )
+
+    manager, server_dest = make_command_manager(DummyAPI())
+    client_identity = RNS.Identity()
+    client_dest = RNS.Destination(
+        client_identity, RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"
+    )
+    message = make_message(
+        server_dest,
+        client_dest,
+        CommandManager.CMD_SUBSCRIBE_TOPIC,
+        TopicID="topic-9",
+        RejectTests=5,
+        Metadata={"app": "demo"},
+    )
+    command = message.fields[LXMF.FIELD_COMMANDS][0]
+
+    reply = manager.handle_command(command, message)
+    expected_destination = CommandManager._identity_hex(client_identity)
+    assert captured["topic_id"] == "topic-9"
+    assert captured["destination"] == expected_destination
+    assert captured["reject_tests"] == 5
+    assert captured["metadata"] == {"app": "demo"}
+    assert "Subscribed" in reply.content_as_string()


### PR DESCRIPTION
## Summary
- implement the topic and subscriber command handlers in `CommandManager`, reusing the ReticulumTelemetryHubAPI to back each LXMF reply
- add topic list formatting helpers that include a follow-up subscribe hint so clients know how to join a topic
- extend the command manager tests to cover list/create/subscribe flows with mocked APIs

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2a7aee10832589330416c87a7742)