### PR TITLE
Handle escape-prefixed LXMF command bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ RTH consumes LXMF commands from the `Commands` field (numeric field ID `9`). Eac
 - A plain JSON object: `[{"Command": "join"}]`
 - A JSON string that parses to an object: `[ "{\"Command\": \"join\"}" ]`
 - Sideband-style numeric wrapper that RTH unwraps automatically: `[{"0": "{\"Command\":\"join\"}"}]`
+- An escape-prefixed message body when you cannot populate the `Commands` field:
+  - Plain text: ``\\\join`` (RTH wraps this as `[{"Command":"join"}]`)
+  - JSON: ``\\\{"Command":"CreateTopic","TopicName":"Weather","TopicPath":"environment/weather"}``
 
 Parameters are provided alongside the command name in the same object. RTH tolerates common casing differences (`TopicID`, `topic_id`, `topic_id`, etc.) and will prompt for anything still missing.
 

--- a/TASK.md
+++ b/TASK.md
@@ -12,3 +12,4 @@
 - 2025-11-20: ✅ Normalize Sideband-wrapped command payloads carrying JSON objects.
 - 2025-11-20: ✅ Accept positional LXMF command parameters and log unknown commands.
 - 2025-11-20: ✅ Stop unsolicited "Telemetry data" LXMF broadcasts to known identities.
+- 2025-11-20: ✅ Detect escape-prefixed telemetry payloads and normalize commands before broadcasting.

--- a/docs/supportedCommands.md
+++ b/docs/supportedCommands.md
@@ -25,3 +25,4 @@ Place commands in the LXMF `Commands` field (field ID `9`) as a JSON array of ob
 Notes:
 - RTH accepts common field name variants (e.g., `TopicID`, `topic_id`, `topic_id`, `TopicPath`, `topic_path`).
 - If required fields are missing, the hub replies with the missing keys and merges your follow-up payload with the original.
+- When the `Commands` field is unavailable, prefix the message body with ``\\\`` so the hub treats it as a command payload (e.g., ``\\\join`` or ``\\\{"Command":"SubscribeTopic","TopicID":"<TopicID>"}``).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.20.0"
+version = "0.21.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/tests/test_escape_prefixed_commands.py
+++ b/tests/test_escape_prefixed_commands.py
@@ -1,0 +1,106 @@
+import json
+
+import LXMF
+import RNS
+
+from reticulum_telemetry_hub.reticulum_server.__main__ import (
+    ESCAPED_COMMAND_PREFIX,
+    ReticulumTelemetryHub,
+)
+from reticulum_telemetry_hub.reticulum_server.command_manager import CommandManager
+
+
+def _make_stub_hub():
+    """Build a minimal hub instance for delivery callback tests."""
+    if RNS.Reticulum.get_instance() is None:
+        RNS.Reticulum()
+
+    hub = ReticulumTelemetryHub.__new__(ReticulumTelemetryHub)
+    hub.lxm_router = type(
+        "DummyRouter", (), {"handle_outbound": lambda self, msg: None}
+    )()
+    hub.my_lxmf_dest = RNS.Destination(
+        RNS.Identity(),
+        RNS.Destination.IN,
+        RNS.Destination.SINGLE,
+        "lxmf",
+        "delivery",
+    )
+    hub.connections = {}
+    hub.identities = {}
+    hub.topic_subscribers = {}
+    hub.api = type("DummyAPI", (), {"list_subscribers": lambda self: []})()
+    hub.tel_controller = type(
+        "DummyTelemetryController", (), {"handle_message": lambda self, message: False}
+    )()
+    hub._refresh_topic_registry = lambda: None
+    hub.send_message = lambda *args, **kwargs: None
+    return hub
+
+
+def test_delivery_callback_parses_plaintext_escape():
+    """Ensure plaintext escape bodies become wrapped command payloads."""
+    hub = _make_stub_hub()
+    received = []
+
+    def record(commands, message):
+        received.append(commands)
+
+    hub.command_handler = record
+
+    dest_one = RNS.Destination(
+        RNS.Identity(), RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"
+    )
+    payload = f"{ESCAPED_COMMAND_PREFIX}{CommandManager.CMD_JOIN}"
+    incoming = LXMF.LXMessage(hub.my_lxmf_dest, dest_one, payload, fields={})
+    incoming.signature_validated = True
+
+    hub.delivery_callback(incoming)
+
+    assert received == [[{"Command": CommandManager.CMD_JOIN}]]
+
+
+def test_delivery_callback_parses_json_escape():
+    """Ensure JSON escape bodies are parsed into a command list."""
+    hub = _make_stub_hub()
+    received = []
+
+    def record(commands, message):
+        received.append(commands)
+
+    hub.command_handler = record
+
+    dest_one = RNS.Destination(
+        RNS.Identity(), RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"
+    )
+    command_payload = json.dumps({"Command": CommandManager.CMD_LIST_CLIENTS})
+    payload = f"{ESCAPED_COMMAND_PREFIX}{command_payload}"
+    incoming = LXMF.LXMessage(hub.my_lxmf_dest, dest_one, payload, fields={})
+    incoming.signature_validated = True
+
+    hub.delivery_callback(incoming)
+
+    assert received == [[{"Command": CommandManager.CMD_LIST_CLIENTS}]]
+
+
+def test_delivery_callback_ignores_non_prefixed_bodies():
+    """Ensure normal message bodies do not trigger command parsing."""
+    hub = _make_stub_hub()
+    received = []
+
+    def record(commands, message):
+        received.append(commands)
+
+    hub.command_handler = record
+
+    dest_one = RNS.Destination(
+        RNS.Identity(), RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"
+    )
+    incoming = LXMF.LXMessage(
+        hub.my_lxmf_dest, dest_one, CommandManager.CMD_JOIN, fields={}
+    )
+    incoming.signature_validated = True
+
+    hub.delivery_callback(incoming)
+
+    assert not received


### PR DESCRIPTION
## Summary
- parse escape-prefixed LXMF message bodies into normalized command lists and pass them through the existing command handler with logging for malformed payloads
- document the escape prefix usage alongside supported command examples and record the task/version updates
- add unit coverage for plain-text, JSON, and non-prefixed escape message handling

## Testing
- flake8 reticulum_telemetry_hub tests *(fails: numerous pre-existing style violations in legacy modules)*
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f46e4be3c83258c0ca57987a7a2f9)