### PR TITLE
Ensure CI installs project dependencies

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,14 +20,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest sqlalchemy LXMF RNS msgpack
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install .
+        pip install flake8 pytest pytest-cov
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/TASK.md
+++ b/TASK.md
@@ -50,3 +50,4 @@
 - 2025-12-27: ✅ Review and test the code and fix linter issues.
 - 2025-12-27: ✅ Reorder LXMF daemon imports to satisfy flake8 and bump version to 0.62.0.
 - 2025-12-28: ✅ Add file and image storage configuration paths and tests.
+- 2025-12-28: ✅ Ensure the python-app workflow installs all project dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.63.0"
+version = "0.64.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- ensure the python-app workflow installs project dependencies from the package instead of a partial manual list
- bump the project version to 0.64.0 and record the workflow task in TASK.md

## Testing
- source venv_linux/bin/activate && pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69514f6343b88325b4420ecb3dcb6c0c)