### PR TITLE
Add API docstrings and storage session cleanup

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -50,3 +50,4 @@
 - 2025-12-27: ✅ Review and test the code and fix linter issues.
 - 2025-12-27: ✅ Reorder LXMF daemon imports to satisfy flake8 and bump version to 0.62.0.
 - 2025-12-28: ✅ Add file and image storage configuration paths and tests.
+- 2025-12-28: ✅ Document API models and storage session helpers to satisfy lint checks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.63.0"
+version = "0.64.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/api/models.py
+++ b/reticulum_telemetry_hub/api/models.py
@@ -1,22 +1,36 @@
+"""Data models for the Reticulum Telemetry Hub API."""
+
 from __future__ import annotations
 
-from dataclasses import dataclass, field, asdict
-from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional
+from dataclasses import asdict
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import Any
+from typing import Dict
+from typing import Optional
 
 
 def _now() -> datetime:
+    """Return the current UTC timestamp with timezone information."""
+
     return datetime.now(timezone.utc)
 
 
 @dataclass
 class Topic:
+    """Topic subscription metadata for the Reticulum Telemetry Hub."""
+
     topic_name: str
     topic_path: str
     topic_description: str = ""
     topic_id: Optional[str] = None
 
     def to_dict(self) -> dict:
+        """Serialize the topic into the external API schema."""
+
         return {
             "TopicID": self.topic_id,
             "TopicName": self.topic_name,
@@ -26,6 +40,16 @@ class Topic:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Topic":
+        """Create a Topic from a dictionary with flexible casing.
+
+        Args:
+            data (Dict[str, Any]): Source mapping using either title-case or
+                snake_case keys.
+
+        Returns:
+            Topic: Parsed topic instance with defaults for missing values.
+        """
+
         return cls(
             topic_name=data.get("TopicName") or data.get("topic_name") or "",
             topic_path=data.get("TopicPath") or data.get("topic_path") or "",
@@ -38,6 +62,8 @@ class Topic:
 
 @dataclass
 class Subscriber:
+    """Subscription details linking destinations to topics."""
+
     destination: str
     topic_id: Optional[str] = None
     reject_tests: Optional[int] = None
@@ -45,6 +71,8 @@ class Subscriber:
     subscriber_id: Optional[str] = None
 
     def to_dict(self) -> dict:
+        """Serialize the subscriber into the external API schema."""
+
         return {
             "SubscriberID": self.subscriber_id,
             "Destination": self.destination,
@@ -55,6 +83,16 @@ class Subscriber:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Subscriber":
+        """Create a Subscriber from a dictionary with flexible casing.
+
+        Args:
+            data (Dict[str, Any]): Source mapping using either title-case or
+                snake_case keys.
+
+        Returns:
+            Subscriber: Parsed subscriber instance.
+        """
+
         reject_tests = None
         if "RejectTests" in data:
             reject_tests = data.get("RejectTests")
@@ -72,24 +110,33 @@ class Subscriber:
 
 @dataclass
 class Client:
+    """Connected client state and metadata."""
+
     identity: str
     last_seen: datetime = field(default_factory=_now)
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def touch(self) -> None:
+        """Update ``last_seen`` to the latest timestamp in UTC."""
+
         now = _now()
         if now <= self.last_seen:
             now = self.last_seen + timedelta(microseconds=1)
         self.last_seen = now
 
     def to_dict(self) -> dict:
+        """Serialize the client into primitive types for JSON responses."""
+
         data = asdict(self)
         data["last_seen"] = self.last_seen.isoformat()
         return data
 
 
 @dataclass
+# pylint: disable=too-many-instance-attributes
 class ReticulumInfo:
+    """Application and environment metadata exposed by the API."""
+
     is_transport_enabled: bool
     is_connected_to_shared_instance: bool
     reticulum_config_path: str
@@ -104,4 +151,6 @@ class ReticulumInfo:
     app_description: str
 
     def to_dict(self) -> dict:
+        """Serialize the info model to a dictionary."""
+
         return asdict(self)

--- a/reticulum_telemetry_hub/api/service.py
+++ b/reticulum_telemetry_hub/api/service.py
@@ -1,3 +1,5 @@
+"""Reticulum Telemetry Hub API service operations."""
+
 from __future__ import annotations
 
 import uuid
@@ -199,10 +201,9 @@ class ReticulumTelemetryHubAPI:
             topic.topic_path = updates.get("topic_path") or updates.get("TopicPath")
             update_fields["topic_path"] = topic.topic_path
         if "topic_description" in updates or "TopicDescription" in updates:
-            if "topic_description" in updates:
-                description = updates["topic_description"]
-            else:
-                description = updates["TopicDescription"]
+            description = updates.get(
+                "topic_description", updates.get("TopicDescription")
+            )
             topic.topic_description = description or ""
             update_fields["topic_description"] = topic.topic_description
         if not update_fields:

--- a/tests/test_rth_api.py
+++ b/tests/test_rth_api.py
@@ -143,8 +143,8 @@ def test_concurrent_client_join_and_leave(tmp_path):
 def test_storage_session_retries_close_failed_sessions(tmp_path, monkeypatch):
     api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
     storage = api._storage
-    storage._SESSION_RETRIES = 2
-    storage._SESSION_BACKOFF = 0
+    storage._session_retries = 2
+    storage._session_backoff = 0
 
     closed_sessions: list[bool] = []
 
@@ -155,12 +155,12 @@ def test_storage_session_retries_close_failed_sessions(tmp_path, monkeypatch):
         def close(self):
             closed_sessions.append(True)
 
-    monkeypatch.setattr(storage, "_Session", lambda: FailingSession())
+    monkeypatch.setattr(storage, "_session_factory", lambda: FailingSession())
 
     with pytest.raises(OperationalError):
         storage._acquire_session_with_retry()
 
-    assert len(closed_sessions) == storage._SESSION_RETRIES
+    assert len(closed_sessions) == storage._session_retries
 
 
 def test_get_app_info(tmp_path):


### PR DESCRIPTION
## Summary
- add module and method docstrings for the API models, service, and storage layers
- rename storage session helpers to snake_case and adjust retry tests accordingly
- bump the project version and record the linting documentation task

## Testing
- black reticulum_telemetry_hub/api/models.py reticulum_telemetry_hub/api/storage.py reticulum_telemetry_hub/api/service.py tests/test_rth_api.py
- flake8 reticulum_telemetry_hub/api/models.py reticulum_telemetry_hub/api/service.py reticulum_telemetry_hub/api/storage.py tests/test_rth_api.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69514d2c06908325a18e83414d8b8e2f)