### PR TITLE
Expose HubStorage session factory for API tests

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -52,3 +52,4 @@
 - 2025-12-28: ✅ Add file and image storage configuration paths and tests.
 - 2025-12-28: ✅ Ensure the python-app workflow installs all project dependencies.
 - 2025-12-28: ✅ Document API models and storage session helpers to satisfy lint checks.
+- 2025-12-28: ✅ Expose HubStorage session factory to satisfy API topic patch tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.65.0"
+version = "0.66.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/api/storage.py
+++ b/reticulum_telemetry_hub/api/storage.py
@@ -94,7 +94,8 @@ class HubStorage:
         self._engine = self._create_engine(db_path)
         self._enable_wal_mode()
         Base.metadata.create_all(self._engine)
-        self._session_factory = sessionmaker(bind=self._engine, expire_on_commit=False)
+        self._Session = sessionmaker(bind=self._engine, expire_on_commit=False)
+        self._session_factory = self._Session
 
     # ------------------------------------------------------------------ #
     # Topic helpers


### PR DESCRIPTION
## Summary
- add a _Session attribute in HubStorage that reuses the sessionmaker for direct session access
- bump the project minor version and record the task update

## Testing
- source venv_linux/bin/activate && pytest
- source venv_linux/bin/activate && flake8

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69516bf68384832584ba40c3ea0703a1)