### PR TITLE
Improve subscriber cache refresh logic

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -4,3 +4,4 @@
 - 2025-11-19: ✅ Preserve `RejectTests=0` values when subscribing or patching subscribers.
 - 2025-11-19: ✅ Decode announce metadata using LXMF helper and ensure identity labels follow msgpack names.
 - 2025-11-19: ✅ Ensure create-subscriber commands preserve `RejectTests=0` values.
+- 2025-11-19: ✅ Refresh topic subscriber cache after subscription changes to deliver messages immediately.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.12.0"
+version = "0.13.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Pytest fixtures shared across telemetry tests."""
+
 from __future__ import annotations
 
 from contextlib import contextmanager
@@ -11,10 +12,24 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from reticulum_telemetry_hub.reticulum_server.__main__ import ReticulumTelemetryHub
+
+
+@pytest.fixture(autouse=True)
+def reset_shared_router():
+    """Ensure each test starts with a clean shared LXMF router."""
+
+    ReticulumTelemetryHub._shared_lxm_router = None
+    yield
+    ReticulumTelemetryHub._shared_lxm_router = None
+
+
 from reticulum_telemetry_hub.embedded_lxmd.embedded import EmbeddedLxmd
 from reticulum_telemetry_hub.lxmf_telemetry import telemetry_controller as tc_mod
 from reticulum_telemetry_hub.lxmf_telemetry.model.persistance import Base
-from reticulum_telemetry_hub.lxmf_telemetry.telemetry_controller import TelemetryController
+from reticulum_telemetry_hub.lxmf_telemetry.telemetry_controller import (
+    TelemetryController,
+)
 
 
 @pytest.fixture
@@ -147,4 +162,3 @@ def running_embedded_lxmd(embedded_lxmd_factory):
             harness.embedded.stop()
 
     return factory
-

--- a/tests/test_reticulum_server_daemon.py
+++ b/tests/test_reticulum_server_daemon.py
@@ -1,6 +1,13 @@
 import time
 
+import LXMF
+import RNS
+import pytest
+
+from reticulum_telemetry_hub.api.models import Subscriber
 from reticulum_telemetry_hub.reticulum_server import services
+from reticulum_telemetry_hub.reticulum_server.command_manager import CommandManager
+from reticulum_telemetry_hub.reticulum_server.constants import PLUGIN_COMMAND
 from reticulum_telemetry_hub.reticulum_server.__main__ import ReticulumTelemetryHub
 
 
@@ -65,4 +72,82 @@ def test_daemon_service_gating(monkeypatch, tmp_path):
         assert "unsupported" not in hub._active_services
     finally:
         hub.stop_daemon_workers()
+        hub.shutdown()
+
+
+def test_subscriber_cache_refresh_after_subscribe(tmp_path):
+    hub = ReticulumTelemetryHub(
+        "Daemon",
+        str(tmp_path),
+        tmp_path / "identity",
+    )
+
+    topic_id = "topic-dynamic"
+    dest_one = RNS.Destination(
+        RNS.Identity(), RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"
+    )
+    dest_two = RNS.Destination(
+        RNS.Identity(), RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"
+    )
+
+    class DummyAPI:
+        def __init__(self) -> None:
+            self.subscribers = [
+                Subscriber(
+                    destination=dest_one.identity.hash.hex(),
+                    topic_id=topic_id,
+                    metadata={"tag": "alpha"},
+                )
+            ]
+
+        def list_subscribers(self):
+            return list(self.subscribers)
+
+        def subscribe_topic(self, topic_id: str, destination: str, **_: dict):
+            subscriber = Subscriber(
+                destination=destination,
+                topic_id=topic_id,
+                metadata={"tag": "beta"},
+            )
+            self.subscribers.append(subscriber)
+            return subscriber
+
+    dummy_api = DummyAPI()
+    hub.api = dummy_api
+    hub.command_manager.api = dummy_api
+    hub.connections = {
+        dest_one.identity.hash: dest_one,
+        dest_two.identity.hash: dest_two,
+    }
+    sent: list[LXMF.LXMessage] = []
+    hub.lxm_router.handle_outbound = lambda message: sent.append(message)
+
+    try:
+        hub._refresh_topic_registry()
+        hub.send_message("Hello", topic=topic_id)
+
+        assert {msg.destination_hash for msg in sent} == {dest_one.identity.hash}
+
+        subscribe_command = {
+            PLUGIN_COMMAND: CommandManager.CMD_SUBSCRIBE_TOPIC,
+            "TopicID": topic_id,
+        }
+        subscribe_message = LXMF.LXMessage(
+            hub.my_lxmf_dest,
+            dest_two,
+            fields={LXMF.FIELD_COMMANDS: [subscribe_command]},
+            desired_method=LXMF.LXMessage.DIRECT,
+        )
+        subscribe_message.pack()
+        subscribe_message.signature_validated = True
+
+        sent.clear()
+        hub.delivery_callback(subscribe_message)
+        hub.send_message("Hello again", topic=topic_id)
+
+        destinations = {msg.destination_hash for msg in sent}
+        assert dest_two.identity.hash in destinations
+        topic_hexes = hub.topic_subscribers.get(topic_id, set())
+        assert dest_two.identity.hash.hex().lower() in topic_hexes
+    finally:
         hub.shutdown()


### PR DESCRIPTION
## Summary
- add TTL-based invalidation and command-aware refreshes to the topic subscriber cache
- reset the shared LXMF router between tests and cover dynamic subscription delivery without restarting the hub
- bump the package version and record the completed work in TASK.md

## Testing
- pytest tests/test_reticulum_server_daemon.py tests/test_command_manager.py --disable-warnings --maxfail=1 --no-cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e1fb5e9288325817aa6110a43c196)