### PR TITLE
Improve announce label decoding

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -2,3 +2,4 @@
 
 - 2025-02-14: ✅ Make messaging more robust by limiting telemetry broadcasts, suppressing echo replies, and listing commands for bad requests.
 - 2025-11-19: ✅ Preserve `RejectTests=0` values when subscribing or patching subscribers.
+- 2025-11-19: ✅ Decode announce metadata using LXMF helper and ensure identity labels follow msgpack names.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.10.0"
+version = "0.11.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/lxmf_daemon/LXStamper.py
+++ b/reticulum_telemetry_hub/lxmf_daemon/LXStamper.py
@@ -15,7 +15,11 @@ PN_VALIDATION_POOL_MIN_SIZE     = 256
 
 active_jobs = {}
 
-if RNS.vendor.platformutils.is_linux(): multiprocessing.set_start_method("fork")
+if RNS.vendor.platformutils.is_linux():
+    try:
+        multiprocessing.set_start_method("fork")
+    except RuntimeError:
+        pass
 
 def stamp_workblock(material, expand_rounds=WORKBLOCK_EXPAND_ROUNDS):
     wb_st = time.time()

--- a/tests/test_announce_handler.py
+++ b/tests/test_announce_handler.py
@@ -1,0 +1,25 @@
+"""Tests for AnnounceHandler metadata decoding."""
+
+import RNS.vendor.umsgpack as msgpack
+
+from reticulum_telemetry_hub.reticulum_server.__main__ import (
+    AnnounceHandler,
+    ReticulumTelemetryHub,
+)
+
+
+def test_announce_handler_decodes_display_name_from_msgpack():
+    identities: dict[str, str] = {}
+    handler = AnnounceHandler(identities)
+    announce_data = msgpack.packb([b"Name", 1])
+
+    handler.received_announce(
+        b"\x01\x02",
+        announced_identity="peer",
+        app_data=announce_data,
+    )
+
+    hub = ReticulumTelemetryHub.__new__(ReticulumTelemetryHub)
+    hub.identities = identities
+
+    assert hub._lookup_identity_label(b"\x01\x02") == "Name"


### PR DESCRIPTION
## Summary
- import and use the LXMF `display_name_from_app_data` helper so announce metadata decodes correctly while retaining existing fallbacks
- make the LXMF stamper resilient to repeated multiprocessing start-method initialization and add a focused regression test for `AnnounceHandler`
- bump the project version and record the task in `TASK.md`

## Testing
- `source venv_linux/bin/activate && pytest tests/test_announce_handler.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd9b08b3483259f5c1b4e9f89354e)