### PR TITLE
Handle empty subscriber metadata patches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.7.0"
+version = "0.8.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/api/service.py
+++ b/reticulum_telemetry_hub/api/service.py
@@ -141,9 +141,14 @@ class ReticulumTelemetryHubAPI:
             subscriber.reject_tests = updates.get("reject_tests") or updates.get(
                 "RejectTests"
             )
-        metadata = updates.get("metadata") or updates.get("Metadata")
-        if metadata is not None:
-            subscriber.metadata = metadata
+        metadata_key = None
+        if "metadata" in updates:
+            metadata_key = "metadata"
+        elif "Metadata" in updates:
+            metadata_key = "Metadata"
+
+        if metadata_key is not None:
+            subscriber.metadata = updates[metadata_key]
         return self._storage.update_subscriber(subscriber)
 
     def add_subscriber(self, subscriber: Subscriber) -> Subscriber:

--- a/tests/test_rth_api.py
+++ b/tests/test_rth_api.py
@@ -60,6 +60,8 @@ def test_subscriber_management(tmp_path):
     assert retrieved.destination == "abc123"
     api.patch_subscriber(subscriber.subscriber_id, metadata={"level": "high"})
     assert api.retrieve_subscriber(subscriber.subscriber_id).metadata == {"level": "high"}
+    api.patch_subscriber(subscriber.subscriber_id, metadata={})
+    assert api.retrieve_subscriber(subscriber.subscriber_id).metadata == {}
     all_subs = api.list_subscribers()
     assert len(all_subs) == 1
     api.delete_subscriber(subscriber.subscriber_id)


### PR DESCRIPTION
## Summary
- ensure `ReticulumTelemetryHubAPI.patch_subscriber` updates metadata whenever a metadata key is provided, even for empty dicts
- extend `test_subscriber_management` to assert metadata can be cleared and bump the project version

## Testing
- (source venv_linux/bin/activate && pytest)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691db5121b148325982a26a86bd75184)