### PR TITLE
Fix Iterable import for PyTAK client

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -52,3 +52,4 @@
 - 2025-12-28: ✅ Add file and image storage configuration paths and tests.
 - 2025-12-28: ✅ Ensure the python-app workflow installs all project dependencies.
 - 2025-12-28: ✅ Document API models and storage session helpers to satisfy lint checks.
+- 2025-12-28: ✅ Fix Iterable import for PyTAK client to resolve pylint error.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.65.0"
+version = "0.66.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/atak_cot/pytak_client.py
+++ b/reticulum_telemetry_hub/atak_cot/pytak_client.py
@@ -8,7 +8,7 @@ import asyncio
 import atexit
 import logging
 import xml.etree.ElementTree as ET
-from collections.abc import Iterable as IterableABC
+from collections.abc import Iterable
 from configparser import ConfigParser, SectionProxy
 from contextlib import suppress
 from threading import Event as ThreadEvent
@@ -16,7 +16,6 @@ from threading import Lock
 from threading import Thread
 from typing import Any
 from typing import Awaitable
-from typing import Iterable
 from typing import Optional
 from typing import Union
 from typing import cast
@@ -45,7 +44,7 @@ def _is_iterable_payload(obj: Any) -> bool:
     """Return True when the object should be treated as a payload collection."""
     if isinstance(obj, (Event, ET.Element, str, bytes, dict)):
         return False
-    return isinstance(obj, IterableABC)
+    return isinstance(obj, Iterable)
 
 
 def _payload_to_xml_bytes(payload: CotPayload) -> bytes:


### PR DESCRIPTION
## Summary
- replace IterableABC usage with collections.abc.Iterable to satisfy pylint
- bump project version to 0.66.0 and document task completion

## Testing
- flake8


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695153eff0a483258b865483d4a9c03f)