### PR TITLE
Assign TAK locations to identity labels

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -21,3 +21,4 @@
 - 2025-11-29: ✅ Add Google-style docstrings to API service methods to clarify IDs, metadata defaults, and error handling.
 - 2025-11-29: ✅ Refresh README installation steps, dependency guidance, and link targets.
 - 2025-11-29: ✅ Assign TAK location events to the originating Reticulum identity using display names when available or LXMF addresses otherwise.
+- 2025-11-29: ✅ Normalize TAK connector identifiers derived from pretty-formatted hashes.

--- a/TASK.md
+++ b/TASK.md
@@ -20,3 +20,4 @@
 - 2025-11-28: ✅ Consolidate hub configuration (including TAK) into a unified ``config.ini`` while preserving CLI flag overrides.
 - 2025-11-29: ✅ Add Google-style docstrings to API service methods to clarify IDs, metadata defaults, and error handling.
 - 2025-11-29: ✅ Refresh README installation steps, dependency guidance, and link targets.
+- 2025-11-29: ✅ Assign TAK location events to the originating Reticulum identity using display names when available or LXMF addresses otherwise.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.31.0"
+version = "0.32.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.30.0"
+version = "0.31.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/atak_cot/tak_connector.py
+++ b/reticulum_telemetry_hub/atak_cot/tak_connector.py
@@ -381,18 +381,18 @@ class TakConnector:
             str: Callsign-compatible identifier.
         """
 
+        label = self._label_from_identity(peer_hash)
+        if label:
+            return label
         if peer_hash is None:
             return self._config.callsign
         if isinstance(peer_hash, (bytes, bytearray)):
             normalized = peer_hash.hex()
         else:
-            normalized = str(peer_hash).strip().split(":")[-1]
-        normalized = normalized or self._config.callsign
+            normalized = str(peer_hash).strip()
+        normalized = normalized.replace(":", "") or self._config.callsign
         if len(normalized) > 12:
             normalized = normalized[-12:]
-        label = self._label_from_identity(peer_hash)
-        if label:
-            return label
         return normalized
 
     def _label_from_identity(self, peer_hash: str | bytes | None) -> str | None:

--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -252,6 +252,7 @@ class ReticulumTelemetryHub:
             config=tak_config_manager.tak_config if tak_config_manager else None,
             telemeter_manager=self.telemeter_manager,
             telemetry_controller=self.tel_controller,
+            identity_lookup=self._lookup_identity_label,
         )
         self.telemetry_sampler = TelemetrySampler(
             self.tel_controller,

--- a/reticulum_telemetry_hub/reticulum_server/services.py
+++ b/reticulum_telemetry_hub/reticulum_server/services.py
@@ -234,6 +234,7 @@ def _cot_factory(hub: "ReticulumTelemetryHub") -> HubService:
             config=config_manager.tak_config,
             telemeter_manager=hub.telemeter_manager,
             telemetry_controller=hub.tel_controller,
+            identity_lookup=hub._lookup_identity_label,
         )
     interval = connector.config.poll_interval_seconds
     return CotTelemetryService(connector=connector, interval=interval)

--- a/tests/test_tak_connector.py
+++ b/tests/test_tak_connector.py
@@ -87,6 +87,22 @@ def test_connector_prefers_identity_lookup_label():
     assert lookups
 
 
+def test_connector_normalizes_pretty_hash_identifiers():
+    manager = _build_manager()
+    manager.telemeter.peer_dest = "aa:bb:cc:dd"
+    connector = TakConnector(
+        config=TakConnectionConfig(callsign="HUB"), telemeter_manager=manager
+    )
+
+    event = connector.build_event()
+
+    assert event is not None
+    assert event.detail is not None
+    assert event.detail.contact is not None
+    assert event.detail.contact.callsign == "aabbccdd"
+    assert event.uid.startswith("HUB-aabbccdd")
+
+
 def test_connector_sends_cot_payload():
     manager = _build_manager()
     client = DummyPytakClient()

--- a/tests/test_tak_connector.py
+++ b/tests/test_tak_connector.py
@@ -61,6 +61,32 @@ def test_connector_builds_cot_event_from_location():
     assert event.start.startswith("2025-01-01T00:00:00")
 
 
+def test_connector_prefers_identity_lookup_label():
+    manager = _build_manager()
+    manager.telemeter.peer_dest = "deadbeef"
+    lookups: list[str | bytes | None] = []
+
+    def lookup_identity(peer_hash: str | bytes | None) -> str:
+        lookups.append(peer_hash)
+        if peer_hash == "deadbeef":
+            return "Display Name"
+        return ""
+
+    connector = TakConnector(
+        config=TakConnectionConfig(callsign="HUB"),
+        telemeter_manager=manager,
+        identity_lookup=lookup_identity,
+    )
+
+    event = connector.build_event()
+
+    assert event is not None
+    assert event.detail is not None
+    assert event.detail.contact is not None
+    assert event.detail.contact.callsign == "Display Name"
+    assert lookups
+
+
 def test_connector_sends_cot_payload():
     manager = _build_manager()
     client = DummyPytakClient()


### PR DESCRIPTION
## Summary
- add an optional identity lookup to the TAK connector so CoT events use peer display names or LXMF addresses
- connect the hub’s TAK connector wiring to the identity lookup and extend tests for the new labeling
- bump the package version and record the completed task

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692aeab2cbc483259dc1d69ab0828541)