### PR TITLE
Handle invalid announce metadata and update release info

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -5,3 +5,4 @@
 - 2025-11-19: ✅ Decode announce metadata using LXMF helper and ensure identity labels follow msgpack names.
 - 2025-11-19: ✅ Ensure create-subscriber commands preserve `RejectTests=0` values.
 - 2025-11-19: ✅ Refresh topic subscriber cache after subscription changes to deliver messages immediately.
+- 2025-11-19: ✅ Persist joined client list across Reticulum Telemetry Hub sessions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.13.0"
+version = "0.14.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -114,9 +114,14 @@ class AnnounceHandler:
             return "unknown"
 
         if isinstance(app_data, bytes):
-            display_name = display_name_from_app_data(app_data)
+            try:
+                display_name = display_name_from_app_data(app_data)
+            except Exception:
+                display_name = None
+
             if display_name is not None:
                 return display_name.strip()
+
             try:
                 return app_data.decode("utf-8").strip()
             except UnicodeDecodeError:


### PR DESCRIPTION
## Summary
- prevent invalid LXMF announce payloads from crashing decode by falling back to hex strings
- record completion of client list persistence work and bump project version to 0.14.0

## Testing
- pytest
- flake8 reticulum_telemetry_hub/reticulum_server/__main__.py (fails: existing line-length warnings)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e24844dec832594855d87cd871498)