### PR TITLE
Add TAK proto and compatibility defaults for PyTAK configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ tls_client_cert =
 tls_client_key =
 tls_ca =
 tls_insecure = false
+tak_proto = 0
+fts_compat = 1
 
 [gpsd]
 host = 127.0.0.1
@@ -264,6 +266,10 @@ location_accuracy = 5.0
 static_information = Callsign RTH
 enable_battery = yes
 ```
+
+TAK servers typically expect TCP unicast connections. Keep ``cot_url`` in the
+``tcp://host:port`` format and use ``tak_proto = 0`` (TAK XML) with
+``fts_compat = 1`` to match PyTAK's compatibility guidance.
 
 Values omitted from the file fall back to the built-in defaults listed below. The telemetry section mirrors the prior ``telemetry.ini`` format so existing files remain compatible.
 

--- a/TASK.md
+++ b/TASK.md
@@ -31,3 +31,4 @@
 - 2025-11-30: ✅ Avoid rerunning event loops when dispatching telemetry CoT events.
 - 2025-11-30: ✅ Fix TAK GeoChat payload structure and hierarchy.
 - 2025-12-02: ✅ Ensure TAK connection status logging and keepalive pongs.
+- 2025-12-03: ✅ Ensure TAK COR events use TCP unicast with TAK_PROTO=0 and FTS_COMPAT=1 defaults.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.42.0"
+version = "0.43.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/atak_cot/pytak_client.py
+++ b/reticulum_telemetry_hub/atak_cot/pytak_client.py
@@ -171,6 +171,8 @@ class PytakClient:
         config["fts"] = {
             "COT_URL": "tcp://127.0.0.1:8087",
             "CALLSIGN": "FTS_PYTAK",
+            "TAK_PROTO": "0",
+            "FTS_COMPAT": "1",
         }
         return config
 

--- a/reticulum_telemetry_hub/config/manager.py
+++ b/reticulum_telemetry_hub/config/manager.py
@@ -307,6 +307,13 @@ class HubConfigurationManager:
             defaults.poll_interval_seconds,
         )
 
+        tak_proto = self._coerce_int(
+            section.get("tak_proto"), defaults.tak_proto
+        )
+        fts_compat = self._coerce_int(
+            section.get("fts_compat"), defaults.fts_compat
+        )
+
         return TakConnectionConfig(
             cot_url=section.get("cot_url", defaults.cot_url),
             callsign=section.get("callsign", defaults.callsign),
@@ -317,4 +324,6 @@ class HubConfigurationManager:
             tls_insecure=self._get_bool(
                 section, "tls_insecure", defaults.tls_insecure
             ),
+            tak_proto=tak_proto,
+            fts_compat=fts_compat,
         )

--- a/reticulum_telemetry_hub/config/models.py
+++ b/reticulum_telemetry_hub/config/models.py
@@ -159,6 +159,8 @@ class TakConnectionConfig:
     tls_client_key: str | None = None
     tls_ca: str | None = None
     tls_insecure: bool = False
+    tak_proto: int = 0
+    fts_compat: int = 1
 
     def to_config_parser(self) -> ConfigParser:
         """Return a ConfigParser that PyTAK understands.
@@ -175,6 +177,8 @@ class TakConnectionConfig:
             "SSL_CLIENT_KEY": self.tls_client_key or "",
             "SSL_CLIENT_CAFILE": self.tls_ca or "",
             "SSL_VERIFY": "false" if self.tls_insecure else "true",
+            "TAK_PROTO": str(self.tak_proto),
+            "FTS_COMPAT": str(self.fts_compat),
         }
         return parser
 
@@ -193,4 +197,6 @@ class TakConnectionConfig:
             "tls_client_key": self.tls_client_key,
             "tls_ca": self.tls_ca,
             "tls_insecure": self.tls_insecure,
+            "tak_proto": self.tak_proto,
+            "fts_compat": self.fts_compat,
         }

--- a/tests/test_config_paths.py
+++ b/tests/test_config_paths.py
@@ -37,3 +37,21 @@ def test_config_manager_expands_optional_config_overrides(monkeypatch, tmp_path)
         tmp_path / "custom/.reticulum/config"
     )
     assert manager.lxmf_router_config_path == tmp_path / "custom/.lxmd/config"
+
+
+def test_tak_config_includes_proto_and_compat(tmp_path):
+    config_path = tmp_path / "config.ini"
+    config_path.write_text(
+        "[tak]\n"
+        "cot_url = tcp://example:8087\n"
+        "tak_proto = 0\n"
+        "fts_compat = 1\n"
+    )
+
+    manager = HubConfigurationManager(
+        storage_path=tmp_path, config_path=config_path
+    )
+
+    assert manager.tak_config.cot_url == "tcp://example:8087"
+    assert manager.tak_config.tak_proto == 0
+    assert manager.tak_config.fts_compat == 1

--- a/tests/test_tak_connector.py
+++ b/tests/test_tak_connector.py
@@ -200,7 +200,25 @@ def test_connector_sends_cot_payload():
     message, cfg, parse_flag = client.sent[0]
     assert message.detail.contact.callsign == "userhash1"
     assert cfg["fts"]["COT_URL"] == "udp://example:8087"
+    assert cfg["fts"]["TAK_PROTO"] == "0"
+    assert cfg["fts"]["FTS_COMPAT"] == "1"
     assert parse_flag is False
+
+
+def test_connection_config_includes_pytak_options():
+    config = TakConnectionConfig(
+        cot_url="tcp://example:1234",
+        callsign="TEST",
+        tak_proto=0,
+        fts_compat=1,
+    )
+
+    cfg = config.to_config_parser()
+
+    assert cfg["fts"]["COT_URL"] == "tcp://example:1234"
+    assert cfg["fts"]["CALLSIGN"] == "TEST"
+    assert cfg["fts"]["TAK_PROTO"] == "0"
+    assert cfg["fts"]["FTS_COMPAT"] == "1"
 
 
 def test_send_latest_location_uses_snapshot(monkeypatch):


### PR DESCRIPTION
## Summary
- add tak_proto and fts_compat defaults to the TAK connection configuration and propagate them through the config manager and PyTAK client
- document TCP unicast expectations for TAK endpoints and bump the project version and task log
- expand TAK configuration tests to cover new defaults and ensure parsing from config.ini

## Testing
- flake8 --exclude venv_linux,.venv *(fails: existing repository lint violations unrelated to this change)*
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930425e600c8325b35c798f11a35c0e)