### PR TITLE
Add TAK connection logging and keepalive

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -30,3 +30,4 @@
 - 2025-11-29: ✅ Convert incoming telemetry to TAK CoT events using sender UIDs and display names.
 - 2025-11-30: ✅ Avoid rerunning event loops when dispatching telemetry CoT events.
 - 2025-11-30: ✅ Fix TAK GeoChat payload structure and hierarchy.
+- 2025-12-02: ✅ Ensure TAK connection status logging and keepalive pongs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.40.0"
+version = "0.41.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/atak_cot/pytak_client.py
+++ b/reticulum_telemetry_hub/atak_cot/pytak_client.py
@@ -114,6 +114,17 @@ class FTSCLITool(pytak.CLITool):
         for task in tasks:
             self.run_c_task(task)
 
+    async def setup(self) -> None:
+        cot_url = self.config.get("COT_URL", "")
+        try:
+            await super().setup()
+        except Exception as exc:
+            self._logger.error(
+                "Failed to connect to TAK server at %s: %s", cot_url or "unknown", exc
+            )
+            raise
+        self._logger.info("Connected to TAK server at %s", cot_url or "unknown")
+
     async def run(self, number_of_iterations: int = 0) -> None:
         """Runs this Thread and its associated coroutine tasks."""
         self._logger.info("Run: %s", self.__class__)

--- a/reticulum_telemetry_hub/atak_cot/tak_connector.py
+++ b/reticulum_telemetry_hub/atak_cot/tak_connector.py
@@ -7,6 +7,7 @@ import json
 import uuid
 
 import RNS
+from pytak.functions import tak_pong
 from reticulum_telemetry_hub.atak_cot import Chat
 from reticulum_telemetry_hub.atak_cot import ChatGroup
 from reticulum_telemetry_hub.atak_cot import ChatHierarchy
@@ -228,6 +229,19 @@ class TakConnector:
             event, config=self._config_parser, parse_inbound=False
         )
         RNS.log("TAK connector dispatched telemetry CoT event", RNS.LOG_INFO)
+        return True
+
+    async def send_keepalive(self) -> bool:
+        """Transmit a takPong CoT event to keep the TAK session alive.
+
+        Returns:
+            bool: ``True`` when the keepalive is dispatched.
+        """
+
+        RNS.log("TAK connector sending keepalive takPong", RNS.LOG_DEBUG)
+        await self._pytak_client.create_and_send_message(
+            tak_pong(), config=self._config_parser, parse_inbound=False
+        )
         return True
 
     def build_chat_event(

--- a/tests/test_pytak_client.py
+++ b/tests/test_pytak_client.py
@@ -1,0 +1,48 @@
+import logging
+from configparser import ConfigParser
+
+import asyncio
+import pytest
+
+from reticulum_telemetry_hub.atak_cot import pytak_client
+
+
+def test_cli_tool_logs_connection_success(caplog, monkeypatch):
+    async def fake_protocol_factory(config):
+        return object(), object()
+
+    monkeypatch.setattr(pytak_client.pytak, "protocol_factory", fake_protocol_factory)
+    config = ConfigParser()
+    config["fts"] = {"COT_URL": "tcp://example:8087"}
+
+    cli_tool = pytak_client.FTSCLITool(config["fts"])
+
+    caplog.set_level(logging.INFO)
+    original_propagate = cli_tool._logger.propagate
+    cli_tool._logger.propagate = True
+    asyncio.run(cli_tool.setup())
+    cli_tool._logger.propagate = original_propagate
+
+    assert "Connected to TAK server at tcp://example:8087" in caplog.text
+
+
+def test_cli_tool_logs_connection_failure(caplog, monkeypatch):
+    async def failing_protocol_factory(config):  # pragma: no cover - injected failure
+        raise RuntimeError("socket error")
+
+    monkeypatch.setattr(
+        pytak_client.pytak, "protocol_factory", failing_protocol_factory
+    )
+    config = ConfigParser()
+    config["fts"] = {"COT_URL": "tcp://example:8087"}
+
+    cli_tool = pytak_client.FTSCLITool(config["fts"])
+
+    caplog.set_level(logging.ERROR)
+    original_propagate = cli_tool._logger.propagate
+    cli_tool._logger.propagate = True
+    with pytest.raises(RuntimeError):
+        asyncio.run(cli_tool.setup())
+    cli_tool._logger.propagate = original_propagate
+
+    assert "Failed to connect to TAK server" in caplog.text


### PR DESCRIPTION
## Summary
- log TAK connection setup status through the PyTAK client and expose a keepalive sender on the TAK connector
- dispatch takPong keepalives alongside periodic location updates and cover the new flows with tests
- record the completed task, bump the package version, and document the TAK connection checks in tests

## Testing
- pytest
- flake8 reticulum_telemetry_hub/atak_cot/pytak_client.py reticulum_telemetry_hub/atak_cot/tak_connector.py reticulum_telemetry_hub/reticulum_server/services.py tests/test_tak_connector.py tests/test_pytak_client.py (line-length warnings remain from existing code)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ece5c3a288325b8ae96b9e595a1ed)