### PR TITLE
Handle positional LXMF command payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ This is the exact payload the hub expects (`reticulum_telemetry_hub/reticulum_se
 
 Current Sideband builds wrap whatever you paste into the `Commands` field as a quoted string, so the hub sees `Fields : {9: [{0: '{\"Command\":\"CreateTopic\"...`}]}` and ignores it. RTH expects a JSON object inside the commands array, not a quoted blob, and there is no Sideband UI that emits that today. Until RTH is updated to either parse the wrapped string or prompt interactively (e.g., ask for `TopicName` and `TopicPath` after receiving `CreateTopic`), the only reliable way to create topics is via a client that sends real JSON (e.g., the HTTP API, a custom LXMF sender, or by patching RTH to unwrap the string). If you are testing, check the RTH log; if you see quotes around the whole command, the hub will not act on it with the current code.
 
+RTH now also tolerates Sideband's positional fallback that shows up in logs like `Fields: {9: {0: "CreateTopic", 1: "Weather", 2: "environment/weather"}}`. The hub maps the numeric positions into the expected fields for known commands, so the payload above is treated the same as the JSON example earlier.
+
 Any message sent to the hub that includes a `TopicID` (in the LXMF fields or a command payload) will only be forwarded to the subscribers registered for that topic. The hub automatically refreshes the registry from the API, so new subscriptions take effect without restarting the process.
 
 ### Command-line options

--- a/TASK.md
+++ b/TASK.md
@@ -10,3 +10,4 @@
 - 2025-11-19: ✅ Accept snake_case command fields when prompting for missing data.
 - 2025-11-20: ✅ Normalize Sideband-wrapped commands to preserve telemetry commands.
 - 2025-11-20: ✅ Normalize Sideband-wrapped command payloads carrying JSON objects.
+- 2025-11-20: ✅ Accept positional LXMF command parameters and log unknown commands.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.18.0"
+version = "0.19.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- normalize positional LXMF command payloads so numeric-key Sideband messages map into the expected fields
- log unknown command attempts for easier troubleshooting and document the newly accepted format
- expand command manager tests and bump project metadata

## Testing
- pytest -q --disable-warnings --no-cov


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f27129b3c832589b53f46af2a4dd0)