### PR TITLE
Ensure TAK keepalive runs every 60 seconds

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -33,3 +33,4 @@
 - 2025-12-02: ✅ Ensure TAK connection status logging and keepalive pongs.
 - 2025-12-03: ✅ Ensure TAK COR events use TCP unicast with TAK_PROTO=0 and FTS_COMPAT=1 defaults.
 - 2025-12-03: ✅ Wrap CoT JSON payloads with the event root type to match ATAK expectations.
+- 2025-12-03: ✅ Ensure TAK connector emits a takPong keepalive every 60 seconds.

--- a/docs/tak.md
+++ b/docs/tak.md
@@ -34,7 +34,7 @@
   - An identity lookup used to render peer hashes as labels in CoT `callsign`s
 - Telemetry fan-out:
   - `TelemetryController.register_listener` calls `_handle_telemetry_for_tak`, which invokes `TakConnector.send_telemetry_event(...)` for every inbound telemetry payload that contains location data.
-  - The `tak_cot` daemon service runs `send_keepalive()` and `send_latest_location()` every `poll_interval_seconds`.
+  - The `tak_cot` daemon service runs `send_latest_location()` every `poll_interval_seconds` and dispatches a keepalive `takPong` every 60 seconds to maintain the session.
 - Chat relay:
   - Inbound LXMF deliveries handled in `ReticulumTelemetryHub.delivery_callback` are mirrored into TAK via `TakConnector.send_chat_event(...)` when the message body is non-empty.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.44.0"
+version = "0.45.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- schedule TAK keepalive dispatching on a dedicated 60-second interval while keeping location updates tied to the configured poll interval
- document the keepalive cadence, record the completed task entry, and bump the project version
- broaden TAK connector tests with targeted keepalive scheduling coverage and resilient payload log assertions

## Testing
- source venv_linux/bin/activate && pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930714e72088325a179b9e0c55899f2)