### PR TITLE
Ensure TAK chat CoT payload matches server template

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -40,3 +40,4 @@
 - 2025-12-05: ✅ Keep telemetry payloads out of LXMF message bodies and rely on field delivery only.
 - 2025-12-05: ✅ Restore TAK connector keepalive delivery and connection visibility by running PyTAK in a persistent background loop.
 - 2025-12-05: ✅ Periodically dispatch the latest unique telemetry as CoT updates from the TAK connector.
+- 2025-12-05: ✅ Mirror LXMF chat messages to TAK servers using the required CoT chat template.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.52.0"
+version = "0.53.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/atak_cot/chat.py
+++ b/reticulum_telemetry_hub/atak_cot/chat.py
@@ -261,7 +261,7 @@ class Remarks:
 class MartiDest:
     """Represents a MARTI destination element."""
 
-    callsign: str
+    callsign: Optional[str] = None
 
     @classmethod
     def from_xml(cls, elem: ET.Element) -> "MartiDest":
@@ -272,7 +272,10 @@ class MartiDest:
     def to_element(self) -> ET.Element:
         """Return an XML element representing the destination."""
 
-        return ET.Element("dest", {"callsign": self.callsign})
+        attrib: dict[str, str] = {}
+        if self.callsign:
+            attrib["callsign"] = self.callsign
+        return ET.Element("dest", attrib)
 
     def to_dict(self) -> dict:
         """Return a serialisable representation of the destination."""
@@ -283,7 +286,7 @@ class MartiDest:
     def from_dict(cls, data: dict) -> "MartiDest":
         """Create a :class:`MartiDest` from a dictionary."""
 
-        return cls(callsign=data.get("callsign", ""))
+        return cls(callsign=data.get("callsign"))
 
 
 @dataclass
@@ -320,8 +323,25 @@ class Marti:
         """Create a :class:`Marti` from a dictionary."""
 
         dest_data = data.get("dest")
-        dest = MartiDest.from_dict(dest_data) if dest_data else None
+        dest = MartiDest.from_dict(dest_data) if isinstance(dest_data, dict) else None
         return cls(dest=dest)
+
+
+@dataclass
+class ServerDestination:
+    """Represents an empty ``__serverdestination`` marker element."""
+
+    @staticmethod
+    def to_element() -> ET.Element:
+        """Return an empty ``__serverdestination`` element."""
+
+        return ET.Element("__serverdestination")
+
+    @staticmethod
+    def to_dict() -> dict:
+        """Return an empty mapping representing the marker."""
+
+        return {}
 
 
 @dataclass

--- a/reticulum_telemetry_hub/atak_cot/detail.py
+++ b/reticulum_telemetry_hub/atak_cot/detail.py
@@ -14,6 +14,7 @@ from reticulum_telemetry_hub.atak_cot.chat import Chat
 from reticulum_telemetry_hub.atak_cot.chat import ChatGroup
 from reticulum_telemetry_hub.atak_cot.chat import Link
 from reticulum_telemetry_hub.atak_cot.chat import Marti
+from reticulum_telemetry_hub.atak_cot.chat import ServerDestination
 from reticulum_telemetry_hub.atak_cot.chat import Remarks
 
 
@@ -33,6 +34,7 @@ class Detail:
     remarks: Optional[Union[str, Remarks]] = None
     marti: Optional[Marti] = None
     status: Optional[Status] = None
+    server_destination: bool = False
 
     @classmethod
     def from_xml(cls, elem: ET.Element) -> "Detail":
@@ -48,6 +50,7 @@ class Detail:
         link_elems = elem.findall("link")
         remarks_el = elem.find("remarks")
         marti_el = elem.find("marti")
+        server_destination_el = elem.find("__serverdestination")
         status_el = elem.find("status")
         groups = [Group.from_xml(item) for item in group_elems]
         primary_group = groups[0] if groups else None
@@ -73,6 +76,7 @@ class Detail:
             remarks=remarks,
             marti=Marti.from_xml(marti_el) if marti_el is not None else None,
             status=Status.from_xml(status_el) if status_el is not None else None,
+            server_destination=server_destination_el is not None,
         )
 
     def to_element(self) -> Optional[ET.Element]:
@@ -92,6 +96,7 @@ class Detail:
                 self.remarks,
                 self.marti,
                 self.status,
+                self.server_destination,
             ]
         ):
             return None
@@ -124,6 +129,8 @@ class Detail:
             marti_element = self.marti.to_element()
             if marti_element is not None:
                 detail_el.append(marti_element)
+        if self.server_destination:
+            detail_el.append(ServerDestination.to_element())
         if self.status:
             detail_el.append(self.status.to_element())
         return detail_el
@@ -162,6 +169,8 @@ class Detail:
                 data["marti"] = marti_dict
         if self.status:
             data["status"] = self.status.to_dict()
+        if self.server_destination:
+            data["server_destination"] = True
         return data
 
     @classmethod
@@ -205,6 +214,7 @@ class Detail:
         status = None
         if "status" in data:
             status = Status.from_dict(data.get("status", {}))
+        server_destination = data.get("server_destination", False) is True
         return cls(
             contact=contact,
             group=group,
@@ -218,4 +228,5 @@ class Detail:
             remarks=remarks,
             marti=marti,
             status=status,
+            server_destination=server_destination,
         )

--- a/reticulum_telemetry_hub/atak_cot/event.py
+++ b/reticulum_telemetry_hub/atak_cot/event.py
@@ -49,6 +49,7 @@ class Event:
     start: str
     stale: str
     point: Point
+    access: str | None = None
     detail: Detail | None = None
 
     @classmethod
@@ -78,6 +79,7 @@ class Event:
             start=root.get("start", ""),
             stale=root.get("stale", ""),
             point=point,
+            access=root.get("access"),
             detail=detail,
         )
 
@@ -98,6 +100,7 @@ class Event:
             start=event_obj.get("start", ""),
             stale=event_obj.get("stale", ""),
             point=point,
+            access=event_obj.get("access"),
             detail=detail,
         )
 
@@ -119,6 +122,8 @@ class Event:
             "start": self.start,
             "stale": self.stale,
         }
+        if self.access:
+            attrib["access"] = self.access
         event_el = ET.Element("event", attrib)
         event_el.append(self.point.to_element())
         detail_el = self.detail.to_element() if self.detail else None
@@ -149,6 +154,8 @@ class Event:
             "stale": self.stale,
             "point": self.point.to_dict(),
         }
+        if self.access:
+            event_data["access"] = self.access
         if self.detail:
             event_data["detail"] = self.detail.to_dict()
         return {"event": event_data}


### PR DESCRIPTION
## Summary
- align TAK chat event generation with the required server template, including server destination, MARTI, and access metadata
- extend CoT event/detail models to preserve access attributes and server destination markers
- refresh chat connector tests and metadata to reflect the new CoT chat payload and version bump

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933168fd8c08325b60b268d843c99ff)