### PR TITLE
Add TAK metadata to CoT events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.41.0"
+version = "0.42.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/atak_cot/__init__.py
+++ b/reticulum_telemetry_hub/atak_cot/__init__.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from reticulum_telemetry_hub.atak_cot.base import Contact
 from reticulum_telemetry_hub.atak_cot.base import Group
 from reticulum_telemetry_hub.atak_cot.base import Point
+from reticulum_telemetry_hub.atak_cot.base import Status
+from reticulum_telemetry_hub.atak_cot.base import Takv
 from reticulum_telemetry_hub.atak_cot.base import Track
+from reticulum_telemetry_hub.atak_cot.base import Uid
 from reticulum_telemetry_hub.atak_cot.chat import Chat
 from reticulum_telemetry_hub.atak_cot.chat import ChatGroup
 from reticulum_telemetry_hub.atak_cot.chat import ChatHierarchy
@@ -26,6 +29,9 @@ __all__ = [
     "Group",
     "Point",
     "Track",
+    "Takv",
+    "Uid",
+    "Status",
     "Chat",
     "ChatGroup",
     "ChatHierarchy",

--- a/reticulum_telemetry_hub/atak_cot/base.py
+++ b/reticulum_telemetry_hub/atak_cot/base.py
@@ -68,30 +68,37 @@ class Contact:
     """Identifies the sender of the COT message."""
 
     callsign: str
+    endpoint: str | None = None
 
     @classmethod
     def from_xml(cls, elem):
         """Construct a :class:`Contact` from an XML ``<contact>`` element."""
 
-        return cls(callsign=elem.get("callsign", ""))
+        return cls(callsign=elem.get("callsign", ""), endpoint=elem.get("endpoint"))
 
     def to_element(self):
         """Return an XML element for the contact."""
 
         from xml.etree import ElementTree as ET
 
-        return ET.Element("contact", {"callsign": self.callsign})
+        attrib = {"callsign": self.callsign}
+        if self.endpoint:
+            attrib["endpoint"] = self.endpoint
+        return ET.Element("contact", attrib)
 
     def to_dict(self) -> dict:
         """Return a serialisable representation."""
 
-        return {"callsign": self.callsign}
+        data = {"callsign": self.callsign}
+        if self.endpoint:
+            data["endpoint"] = self.endpoint
+        return data
 
     @classmethod
     def from_dict(cls, data: dict) -> "Contact":
         """Create a :class:`Contact` from a dictionary."""
 
-        return cls(callsign=data.get("callsign", ""))
+        return cls(callsign=data.get("callsign", ""), endpoint=data.get("endpoint"))
 
 
 @dataclass
@@ -162,3 +169,122 @@ class Track:
         return cls(
             course=float(data.get("course", 0)), speed=float(data.get("speed", 0))
         )
+
+
+@dataclass
+class Takv:
+    """Describes the TAK client version and platform information."""
+
+    version: str
+    platform: str
+    os: str
+    device: str
+
+    @classmethod
+    def from_xml(cls, elem):
+        """Create a :class:`Takv` from an XML ``<takv>`` element."""
+
+        return cls(
+            version=elem.get("version", ""),
+            platform=elem.get("platform", ""),
+            os=elem.get("os", ""),
+            device=elem.get("device", ""),
+        )
+
+    def to_element(self):
+        """Return an XML element representing this TAK client."""
+
+        from xml.etree import ElementTree as ET
+
+        return ET.Element(
+            "takv",
+            {
+                "version": self.version,
+                "platform": self.platform,
+                "os": self.os,
+                "device": self.device,
+            },
+        )
+
+    def to_dict(self) -> dict:
+        """Return a serialisable representation."""
+
+        return {
+            "version": self.version,
+            "platform": self.platform,
+            "os": self.os,
+            "device": self.device,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Takv":
+        """Create a :class:`Takv` from a dictionary."""
+
+        return cls(
+            version=data.get("version", ""),
+            platform=data.get("platform", ""),
+            os=data.get("os", ""),
+            device=data.get("device", ""),
+        )
+
+
+@dataclass
+class Uid:
+    """Nested UID used by ATAK to describe the Droid identifier."""
+
+    droid: str
+
+    @classmethod
+    def from_xml(cls, elem):
+        """Construct a :class:`Uid` from an XML ``<uid>`` element."""
+
+        return cls(droid=elem.get("Droid", ""))
+
+    def to_element(self):
+        """Return an XML element representing the UID."""
+
+        from xml.etree import ElementTree as ET
+
+        return ET.Element("uid", {"Droid": self.droid})
+
+    def to_dict(self) -> dict:
+        """Return a serialisable representation."""
+
+        return {"Droid": self.droid}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Uid":
+        """Create a :class:`Uid` from a dictionary."""
+
+        return cls(droid=data.get("Droid", ""))
+
+
+@dataclass
+class Status:
+    """Represents battery status information."""
+
+    battery: float
+
+    @classmethod
+    def from_xml(cls, elem):
+        """Construct a :class:`Status` from an XML ``<status>`` element."""
+
+        return cls(battery=float(elem.get("battery", 0)))
+
+    def to_element(self):
+        """Return an XML element representing status."""
+
+        from xml.etree import ElementTree as ET
+
+        return ET.Element("status", {"battery": str(self.battery)})
+
+    def to_dict(self) -> dict:
+        """Return a serialisable representation."""
+
+        return {"battery": self.battery}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Status":
+        """Create a :class:`Status` from a dictionary."""
+
+        return cls(battery=float(data.get("battery", 0)))

--- a/reticulum_telemetry_hub/atak_cot/detail.py
+++ b/reticulum_telemetry_hub/atak_cot/detail.py
@@ -6,7 +6,10 @@ import xml.etree.ElementTree as ET
 
 from reticulum_telemetry_hub.atak_cot.base import Contact
 from reticulum_telemetry_hub.atak_cot.base import Group
+from reticulum_telemetry_hub.atak_cot.base import Status
+from reticulum_telemetry_hub.atak_cot.base import Takv
 from reticulum_telemetry_hub.atak_cot.base import Track
+from reticulum_telemetry_hub.atak_cot.base import Uid
 from reticulum_telemetry_hub.atak_cot.chat import Chat
 from reticulum_telemetry_hub.atak_cot.chat import ChatGroup
 from reticulum_telemetry_hub.atak_cot.chat import Link
@@ -22,11 +25,14 @@ class Detail:
     group: Optional[Group] = None
     groups: list[Group] = field(default_factory=list)
     track: Optional[Track] = None
+    takv: Optional[Takv] = None
     chat: Optional[Chat] = None
     chat_group: Optional[ChatGroup] = None
+    uid: Optional[Uid] = None
     links: list[Link] = field(default_factory=list)
     remarks: Optional[Union[str, Remarks]] = None
     marti: Optional[Marti] = None
+    status: Optional[Status] = None
 
     @classmethod
     def from_xml(cls, elem: ET.Element) -> "Detail":
@@ -35,11 +41,14 @@ class Detail:
         contact_el = elem.find("contact")
         group_elems = elem.findall("__group")
         track_el = elem.find("track")
+        takv_el = elem.find("takv")
         chat_el = elem.find("__chat")
         chatgrp_el = elem.find("chatgrp")
+        uid_el = elem.find("uid")
         link_elems = elem.findall("link")
         remarks_el = elem.find("remarks")
         marti_el = elem.find("marti")
+        status_el = elem.find("status")
         groups = [Group.from_xml(item) for item in group_elems]
         primary_group = groups[0] if groups else None
         extra_groups = groups[1:] if len(groups) > 1 else []
@@ -54,13 +63,16 @@ class Detail:
             group=primary_group,
             groups=extra_groups,
             track=(Track.from_xml(track_el) if track_el is not None else None),
+            takv=Takv.from_xml(takv_el) if takv_el is not None else None,
             chat=Chat.from_xml(chat_el) if chat_el is not None else None,
             chat_group=(
                 ChatGroup.from_xml(chatgrp_el) if chatgrp_el is not None else None
             ),
+            uid=Uid.from_xml(uid_el) if uid_el is not None else None,
             links=[Link.from_xml(item) for item in link_elems],
             remarks=remarks,
             marti=Marti.from_xml(marti_el) if marti_el is not None else None,
+            status=Status.from_xml(status_el) if status_el is not None else None,
         )
 
     def to_element(self) -> Optional[ET.Element]:
@@ -72,15 +84,20 @@ class Detail:
                 self.group,
                 self.groups,
                 self.track,
+                self.takv,
                 self.chat,
                 self.chat_group,
+                self.uid,
                 self.links,
                 self.remarks,
                 self.marti,
+                self.status,
             ]
         ):
             return None
         detail_el = ET.Element("detail")
+        if self.takv:
+            detail_el.append(self.takv.to_element())
         if self.contact:
             detail_el.append(self.contact.to_element())
         if self.group:
@@ -93,6 +110,8 @@ class Detail:
             detail_el.append(self.chat.to_element())
         if self.chat_group:
             detail_el.append(self.chat_group.to_element())
+        if self.uid:
+            detail_el.append(self.uid.to_element())
         for link in self.links:
             detail_el.append(link.to_element())
         if self.remarks:
@@ -105,6 +124,8 @@ class Detail:
             marti_element = self.marti.to_element()
             if marti_element is not None:
                 detail_el.append(marti_element)
+        if self.status:
+            detail_el.append(self.status.to_element())
         return detail_el
 
     def to_dict(self) -> dict:
@@ -119,10 +140,14 @@ class Detail:
             data["groups"] = [group.to_dict() for group in self.groups]
         if self.track:
             data["track"] = self.track.to_dict()
+        if self.takv:
+            data["takv"] = self.takv.to_dict()
         if self.chat:
             data["chat"] = self.chat.to_dict()
         if self.chat_group:
             data["chat_group"] = self.chat_group.to_dict()
+        if self.uid:
+            data["uid"] = self.uid.to_dict()
         if self.links:
             data["links"] = [link.to_dict() for link in self.links]
         if self.remarks:
@@ -135,6 +160,8 @@ class Detail:
             marti_dict = self.marti.to_dict()
             if marti_dict:
                 data["marti"] = marti_dict
+        if self.status:
+            data["status"] = self.status.to_dict()
         return data
 
     @classmethod
@@ -152,12 +179,18 @@ class Detail:
         track = None
         if "track" in data:
             track = Track.from_dict(data["track"])
+        takv = None
+        if "takv" in data:
+            takv = Takv.from_dict(data["takv"])
         chat = None
         if "chat" in data:
             chat = Chat.from_dict(data["chat"])
         chat_group = None
         if "chat_group" in data:
             chat_group = ChatGroup.from_dict(data["chat_group"])
+        uid = None
+        if "uid" in data:
+            uid = Uid.from_dict(data["uid"])
         links_data = data.get("links", [])
         links = [Link.from_dict(item) for item in links_data]
         remarks_data = data.get("remarks")
@@ -169,14 +202,20 @@ class Detail:
         marti = None
         if "marti" in data:
             marti = Marti.from_dict(data.get("marti", {}))
+        status = None
+        if "status" in data:
+            status = Status.from_dict(data.get("status", {}))
         return cls(
             contact=contact,
             group=group,
             groups=groups,
             track=track,
+            takv=takv,
             chat=chat,
             chat_group=chat_group,
+            uid=uid,
             links=links,
             remarks=remarks,
             marti=marti,
+            status=status,
         )

--- a/tests/test_tak_connector.py
+++ b/tests/test_tak_connector.py
@@ -79,12 +79,19 @@ def test_connector_builds_cot_event_from_location():
     assert event.detail is not None
     assert event.detail.contact is not None
     assert event.detail.contact.callsign == "userhash1"
+    assert event.detail.contact.endpoint == "example:8087:udp"
     assert event.detail.group is not None
-    assert event.detail.group.name == "Cyan"
-    assert event.detail.group.role == "Team"
+    assert event.detail.group.name == "Yellow"
+    assert event.detail.group.role == "Team Member"
     assert event.detail.track is not None
     assert event.detail.track.course == pytest.approx(180.0)
     assert event.detail.track.speed == pytest.approx(2.5)
+    assert event.detail.status is not None
+    assert event.detail.status.battery == pytest.approx(0.0)
+    assert event.detail.takv is not None
+    assert event.detail.takv.version == "4.9.0.156"
+    assert event.detail.uid is not None
+    assert event.detail.uid.droid == "userhash1"
     assert event.start.startswith("2025-01-01T00:00:00")
 
 
@@ -107,16 +114,32 @@ def test_connector_build_event_generates_expected_xml():
     contact_el = detail.find("contact")
     assert contact_el is not None
     assert contact_el.get("callsign") == "userhash1"
+    assert contact_el.get("endpoint") == "127.0.0.1:8087:tcp"
+
+    takv_el = detail.find("takv")
+    assert takv_el is not None
+    assert takv_el.get("version") == "4.9.0.156"
+    assert takv_el.get("platform") == "WinTAK-CIV"
+    assert takv_el.get("os") == "Microsoft Windows 11 Pro"
+    assert takv_el.get("device") == "LENOVO 20XW003LUS"
 
     group_el = detail.find("__group")
     assert group_el is not None
-    assert group_el.get("name") == "Cyan"
-    assert group_el.get("role") == "Team"
+    assert group_el.get("name") == "Yellow"
+    assert group_el.get("role") == "Team Member"
 
     track_el = detail.find("track")
     assert track_el is not None
     assert track_el.get("course") == "180.0"
     assert track_el.get("speed") == "2.5"
+
+    status_el = detail.find("status")
+    assert status_el is not None
+    assert status_el.get("battery") == "0.0"
+
+    uid_el = detail.find("uid")
+    assert uid_el is not None
+    assert uid_el.get("Droid") == "userhash1"
 
 
 def test_connector_prefers_identity_lookup_label():


### PR DESCRIPTION
## Summary
- extend CoT detail serialization to include TAK client metadata, nested UID, battery status, and contact endpoints
- derive contact endpoint strings from the configured COT URL and align group defaults/how values with the expected schema
- update tests and project version to reflect the enriched CoT event payloads

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303d62eaa0832599d20bea40ac5de7)