### PR TITLE
Prevent broadcasting escape-prefixed commands

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -13,3 +13,4 @@
 - 2025-11-20: ✅ Accept positional LXMF command parameters and log unknown commands.
 - 2025-11-20: ✅ Stop unsolicited "Telemetry data" LXMF broadcasts to known identities.
 - 2025-11-20: ✅ Detect escape-prefixed telemetry payloads and normalize commands before broadcasting.
+- 2025-11-20: ✅ Suppress broadcasts when escape-prefixed commands are detected in plaintext bodies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.21.0"
+version = "0.22.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -744,9 +744,8 @@ def test_delivery_callback_handles_commands_and_broadcasts():
     assert len(command_responses) == 1
 
     broadcast_payloads = [msg.content_as_string() for msg in router_messages]
-    assert any("node-a > broadcast" in payload for payload in broadcast_payloads)
-    expected_total = 1 + max(0, len(hub.connections) - 1)
-    assert len(router_messages) == expected_total
+    assert all("broadcast" not in payload for payload in broadcast_payloads)
+    assert len(router_messages) == 1
     assert telemetry_calls == [incoming]
 
 


### PR DESCRIPTION
## Summary
- track escape-prefixed command detection to avoid treating plain-text commands as chat broadcasts
- block LXMF command-bearing messages from being echoed to other clients and add regression coverage
- bump project version and document the completed command-handling task

## Testing
- flake8 reticulum_telemetry_hub tests *(fails due to pre-existing style violations in the codebase)*
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5cbb3dec8325926304404007b067)