### PR TITLE
Ensure CoT JSON payloads use event root

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -32,3 +32,4 @@
 - 2025-11-30: ✅ Fix TAK GeoChat payload structure and hierarchy.
 - 2025-12-02: ✅ Ensure TAK connection status logging and keepalive pongs.
 - 2025-12-03: ✅ Ensure TAK COR events use TCP unicast with TAK_PROTO=0 and FTS_COMPAT=1 defaults.
+- 2025-12-03: ✅ Wrap CoT JSON payloads with the event root type to match ATAK expectations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.43.0"
+version = "0.44.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/atak_cot/event.py
+++ b/reticulum_telemetry_hub/atak_cot/event.py
@@ -83,19 +83,20 @@ class Event:
 
     @classmethod
     def from_dict(cls, obj: dict) -> "Event":
-        """Construct an :class:`Event` from a dictionary."""
+        """Construct an :class:`Event` from a dictionary rooted at ``event``."""
 
-        point = Point.from_dict(obj.get("point", {}))
-        detail_obj = obj.get("detail")
+        event_obj = obj.get("event") if isinstance(obj.get("event"), dict) else obj
+        point = Point.from_dict(event_obj.get("point", {}))
+        detail_obj = event_obj.get("detail")
         detail = Detail.from_dict(detail_obj) if detail_obj else None
         return cls(
-            version=obj.get("version", ""),
-            uid=obj.get("uid", ""),
-            type=obj.get("type", ""),
-            how=obj.get("how", ""),
-            time=obj.get("time", ""),
-            start=obj.get("start", ""),
-            stale=obj.get("stale", ""),
+            version=event_obj.get("version", ""),
+            uid=event_obj.get("uid", ""),
+            type=event_obj.get("type", ""),
+            how=event_obj.get("how", ""),
+            time=event_obj.get("time", ""),
+            start=event_obj.get("start", ""),
+            stale=event_obj.get("stale", ""),
             point=point,
             detail=detail,
         )
@@ -136,9 +137,9 @@ class Event:
         return ET.tostring(self.to_element())
 
     def to_dict(self) -> dict:
-        """Return a dictionary representation of the event."""
+        """Return a dictionary representation of the event with an ``event`` root."""
 
-        data = {
+        event_data = {
             "version": self.version,
             "uid": self.uid,
             "type": self.type,
@@ -149,8 +150,8 @@ class Event:
             "point": self.point.to_dict(),
         }
         if self.detail:
-            data["detail"] = self.detail.to_dict()
-        return data
+            event_data["detail"] = self.detail.to_dict()
+        return {"event": event_data}
 
     def to_json(self) -> str:
         """Return a JSON representation of the event."""

--- a/tests/test_atak_cot.py
+++ b/tests/test_atak_cot.py
@@ -43,12 +43,26 @@ def test_roundtrip_datapack():
 
 def test_json_roundtrip():
     event = Event.from_xml(COT_XML)
-    json_data = json.dumps(event.to_dict())
+    event_dict = event.to_dict()
+    assert "event" in event_dict
+    json_data = json.dumps(event_dict)
     restored = Event.from_json(json_data)
     assert restored.uid == event.uid
     assert restored.detail.group.name == "Blue"
     assert restored.detail.track is not None
     assert restored.detail.track.course == pytest.approx(90.0)
+
+
+def test_from_dict_accepts_legacy_payload():
+    event = Event.from_xml(COT_XML)
+    legacy_payload = event.to_dict()["event"]
+
+    restored = Event.from_dict(legacy_payload)
+
+    assert restored.uid == event.uid
+    assert restored.type == event.type
+    assert restored.point.lat == event.point.lat
+    assert restored.detail.contact.callsign == "TestMarker"
 
 
 def test_pack_data_accepts_event_instances():


### PR DESCRIPTION
## Summary
- wrap CoT event dictionaries with the event root element while keeping legacy payloads readable
- expand CoT tests to assert rooted JSON output and backward compatibility for unwrapped payloads
- bump the package version and record completion in TASK.md

## Testing
- flake8 reticulum_telemetry_hub tests *(fails due to numerous pre-existing style violations outside this change)*
- pytest tests/test_atak_cot.py *(fails because project-wide coverage threshold is set to 90% and overall coverage remains ~43%)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69305044477c832580b66771aed7c072)