### PR TITLE
Send unique telemetry snapshots to TAK

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -39,3 +39,4 @@
 - 2025-12-05: ✅ Persist PyTAK sessions with shared queues, add hello/ping keepalives, and extend TAK connector coverage.
 - 2025-12-05: ✅ Keep telemetry payloads out of LXMF message bodies and rely on field delivery only.
 - 2025-12-05: ✅ Restore TAK connector keepalive delivery and connection visibility by running PyTAK in a persistent background loop.
+- 2025-12-05: ✅ Periodically dispatch the latest unique telemetry as CoT updates from the TAK connector.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.51.0"
+version = "0.52.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/tests/test_tak_connector.py
+++ b/tests/test_tak_connector.py
@@ -15,6 +15,13 @@ from reticulum_telemetry_hub.atak_cot.tak_connector import LocationSnapshot
 from reticulum_telemetry_hub.atak_cot.tak_connector import TakConnector
 from reticulum_telemetry_hub.atak_cot import Remarks
 from reticulum_telemetry_hub.config.models import TakConnectionConfig
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.location import (
+    Location,
+)
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.sensor_enum import (
+    SID_LOCATION,
+    SID_TIME,
+)
 from reticulum_telemetry_hub.lxmf_telemetry.telemeter_manager import (
     TelemeterManager,
 )
@@ -139,6 +146,27 @@ def _telemetry_payload() -> dict:
             "last_update_iso": "2025-11-29T20:36:02",
         },
     }
+
+
+def _persist_telemeter_location(
+    telemetry_controller,
+    peer_dest: str,
+    latitude: float,
+    longitude: float,
+    timestamp: datetime,
+) -> None:
+    location_sensor = Location()
+    location_sensor.latitude = latitude
+    location_sensor.longitude = longitude
+    location_sensor.altitude = 1.0
+    location_sensor.speed = 0.5
+    location_sensor.bearing = 90.0
+    location_sensor.accuracy = 1.0
+    location_sensor.last_update = timestamp
+    packed_location = location_sensor.pack()
+    assert packed_location is not None
+    payload = {SID_TIME: int(timestamp.timestamp()), SID_LOCATION: packed_location}
+    telemetry_controller.save_telemetry(payload, peer_dest)
 
 
 def test_connector_builds_cot_event_from_location():
@@ -320,7 +348,7 @@ def test_send_latest_location_uses_snapshot(monkeypatch):
         accuracy=1.0,
         updated_at=datetime(2025, 1, 1, 0, 0, 0),
     )
-    monkeypatch.setattr(connector, "_latest_location", lambda: snapshot)
+    monkeypatch.setattr(connector, "_latest_location_snapshots", lambda: [snapshot])
 
     result = asyncio.run(connector.send_latest_location())
 
@@ -331,6 +359,54 @@ def test_send_latest_location_uses_snapshot(monkeypatch):
     assert message.point.lon == pytest.approx(2.0)
     assert cfg["fts"]["CALLSIGN"] == "HUB"
     assert parse_flag is False
+
+
+def test_send_latest_location_dispatches_unique_telemeter_entries(
+    telemetry_controller,
+):
+    client = DummyPytakClient()
+    connector = TakConnector(
+        config=TakConnectionConfig(callsign="HUB"),
+        pytak_client=client,
+        telemetry_controller=telemetry_controller,
+        telemeter_manager=None,
+    )
+    stale_time = datetime(2025, 1, 1, 12, 0, 0)
+    fresh_time = datetime(2025, 1, 2, 12, 0, 0)
+    other_time = datetime(2025, 1, 2, 12, 5, 0)
+
+    _persist_telemeter_location(
+        telemetry_controller,
+        "peer_a",
+        10.0,
+        20.0,
+        stale_time,
+    )
+    _persist_telemeter_location(
+        telemetry_controller,
+        "peer_b",
+        30.0,
+        40.0,
+        other_time,
+    )
+    _persist_telemeter_location(
+        telemetry_controller,
+        "peer_a",
+        11.0,
+        21.0,
+        fresh_time,
+    )
+
+    asyncio.run(connector.send_latest_location())
+
+    assert len(client.sent) == 2
+    events = [entry[0] for entry in client.sent]
+    peer_uids = {event.uid for event in events}
+    assert peer_uids == {"peer_a", "peer_b"}
+    peer_a_event = next(event for event in events if event.uid == "peer_a")
+    assert peer_a_event.point.lat == pytest.approx(11.0)
+    assert peer_a_event.point.lon == pytest.approx(21.0)
+    assert peer_a_event.start.startswith("2025-01-02T12:00:00")
 
 
 def test_build_event_from_telemetry_uses_sender_uid():


### PR DESCRIPTION
## Summary
- send CoT updates for each latest unique telemetry snapshot instead of a single hard-coded location
- decode stored telemetry records safely when building Cursor-on-Target events
- add coverage for unique telemetry dispatch and bump the project version

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330b28fdcc8325af04c4c528b360f4)