### PR TITLE
Add GeoChat detail support for CoT chat events

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -25,3 +25,4 @@
 - 2025-11-29: ✅ Raise coverage to at least 90% and correct formatting issues.
 - 2025-11-29: ✅ Add RNS import to TAK connector and test send_latest_location to avoid NameError.
 - 2025-11-29: ✅ Extend TakConnector.build_event to include group defaults and track metadata.
+- 2025-11-29: ✅ Add GeoChat detail construction for chat events including hierarchy links.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.35.0"
+version = "0.36.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- extend CoT model layer with GeoChat chat, chat group, link, and hierarchy support
- build chat event details that mirror GeoChat payload expectations in TakConnector
- add GeoChat serialization tests and bump project version/task log

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b673c9e4c8325918708089cf670cc)