### PR TITLE
Refresh README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![image](https://github.com/user-attachments/assets/ba29799c-7194-4052-aedf-1b5e1c8648d5)
 
 Reticulum-Telemetry-Hub (RTH) is an independent component within the [Reticulum](https://reticulum.network/) / [lXMF](https://github.com/markqvist/LXMF) ecosystem, designed to manage a complete TCP node across a Reticulum-based network.
-The RTH  enable communication and data sharing between clients like [Sideband](https://github.com/markqvist/Sideband) or Meshchat, enhancing situational awareness and operational efficiency in distributed networks.
+RTH enables communication and data sharing between clients like [Sideband](https://github.com/markqvist/Sideband) or Meshchat, enhancing situational awareness and operational efficiency in distributed networks.
 
 ## Core Functionalities
 
@@ -11,44 +11,54 @@ The Reticulum-Telemetry-Hub can perform the following key functions:
 
 - **One to Many & Topic-Targeted Messages**: RTH supports broadcasting messages to all connected clients or filtering the fan-out by topic tags maintained in the hub's subscriber registry.
 - By sending a message to the hub, it will be distributed to all clients connected to the network or, when the payload includes a `TopicID`, only to the peers subscribed to that topic. *(Initial implementation - Experimental)*
-- **Telemetry Collector**: RTH acts as a telemetry data repository, collecting data from all connected clients.
-  Currently, this functionality is focused on Sideband clients that have enabled their Reticulum identity. By  rewriting the code we hope to see a wider implementation of Telemetry in other applications.
+- **Telemetry Collector**: RTH acts as a telemetry data repository, collecting data from all connected clients. Currently, this functionality is focused on Sideband clients that have enabled their Reticulum identity. By rewriting the code we hope to see a wider implementation of telemetry in other applications.
 - **Replication Node**: RTH uses the LXMF router to ensure message delivery even when the target client is offline. If a message's destination is not available at the time of sending, RTH will save the message and deliver it once the client comes online.
-- **Reticulum Transport**: RTH uses Reticulum  as a transport node, routing traffic to other peers, passing network announcements, and fulfilling path requests.
+- **Reticulum Transport**: RTH uses Reticulum as a transport node, routing traffic to other peers, passing network announcements, and fulfilling path requests.
+
+## Documentation
+
+- Command payload formats and examples: [`docs/supportedCommands.md`](docs/supportedCommands.md)
+- TAK / Cursor-on-Target relay details: [`docs/tak.md`](docs/tak.md)
+
+## Quickstart
+
+Follow these steps to bring up a local hub using the bundled defaults:
+
+1. Clone the repository and enter it.
+   ```bash
+   git clone https://github.com/FreeTAKTeam/Reticulum-Telemetry-Hub.git
+   cd Reticulum-Telemetry-Hub
+   ```
+2. Create and activate a virtual environment.
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+   You should see `(.venv)` in your shell prompt after activation.
+3. Install dependencies in editable mode (or use Poetry if you prefer).
+   ```bash
+   pip install --upgrade pip
+   pip install -e .
+   ```
+   The editable install pulls every dependency declared in `pyproject.toml` (including runtime services and the bundled tests). If you prefer Poetry, run `pip install poetry` once and then use `poetry install` to create and manage the virtual environment instead.
+4. Prepare a storage directory and unified config (the defaults live under `RTH_Store`).
+   - Copy `config.ini` into `RTH_Store` or point the `--storage_dir` flag at another directory.
+   - See the [Configuration](#configuration) section below for the available options and defaults.
+5. Run the lightweight smoke checks to confirm the entry point and daemon wiring.
+   ```bash
+   python -m reticulum_telemetry_hub.reticulum_server --help
+   pytest tests/test_reticulum_server_daemon.py -q
+   ```
+6. Start the hub.
+   ```bash
+   python -m reticulum_telemetry_hub.reticulum_server \
+       --storage_dir ./RTH_Store \
+       --display_name "RTH"
+   ```
 
 ## Installation
 
-To install Reticulum-Telemetry-Hub, clone the repository and proceed with the following steps:
-
-```bash
-git clone https://github.com/FreeTAKTeam/Reticulum-Telemetry-Hub.git
-cd Reticulum-Telemetry-Hub
-```
-
-Create the environment
-
-Choose a directory where you want the Telemetry Hub to live:
-
-```bash
-python3 -m venv .venv
-```
-
- Activate it
-
-```bash
-source .venv/bin/activate
-```
-
-You will now see (.venv) in your shell prompt. you can now
-
-```bash
-pip install --upgrade pip
-pip install -e .
-```
-
-The editable install pulls every dependency declared in ``pyproject.toml`` (including runtime services and the bundled tests). If you prefer Poetry, run ``pip install poetry`` once and then use ``poetry install`` to create and manage the virtual environment instead.
-
-*Optional extras*: No extras are currently defined, so the commands above install the complete feature set out of the box.
+If you want the full installation steps outside the quickstart, follow the same commands above. *Optional extras*: No extras are currently defined, so the commands above install the complete feature set out of the box.
 
 ### Verify the setup
 

--- a/TASK.md
+++ b/TASK.md
@@ -41,3 +41,4 @@
 - 2025-12-05: ✅ Restore TAK connector keepalive delivery and connection visibility by running PyTAK in a persistent background loop.
 - 2025-12-05: ✅ Periodically dispatch the latest unique telemetry as CoT updates from the TAK connector.
 - 2025-12-05: ✅ Mirror LXMF chat messages to TAK servers using the required CoT chat template.
+- 2025-12-05: ✅ Refresh README and documentation under `docs/`.

--- a/docs/supportedCommands.md
+++ b/docs/supportedCommands.md
@@ -11,19 +11,39 @@ Place commands in the LXMF `Commands` field (field ID `9`) as a JSON array of ob
 | `getAppInfo` | Return the hub name so you can confirm connectivity. | ``[{"Command":"getAppInfo"}]`` |
 | `ListTopic` | List every registered topic and its ID. | ``[{"Command":"ListTopic"}]`` |
 | `CreateTopic` | Create a topic with a name and path. | ``[{"Command":"CreateTopic","TopicName":"Weather","TopicPath":"environment/weather"}]`` |
-| `RetreiveTopic` | Fetch a topic by `TopicID`. | ``[{"Command":"RetreiveTopic","TopicID":"<TopicID>"}]`` |
+| `RetrieveTopic` | Fetch a topic by `TopicID`. | ``[{"Command":"RetrieveTopic","TopicID":"<TopicID>"}]`` |
 | `DeleteTopic` | Delete a topic (and unsubscribe its listeners). | ``[{"Command":"DeleteTopic","TopicID":"<TopicID>"}]`` |
 | `PatchTopic` | Update fields on a topic by `TopicID`. | ``[{"Command":"PatchTopic","TopicID":"<TopicID>","TopicDescription":"New description"}]`` |
 | `SubscribeTopic` | Subscribe the sending destination to a topic. Supports optional `RejectTests` and `Metadata`. | ``[{"Command":"SubscribeTopic","TopicID":"<TopicID>","RejectTests":true,"Metadata":{"role":"field-station"}}]`` |
 | `ListSubscriber` | List every subscriber registered with the hub. | ``[{"Command":"ListSubscriber"}]`` |
 | `CreateSubscriber` / `AddSubscriber` | Create a subscriber entry for any destination. | ``[{"Command":"CreateSubscriber","Destination":"<hex destination>","TopicID":"<TopicID>","Metadata":{"tag":"sensor"}}]`` |
-| `RetreiveSubscriber` | Fetch subscriber metadata by `SubscriberID`. | ``[{"Command":"RetreiveSubscriber","SubscriberID":"<SubscriberID>"}]`` |
+| `RetrieveSubscriber` | Fetch subscriber metadata by `SubscriberID`. | ``[{"Command":"RetrieveSubscriber","SubscriberID":"<SubscriberID>"}]`` |
 | `DeleteSubscriber` / `RemoveSubscriber` | Remove a subscriber mapping. | ``[{"Command":"DeleteSubscriber","SubscriberID":"<SubscriberID>"}]`` |
 | `PatchSubscriber` | Update subscriber metadata by `SubscriberID`. | ``[{"Command":"PatchSubscriber","SubscriberID":"<SubscriberID>","Metadata":{"tag":"updated"}}]`` |
 | `TelemetryRequest` (`1`) | Request telemetry snapshots from all peers since the provided UNIX timestamp. Response includes packed telemetry in `FIELD_TELEMETRY_STREAM` plus a JSON body with human-readable telemetry. | ``[{"1":1700000000}]`` |
 
 Notes:
-- RTH accepts common field name variants (e.g., `TopicID`, `topic_id`, `topic_id`, `TopicPath`, `topic_path`).
-- If required fields are missing, the hub replies with the missing keys and merges your follow-up payload with the original.
+- RTH accepts common field name variants (e.g., `TopicID`, `topicId`, `topic_id`, `TopicPath`, `topic_path`).
+- If required fields are missing, the hub replies with the missing keys and merges your follow-up payload with the original so you can send only the missing fields.
 - When the `Commands` field is unavailable, prefix the message body with ``\\\`` so the hub treats it as a command payload (e.g., ``\\\join`` or ``\\\{"Command":"SubscribeTopic","TopicID":"<TopicID>"}``).
 - Telemetry responses now mirror the packed stream and also embed a human-readable JSON payload; see `docs/example_telemetry.json` for a sample body.
+- Command casing is permissive (`CreateTopic`, `createtopic`, and `createTopic` are all accepted), but the JSON keys shown above are the clearest to read.
+
+### Tips for building command payloads
+
+- Wrap multiple actions in a single array to reduce round-trips, for example:
+
+  ```json
+  [
+    {"Command": "join"},
+    {"Command": "SubscribeTopic", "TopicID": "<TopicID>"}
+  ]
+  ```
+
+- When requesting telemetry with the numeric `TelemetryController.TELEMETRY_REQUEST` key, pass a Unix timestamp (seconds) to limit the response window:
+
+  ```json
+  [{"1": 1700000000}]
+  ```
+
+- Subscriber metadata is merged when you patch or resubmit a command. You can safely send partial structures such as `{"Metadata":{"role":"sensor"}}` without losing existing attributes.

--- a/docs/tak.md
+++ b/docs/tak.md
@@ -43,3 +43,18 @@
 - Ensure a location sensor is enabled (e.g., via `TelemeterManager` or the optional `gpsd` service); otherwise `send_latest_location()` and `send_telemetry_event()` no-op and log a warning.
 - When pointing at a remote TAK server, set the TLS fields in `TakConnectionConfig`; PyTAK reads them directly from the generated `ConfigParser`.
 - For debugging, you can inspect the `Event.to_xml()` output (see `tests/test_tak_connector.py` for expectations) to verify UID, contact endpoint, group, track, and takv metadata before sending.
+
+## Running the TAK connector
+
+1. Enable the `tak_cot` service when starting the hub:
+   ```bash
+   python -m reticulum_telemetry_hub.reticulum_server \
+       --storage_dir ./RTH_Store \
+       --service tak_cot
+   ```
+2. Confirm that `RTH_Store/config.ini` includes a `[TAK]` section. The `tak_cot` daemon reads these values on startup and reuses them across keepalive and telemetry dispatches.
+3. Watch for the following log signals:
+   - `PyTAK TX/RX queue workers started` indicates the connector’s background loop is healthy.
+   - `Sending takPong keepalive` appears roughly every 60 seconds while connected.
+   - `send_latest_location` or `send_telemetry_event` warnings call out when no location data is available.
+4. When testing against ATAK or WinTAK, verify that the `detail.contact` endpoint matches the `<host>:<port>:<scheme>` derived from your `COT_URL` and that the `takv` block shows the current RTH version from `pyproject.toml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.54.0"
+version = "0.55.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- add quickstart documentation and entry-point smoke checks to README
- correct supported command names and add usage tips for building payloads
- expand TAK connector guidance and bump project version to 0.55.0

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933626d6c8883258fd118837054c527)