### PR TITLE
Preserve RejectTests overrides for subscriber creation

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -3,3 +3,4 @@
 - 2025-02-14: ✅ Make messaging more robust by limiting telemetry broadcasts, suppressing echo replies, and listing commands for bad requests.
 - 2025-11-19: ✅ Preserve `RejectTests=0` values when subscribing or patching subscribers.
 - 2025-11-19: ✅ Decode announce metadata using LXMF helper and ensure identity labels follow msgpack names.
+- 2025-11-19: ✅ Ensure create-subscriber commands preserve `RejectTests=0` values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.11.0"
+version = "0.12.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/api/models.py
+++ b/reticulum_telemetry_hub/api/models.py
@@ -55,10 +55,16 @@ class Subscriber:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Subscriber":
+        reject_tests = None
+        if "RejectTests" in data:
+            reject_tests = data.get("RejectTests")
+        elif "reject_tests" in data:
+            reject_tests = data.get("reject_tests")
+
         return cls(
             destination=data.get("Destination") or data.get("destination") or "",
             topic_id=data.get("TopicID") or data.get("topic_id"),
-            reject_tests=data.get("RejectTests") or data.get("reject_tests"),
+            reject_tests=reject_tests,
             metadata=data.get("Metadata") or data.get("metadata") or {},
             subscriber_id=data.get("SubscriberID") or data.get("subscriber_id"),
         )

--- a/tests/test_command_manager_subscribers.py
+++ b/tests/test_command_manager_subscribers.py
@@ -1,0 +1,35 @@
+import LXMF
+import RNS
+
+from reticulum_telemetry_hub.reticulum_server.command_manager import CommandManager
+from tests.test_command_manager import make_command_manager, make_message
+
+
+def test_create_subscriber_preserves_zero_reject_tests():
+    captured = {}
+
+    class DummyAPI:
+        def create_subscriber(self, subscriber):
+            captured["subscriber"] = subscriber
+            subscriber.subscriber_id = "sub-zero"
+            return subscriber
+
+    manager, server_dest = make_command_manager(DummyAPI())
+    client_identity = RNS.Identity()
+    client_dest = RNS.Destination(
+        client_identity, RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"
+    )
+
+    message = make_message(
+        server_dest,
+        client_dest,
+        CommandManager.CMD_CREATE_SUBSCRIBER,
+        TopicID="topic-22",
+        RejectTests=0,
+    )
+    command = message.fields[LXMF.FIELD_COMMANDS][0]
+
+    reply = manager.handle_command(command, message)
+
+    assert captured["subscriber"].reject_tests == 0
+    assert "Subscriber created" in reply.content_as_string()


### PR DESCRIPTION
## Summary
- ensure subscriber creation keeps explicit RejectTests values, even when zero
- add a regression test covering CreateSubscriber commands with RejectTests=0
- bump the package version and document the completed task

## Testing
- pytest *(fails: tests/test_coverage.py::test_announce_handler_tracks_identities due to UnicodeDecodeError decoding invalid app data)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e11776884832595330397df2e0335)