### PR TITLE
Align TAK GeoChat messages with LXMF chat format

### DIFF
--- a/docs/tak.md
+++ b/docs/tak.md
@@ -25,7 +25,7 @@
   - Location / telemetry CoT (`a-f-G-U-C`): `send_latest_location()` and `send_telemetry_event(...)` call `_build_event_from_snapshot(...)`, which sets:
     - `how=h-g-i-g-o`, start/stale timestamps based on last update and `poll_interval_seconds`
     - `detail`: `contact` (callsign + endpoint), default group (`Yellow` / `Team Member`), `track` (course/speed), `takv` (platform metadata constants; version set to the current RTH release, e.g., `0.44.0`), `uid` (Droid callsign), and `status` (battery currently `0.0`)
-  - Chat CoT (`b-t-f`): `send_chat_event(...)` wraps LXMF message text in a GeoChat payload with `Chat`, `ChatGroup`, `ChatHierarchy`, `Link`, and `Remarks` detail. Uses current hub location if available; builds a unique `GeoChat.<identifier>-chat-<ts>-<suffix>` UID.
+- Chat CoT (`b-t-f`): `send_chat_event(...)` wraps LXMF message text in a GeoChat payload with `Chat`, `ChatGroup`, `ChatHierarchy`, `Link`, and `Remarks` detail. UIDs follow the LXMF sender identity: `GeoChat.<lxmf_destination>.<chatroom_name>.<message_uuid>`. The chat detail mirrors LXMF fields (`senderCallsign`, `messageId`, `chatroom`/`id`), links back to the sender UID, and stamps remarks with `source="LXMF.CLIENT.<lxmf_destination>"`, `sourceID`, and millisecond UTC timestamps (`time`, `start`, `stale` set +24h).
   - Keepalive: `send_keepalive()` emits `tak_pong()` from PyTAK to keep the TAK session alive.
 
 ## Runtime wiring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.53.0"
+version = "0.54.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/atak_cot/chat.py
+++ b/reticulum_telemetry_hub/atak_cot/chat.py
@@ -135,9 +135,9 @@ class ChatHierarchy:
 class ChatGroup:
     """Participants and identifiers for a GeoChat room."""
 
-    chatroom: str
     chat_id: str
     uid0: str
+    chatroom: Optional[str] = None
     uid1: str = ""
     uid2: str = ""
 
@@ -146,7 +146,7 @@ class ChatGroup:
         """Create a :class:`ChatGroup` from a ``<chatgrp>`` element."""
 
         return cls(
-            chatroom=elem.get("chatroom", ""),
+            chatroom=elem.get("chatroom"),
             chat_id=elem.get("id", ""),
             uid0=elem.get("uid0", ""),
             uid1=elem.get("uid1", ""),
@@ -157,11 +157,12 @@ class ChatGroup:
         """Return an XML element describing the chat group."""
 
         attrib = {
-            "chatroom": self.chatroom,
             "id": self.chat_id,
             "uid0": self.uid0,
             "uid1": self.uid1,
         }
+        if self.chatroom:
+            attrib["chatroom"] = self.chatroom
         if self.uid2:
             attrib["uid2"] = self.uid2
         return ET.Element("chatgrp", attrib)
@@ -170,11 +171,12 @@ class ChatGroup:
         """Return a serialisable representation of the chat group."""
 
         data = {
-            "chatroom": self.chatroom,
             "chat_id": self.chat_id,
             "uid0": self.uid0,
             "uid1": self.uid1,
         }
+        if self.chatroom:
+            data["chatroom"] = self.chatroom
         if self.uid2:
             data["uid2"] = self.uid2
         return data
@@ -184,7 +186,7 @@ class ChatGroup:
         """Create a :class:`ChatGroup` from a dictionary."""
 
         return cls(
-            chatroom=data.get("chatroom", ""),
+            chatroom=data.get("chatroom"),
             chat_id=data.get("chat_id", ""),
             uid0=data.get("uid0", ""),
             uid1=data.get("uid1", ""),
@@ -353,6 +355,7 @@ class Chat:
     chatroom: Optional[str] = None
     sender_callsign: Optional[str] = None
     group_owner: Optional[str] = None
+    message_id: Optional[str] = None
     chat_group: Optional[ChatGroup] = None
     hierarchy: Optional[ChatHierarchy] = None
 
@@ -368,6 +371,7 @@ class Chat:
             chatroom=elem.get("chatroom"),
             sender_callsign=elem.get("senderCallsign"),
             group_owner=elem.get("groupOwner"),
+            message_id=elem.get("messageId"),
             chat_group=(
                 ChatGroup.from_xml(chat_group_el) if chat_group_el is not None else None
             ),
@@ -392,6 +396,8 @@ class Chat:
             attrib["senderCallsign"] = self.sender_callsign
         if self.group_owner is not None:
             attrib["groupOwner"] = self.group_owner
+        if self.message_id is not None:
+            attrib["messageId"] = self.message_id
         element = ET.Element("__chat", attrib)
         if self.chat_group:
             element.append(self.chat_group.to_element())
@@ -413,6 +419,8 @@ class Chat:
             data["sender_callsign"] = self.sender_callsign
         if self.group_owner is not None:
             data["group_owner"] = self.group_owner
+        if self.message_id is not None:
+            data["message_id"] = self.message_id
         if self.chat_group:
             data["chat_group"] = self.chat_group.to_dict()
         if self.hierarchy:
@@ -435,6 +443,7 @@ class Chat:
             chatroom=data.get("chatroom"),
             sender_callsign=data.get("sender_callsign"),
             group_owner=data.get("group_owner"),
+            message_id=data.get("message_id"),
             chat_group=chat_group,
             hierarchy=hierarchy,
         )

--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -107,11 +107,11 @@ class AnnounceHandler:
         self.identities = identities
 
     def received_announce(self, destination_hash, announced_identity, app_data):
-        #RNS.log("\t+--- LXMF Announcement -----------------------------------------")
-        #RNS.log(f"\t| Source hash            : {RNS.prettyhexrep(destination_hash)}")
-        #RNS.log(f"\t| Announced identity     : {announced_identity}")
-       # RNS.log(f"\t| App data               : {app_data}")
-        #RNS.log("\t+---------------------------------------------------------------")
+        # RNS.log("\t+--- LXMF Announcement -----------------------------------------")
+        # RNS.log(f"\t| Source hash            : {RNS.prettyhexrep(destination_hash)}")
+        # RNS.log(f"\t| Announced identity     : {announced_identity}")
+        # RNS.log(f"\t| App data               : {app_data}")
+        # RNS.log("\t+---------------------------------------------------------------")
         label = self._decode_app_data(app_data)
         hash_key = (
             destination_hash.hex()


### PR DESCRIPTION
## Summary
- generate GeoChat chat events using LXMF sender IDs, chatroom names, and UUID-based message IDs with millisecond timestamps
- include sender callsigns, message IDs, and LXMF source/sourceID metadata in chat detail and refresh TAK docs
- support deterministic chat UUIDs in connector APIs and align tests with TAK connector constants

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334a9835908325b9d9a4a8854ab27d)