### PR TITLE
Add group and track details to TAK events

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -24,3 +24,4 @@
 - 2025-11-29: ✅ Normalize TAK connector identifiers derived from pretty-formatted hashes.
 - 2025-11-29: ✅ Raise coverage to at least 90% and correct formatting issues.
 - 2025-11-29: ✅ Add RNS import to TAK connector and test send_latest_location to avoid NameError.
+- 2025-11-29: ✅ Extend TakConnector.build_event to include group defaults and track metadata.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.34.0"
+version = "0.35.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/atak_cot/tak_connector.py
+++ b/reticulum_telemetry_hub/atak_cot/tak_connector.py
@@ -10,6 +10,7 @@ from reticulum_telemetry_hub.atak_cot import Contact
 from reticulum_telemetry_hub.atak_cot import Detail
 from reticulum_telemetry_hub.atak_cot import Event
 from reticulum_telemetry_hub.atak_cot import Group
+from reticulum_telemetry_hub.atak_cot import Track
 from reticulum_telemetry_hub.atak_cot.pytak_client import PytakClient
 from reticulum_telemetry_hub.config.models import TakConnectionConfig
 from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors import (
@@ -116,7 +117,8 @@ class TakConnector:
         event = self.build_event()
         if event is None:
             RNS.log(
-                "TAK connector skipped CoT send because no location is available",
+                "TAK connector skipped CoT send because no location is "
+                "available",
                 RNS.LOG_WARNING,
             )
             return False
@@ -148,7 +150,9 @@ class TakConnector:
             uid = f"{self._config.callsign}-{identifier}"
 
         contact = Contact(callsign=identifier or self._config.callsign)
-        detail = Detail(contact=contact)
+        group = Group(name="Cyan", role="Team")
+        track = Track(course=snapshot.bearing, speed=snapshot.speed)
+        detail = Detail(contact=contact, group=group, track=track)
 
         event_dict = {
             "version": "2.0",
@@ -401,7 +405,9 @@ class TakConnector:
             normalized = normalized[-12:]
         return normalized
 
-    def _label_from_identity(self, peer_hash: str | bytes | None) -> str | None:
+    def _label_from_identity(
+        self, peer_hash: str | bytes | None
+    ) -> str | None:
         """Return a display label for ``peer_hash`` when a lookup is available.
 
         Args:


### PR DESCRIPTION
## Summary
- add CoT track serialization support alongside contact and group metadata
- include default group affiliation and track details when building TAK location events
- expand CoT tests to cover group/track XML output and bump project version

## Testing
- flake8 reticulum_telemetry_hub/atak_cot/__init__.py reticulum_telemetry_hub/atak_cot/tak_connector.py tests/test_atak_cot.py tests/test_tak_connector.py
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b647462488325be0ed159dbc63eef)