### PR TITLE
Keep PyTAK session alive with background loop

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -38,3 +38,4 @@
 - 2025-12-04: ✅ Format codebase and resolve lint configuration issues identified during testing.
 - 2025-12-05: ✅ Persist PyTAK sessions with shared queues, add hello/ping keepalives, and extend TAK connector coverage.
 - 2025-12-05: ✅ Keep telemetry payloads out of LXMF message bodies and rely on field delivery only.
+- 2025-12-05: ✅ Restore TAK connector keepalive delivery and connection visibility by running PyTAK in a persistent background loop.

--- a/docs/tak.md
+++ b/docs/tak.md
@@ -17,6 +17,7 @@
   - Provides `create_and_send_message(...)` which spins up PyTAK TX/RX queue workers and accepts `Event`, XML `Element`, bytes, strings, or dicts.
   - `SendWorker` converts payloads to XML bytes; `ReceiveWorker` can parse inbound CoT into `Event` objects when `parse_inbound=True` (the connector sets `False` because only TX is needed).
   - Defaults to an internal `ConfigParser` if none is provided; normally the connector passes `TakConnectionConfig.to_config_parser()`.
+  - Runs a dedicated background asyncio loop to keep the PyTAK session alive across repeated calls (including from synchronous threads) and logs connection success/failure through both the PyTAK logger and the RNS console.
 
 - `TakConnector` (`reticulum_telemetry_hub/atak_cot/tak_connector.py`)
   - Location source: prefers live `TelemeterManager` sensors, falls back to the persisted `TelemetryController` store. Produces a `LocationSnapshot` with lat/lon/altitude/speed/bearing/accuracy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.50.0"
+version = "0.51.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/tests/test_pytak_client.py
+++ b/tests/test_pytak_client.py
@@ -46,3 +46,26 @@ def test_cli_tool_logs_connection_failure(caplog, monkeypatch):
     cli_tool._logger.propagate = original_propagate
 
     assert "Failed to connect to TAK server" in caplog.text
+
+
+def test_pytak_client_uses_background_loop(monkeypatch):
+    started_loops = []
+
+    async def fake_run_session(self):
+        started_loops.append(asyncio.get_running_loop())
+        while not self._stop_event.is_set():
+            await asyncio.sleep(0.01)
+
+    monkeypatch.setattr(
+        pytak_client.PytakWorkerManager, "_run_session", fake_run_session
+    )
+
+    client = pytak_client.PytakClient()
+    asyncio.run(client.create_and_send_message(b"hello"))
+
+    assert client._loop is not None
+    assert client._loop.is_running()
+    assert started_loops[0] is client._loop
+
+    asyncio.run(client.stop())
+    assert client._loop is None


### PR DESCRIPTION
## Summary
- run the PyTAK client on a persistent background asyncio loop and surface connection success/failure through RNS logging
- add a test proving the worker manager stays active outside caller event loops and document the new lifecycle
- bump the project version and task log to reflect the TAK connector reliability work

## Testing
- flake8 reticulum_telemetry_hub tests
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932ee71af90832580303ca6f07a41e4)