### PR TITLE
Convert incoming telemetry to TAK CoT events

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -28,3 +28,4 @@
 - 2025-11-29: ✅ Add GeoChat detail construction for chat events including hierarchy links.
 - 2025-11-29: ✅ Log TAK event types and JSON payloads before transmission.
 - 2025-11-29: ✅ Convert incoming telemetry to TAK CoT events using sender UIDs and display names.
+- 2025-11-30: ✅ Avoid rerunning event loops when dispatching telemetry CoT events.

--- a/TASK.md
+++ b/TASK.md
@@ -27,3 +27,4 @@
 - 2025-11-29: ✅ Extend TakConnector.build_event to include group defaults and track metadata.
 - 2025-11-29: ✅ Add GeoChat detail construction for chat events including hierarchy links.
 - 2025-11-29: ✅ Log TAK event types and JSON payloads before transmission.
+- 2025-11-29: ✅ Convert incoming telemetry to TAK CoT events using sender UIDs and display names.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.38.0"
+version = "0.39.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.37.0"
+version = "0.38.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- build CoT location events directly from incoming telemetry using the sender’s LXMF UID and display name for callsigns
- hook the telemetry controller into the TAK connector so each telemetry message emits a CoT payload automatically
- expand TAK connector and telemetry controller tests, update task log, and bump the project version

## Testing
- pytest
- flake8 --max-line-length=120 reticulum_telemetry_hub/atak_cot/tak_connector.py reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py reticulum_telemetry_hub/reticulum_server/__main__.py tests/test_tak_connector.py tests/test_lxmf_telemetry.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b6fb50d188325b763ac72abb946bc)