### PR TITLE
Add CoT chat events for TAK integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ transmits it via PyTAK with the configured callsign and TLS settings. Enable the
 service with the CLI flag and customize its behavior through environment
 variables (or a `.env` file):
 
+Signed chat messages delivered over LXMF are also mirrored into CoT chat events
+when they include non-telemetry content. Remarks carry the chat body and topic
+identifier to maintain topic-aware routing inside TAK tools.
+
 | Environment variable | Purpose |
 | --- | --- |
 | `RTH_TAK_COT_URL` | CoT endpoint URL (for example `tcp://127.0.0.1:8087`). |

--- a/TASK.md
+++ b/TASK.md
@@ -15,3 +15,4 @@
 - 2025-11-20: ✅ Detect escape-prefixed telemetry payloads and normalize commands before broadcasting.
 - 2025-11-20: ✅ Suppress broadcasts when escape-prefixed commands are detected in plaintext bodies.
 - 2025-11-28: ✅ Add TAK CoT connector service for broadcasting location updates.
+- 2025-11-28: ✅ Convert LXMF chat traffic into CoT chat events with topic-aware routing.

--- a/TASK.md
+++ b/TASK.md
@@ -16,3 +16,4 @@
 - 2025-11-20: ✅ Suppress broadcasts when escape-prefixed commands are detected in plaintext bodies.
 - 2025-11-28: ✅ Add TAK CoT connector service for broadcasting location updates.
 - 2025-11-28: ✅ Convert LXMF chat traffic into CoT chat events with topic-aware routing.
+- 2025-11-28: ✅ Ensure CoT chat events generate unique UIDs for rapid messages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.25.0"
+version = "0.26.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.24.0"
+version = "0.25.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/atak_cot/tak_connector.py
+++ b/reticulum_telemetry_hub/atak_cot/tak_connector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+import uuid
 
 from reticulum_telemetry_hub.atak_cot import Contact
 from reticulum_telemetry_hub.atak_cot import Detail
@@ -194,7 +195,9 @@ class TakConnector:
         accuracy = snapshot.accuracy if snapshot else 0.0
 
         identifier = self._identifier_from_hash(source_hash)
-        uid = f"{identifier}-chat-{int(now.timestamp())}"
+        timestamp_ms = int(start_time.timestamp() * 1000)
+        uid_suffix = uuid.uuid4().hex[:6]
+        uid = f"{identifier}-chat-{timestamp_ms}-{uid_suffix}"
         contact = Contact(callsign=sender_label or identifier)
         group = Group(name=str(topic_id), role="topic") if topic_id else None
 

--- a/tests/test_tak_connector.py
+++ b/tests/test_tak_connector.py
@@ -18,9 +18,7 @@ class DummyPytakClient:
     def __init__(self) -> None:
         self.sent: list[tuple] = []
 
-    async def create_and_send_message(
-        self, message, config=None, parse_inbound=True
-    ):
+    async def create_and_send_message(self, message, config=None, parse_inbound=True):
         self.sent.append((message, config, parse_inbound))
 
 
@@ -66,9 +64,7 @@ def test_connector_builds_cot_event_from_location():
 def test_connector_sends_cot_payload():
     manager = _build_manager()
     client = DummyPytakClient()
-    config = TakConnectionConfig(
-        cot_url="udp://example:8087", callsign="HUB"
-    )
+    config = TakConnectionConfig(cot_url="udp://example:8087", callsign="HUB")
     connector = TakConnector(
         config=config, pytak_client=client, telemeter_manager=manager
     )
@@ -101,3 +97,48 @@ def test_cot_service_publishes_periodically():
         service.stop()
 
     assert len(client.sent) >= 2
+
+
+def test_build_chat_event_includes_topic():
+    connector = TakConnector(config=TakConnectionConfig(callsign="RTH"))
+
+    event = connector.build_chat_event(
+        content="Hello team",
+        sender_label="Alpha",
+        topic_id="ops",
+        source_hash=b"\xaa" * 8,
+        timestamp=datetime(2025, 1, 2, 3, 4, 5),
+    )
+
+    assert event.type == connector.CHAT_EVENT_TYPE
+    assert event.detail is not None
+    assert event.detail.contact is not None
+    assert event.detail.contact.callsign == "Alpha"
+    assert event.detail.group is not None
+    assert event.detail.group.name == "ops"
+    assert event.detail.remarks.startswith("[topic:ops] Hello team")
+
+
+def test_send_chat_event_dispatches_payload():
+    client = DummyPytakClient()
+    connector = TakConnector(
+        config=TakConnectionConfig(callsign="HUB"), pytak_client=client
+    )
+
+    asyncio.run(
+        connector.send_chat_event(
+            content="Status update",
+            sender_label="Bravo",
+            topic_id="status",
+            source_hash="feed",
+            timestamp=datetime(2025, 1, 1, 0, 0, 0),
+        )
+    )
+
+    assert client.sent
+    event, cfg, parse_flag = client.sent[0]
+    assert event.type == connector.CHAT_EVENT_TYPE
+    assert event.detail is not None
+    assert event.detail.group is not None
+    assert cfg["fts"]["CALLSIGN"] == "HUB"
+    assert parse_flag is False

--- a/tests/test_tak_connector.py
+++ b/tests/test_tak_connector.py
@@ -142,3 +142,24 @@ def test_send_chat_event_dispatches_payload():
     assert event.detail.group is not None
     assert cfg["fts"]["CALLSIGN"] == "HUB"
     assert parse_flag is False
+
+
+def test_chat_uids_remain_unique():
+    connector = TakConnector(config=TakConnectionConfig(callsign="RTH"))
+
+    first = connector.build_chat_event(
+        content="Hello there",
+        sender_label="Alpha",
+        topic_id="ops",
+        source_hash=b"\x01" * 8,
+        timestamp=datetime(2025, 1, 1, 0, 0, 0),
+    )
+    second = connector.build_chat_event(
+        content="Hello there",
+        sender_label="Alpha",
+        topic_id="ops",
+        source_hash=b"\x01" * 8,
+        timestamp=datetime(2025, 1, 1, 0, 0, 0),
+    )
+
+    assert first.uid != second.uid


### PR DESCRIPTION
## Summary
- add CoT chat event builders to the TAK connector so LXMF chat payloads carry sender and topic metadata
- emit CoT chat events from delivery callbacks before rebroadcasting validated, non-telemetry LXMF content
- expand TAK connector and delivery callback tests plus documentation and version/task updates

## Testing
- pytest
- flake8 reticulum_telemetry_hub/atak_cot/tak_connector.py reticulum_telemetry_hub/reticulum_server/__main__.py tests/test_tak_connector.py tests/test_command_manager.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929d8c842b08325a532d199578a82c4)