### PR TITLE
Fix lint warnings and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Example configuration:
 ```ini
 [app]
 name = Reticulum Telemetry Hub
-version = 0.61.0
+version = 0.62.0
 description = Public-facing hub for the mesh network
 
 [hub]

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Example configuration:
 ```ini
 [app]
 name = Reticulum Telemetry Hub
-version = 0.60.0
+version = 0.61.0
 description = Public-facing hub for the mesh network
 
 [hub]

--- a/TASK.md
+++ b/TASK.md
@@ -48,3 +48,4 @@
 - 2025-12-24: ✅ Update README installation instructions for PyPI virtual environment setup.
 - 2025-12-26: ✅ Expand getAppInfo to return configured metadata and auto-respond to unjoined LXMF clients.
 - 2025-12-27: ✅ Review and test the code and fix linter issues.
+- 2025-12-27: ✅ Reorder LXMF daemon imports to satisfy flake8 and bump version to 0.62.0.

--- a/TASK.md
+++ b/TASK.md
@@ -47,3 +47,4 @@
 - 2025-12-17: ✅ Close SQLite retry sessions to avoid leaks when lock contention occurs.
 - 2025-12-24: ✅ Update README installation instructions for PyPI virtual environment setup.
 - 2025-12-26: ✅ Expand getAppInfo to return configured metadata and auto-respond to unjoined LXMF clients.
+- 2025-12-27: ✅ Review and test the code and fix linter issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.61.0"
+version = "0.62.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.60.0"
+version = "0.61.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/embedded_lxmd/embedded.py
+++ b/reticulum_telemetry_hub/embedded_lxmd/embedded.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import LXMF
 import RNS
@@ -19,12 +19,14 @@ from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.sensor_enu
     SID_LXMF_PROPAGATION,
 )
 
+if TYPE_CHECKING:
+    from reticulum_telemetry_hub.lxmf_telemetry.telemetry_controller import (
+        TelemetryController,
+    )
+
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc).replace(tzinfo=None)
-from reticulum_telemetry_hub.lxmf_telemetry.telemetry_controller import (
-    TelemetryController,
-)
 
 
 @dataclass

--- a/reticulum_telemetry_hub/lxmf_daemon/LXMF.py
+++ b/reticulum_telemetry_hub/lxmf_daemon/LXMF.py
@@ -1,3 +1,6 @@
+import RNS
+import RNS.vendor.umsgpack as msgpack
+
 APP_NAME = "lxmf"
 
 ##########################################################
@@ -107,9 +110,6 @@ PN_META_CUSTOM = 0xFF
 # The following helper functions makes it easier to      #
 # handle and operate on LXMF data in client programs     #
 ##########################################################
-
-import RNS
-import RNS.vendor.umsgpack as msgpack
 
 
 def display_name_from_app_data(app_data=None):

--- a/reticulum_telemetry_hub/lxmf_daemon/lxmd.py
+++ b/reticulum_telemetry_hub/lxmf_daemon/lxmd.py
@@ -30,23 +30,23 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-DEFFERED_JOBS_DELAY = 10
-JOBS_INTERVAL = 5
+import argparse
+import os
+import shlex
+import subprocess
+import threading
+import time
 
 import RNS
-import argparse
-import threading
-import subprocess
-import shlex
-import time
-import os
+from RNS.vendor.configobj import ConfigObj
 
 from reticulum_telemetry_hub import lxmf_daemon as LXMF
 from reticulum_telemetry_hub.config.manager import HubConfigurationManager
-from reticulum_telemetry_hub.lxmf_daemon._version import __version__
 from reticulum_telemetry_hub.lxmf_daemon.LXMF import APP_NAME
+from reticulum_telemetry_hub.lxmf_daemon._version import __version__
 
-from RNS.vendor.configobj import ConfigObj
+DEFFERED_JOBS_DELAY = 10
+JOBS_INTERVAL = 5
 
 configpath = None
 ignoredpath = None

--- a/reticulum_telemetry_hub/lxmf_telemetry/model/persistance/sensors/connection_map.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/model/persistance/sensors/connection_map.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-
-_UNSET = object()
-
 from sqlalchemy import Float, ForeignKey, Integer, JSON, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .. import Base
 from .sensor import Sensor
 from .sensor_enum import SID_CONNECTION_MAP
+
+
+_UNSET = object()
 
 
 class ConnectionMap(Sensor):

--- a/reticulum_telemetry_hub/lxmf_telemetry/telemeter_manager.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/telemeter_manager.py
@@ -12,6 +12,9 @@ from reticulum_telemetry_hub.config.manager import HubConfigurationManager
 from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.sensor import (
     Sensor,
 )
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.sensor_mapping import (
+    sid_mapping,
+)
 from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.sensor_enum import (
     SID_ACCELERATION,
     SID_AMBIENT_LIGHT,
@@ -40,14 +43,12 @@ from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.sensor_enu
     SID_TEMPERATURE,
     SID_TIME,
 )
+from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.telemeter import Telemeter
 
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc).replace(tzinfo=None)
-from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.sensors.sensor_mapping import (
-    sid_mapping,
-)
-from reticulum_telemetry_hub.lxmf_telemetry.model.persistance.telemeter import Telemeter
+
 
 SnapshotMutator = Callable[[Telemeter, dict[int, Any]], None]
 

--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -68,6 +68,7 @@ from reticulum_telemetry_hub.config.constants import (
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
+
 # Constants
 STORAGE_PATH = DEFAULT_STORAGE_PATH  # Path to store temporary files
 APP_NAME = LXMF.APP_NAME + ".delivery"  # Application name for LXMF


### PR DESCRIPTION
## Summary
- reorder module imports and spacing in telemetry helpers to resolve flake8 E402/E305 warnings
- bump the project version to 0.61.0 and sync the README example
- log task completion in TASK.md

## Testing
- flake8
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fb62c3010832584e8f1817a50a403)