### PR TITLE
Add file attachment storage API

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,17 @@ How the unified config is used:
 - TAK, GPSD, announce/telemetry intervals, default services, log level, and embedded/external LXMF choices are all centralized here.
 - CLI flags (`--storage_dir`, `--config`, `--display-name`, `--announce-interval`, `--embedded`, `--service`, etc.) override any values loaded from the file.
 
+### File and image metadata API
+
+The Python API exposes helpers to track stored files and images alongside their metadata (paths, MIME types, categories, sizes, and timestamps). Use these calls after you place files under the configured storage directories:
+
+- `ReticulumTelemetryHubAPI.store_file(path, name=None, media_type=None)` records a file in the default `files/` directory.
+- `ReticulumTelemetryHubAPI.store_image(path, name=None, media_type=None)` records an image in the `images/` directory.
+- `list_files()` / `list_images()` return stored metadata filtered by category.
+- `retrieve_file(id)` / `retrieve_image(id)` return a single record by ID, raising `KeyError` when the category does not match.
+
+File and image directories still default to `<storage_dir>/files` and `<storage_dir>/images`, but you can point them elsewhere via the `[files]` and `[images]` sections as shown above.
+
 ## Service
 
 In order to start the RTH   automatically on startup, we will need to install a /etc/systemd/system/RTH.service file:

--- a/TASK.md
+++ b/TASK.md
@@ -56,3 +56,4 @@
 - 2025-12-28: ✅ Resolve pylint warnings in ATAK CoT helpers and refresh package metadata.
 - 2025-12-28: ✅ Fix Iterable import for PyTAK client to resolve pylint error.
 - 2025-12-28: ✅ Analyze code with pylint and fix issues.
+- 2025-12-28: ✅ Add file and image attachment storage APIs and tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.67.0"
+version = "0.68.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/api/__init__.py
+++ b/reticulum_telemetry_hub/api/__init__.py
@@ -1,12 +1,17 @@
 """High level Python API mirroring the ReticulumTelemetryHub OpenAPI spec."""
 
-from .models import Topic, Subscriber, Client, ReticulumInfo
+from .models import Client
+from .models import FileAttachment
+from .models import ReticulumInfo
+from .models import Subscriber
+from .models import Topic
 from .service import ReticulumTelemetryHubAPI
 
 __all__ = [
     "Topic",
     "Subscriber",
     "Client",
+    "FileAttachment",
     "ReticulumInfo",
     "ReticulumTelemetryHubAPI",
 ]

--- a/reticulum_telemetry_hub/api/models.py
+++ b/reticulum_telemetry_hub/api/models.py
@@ -154,3 +154,31 @@ class ReticulumInfo:
         """Serialize the info model to a dictionary."""
 
         return asdict(self)
+
+
+@dataclass
+class FileAttachment:
+    """Metadata for files or images stored by the hub."""
+
+    name: str
+    path: str
+    category: str
+    size: int
+    media_type: Optional[str] = None
+    created_at: datetime = field(default_factory=_now)
+    updated_at: datetime = field(default_factory=_now)
+    file_id: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        """Return a serialization friendly representation."""
+
+        return {
+            "FileID": self.file_id,
+            "Name": self.name,
+            "Path": self.path,
+            "Category": self.category,
+            "MediaType": self.media_type,
+            "Size": self.size,
+            "CreatedAt": self.created_at.isoformat(),
+            "UpdatedAt": self.updated_at.isoformat(),
+        }

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -1,4 +1,5 @@
 from reticulum_telemetry_hub.api.models import Client
+from reticulum_telemetry_hub.api.models import FileAttachment
 from reticulum_telemetry_hub.api.models import ReticulumInfo
 from reticulum_telemetry_hub.api.models import Subscriber
 from reticulum_telemetry_hub.api.models import Topic
@@ -61,3 +62,21 @@ def test_reticulum_info_to_dict_returns_all_fields():
     assert result["image_storage_path"] == "/tmp/storage/images"
     assert result["app_name"] == "RTH"
     assert result["app_description"] == "Reticulum Telemetry Hub instance"
+
+
+def test_file_attachment_to_dict_serializes_fields():
+    attachment = FileAttachment(
+        name="note.txt",
+        path="/tmp/note.txt",
+        category="file",
+        size=10,
+        media_type="text/plain",
+    )
+
+    serialized = attachment.to_dict()
+
+    assert serialized["Name"] == "note.txt"
+    assert serialized["Path"] == "/tmp/note.txt"
+    assert serialized["Category"] == "file"
+    assert serialized["Size"] == 10
+    assert serialized["MediaType"] == "text/plain"

--- a/tests/test_file_api.py
+++ b/tests/test_file_api.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import pytest
+
+from reticulum_telemetry_hub.api import ReticulumTelemetryHubAPI
+from tests.test_rth_api import make_config_manager
+
+
+def test_store_and_list_files(tmp_path: Path):
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+    file_path = api._config_manager.config.file_storage_path / "note.txt"  # pylint: disable=protected-access
+    file_path.write_text("hello file")
+
+    file_record = api.store_file(file_path, media_type="text/plain")
+    image_path = api._config_manager.config.image_storage_path / "photo.jpg"  # pylint: disable=protected-access
+    image_path.write_bytes(b"binary-data")
+    image_record = api.store_image(image_path, media_type="image/jpeg")
+
+    files = api.list_files()
+    images = api.list_images()
+
+    assert file_record.file_id is not None
+    assert image_record.file_id is not None
+    assert file_record.size == len("hello file")
+    assert all(record.category == "file" for record in files)
+    assert all(record.category == "image" for record in images)
+    assert any(record.file_id == file_record.file_id for record in files)
+    assert api.retrieve_file(file_record.file_id).path == str(file_path)
+    assert api.retrieve_image(image_record.file_id).path == str(image_path)
+
+
+def test_store_file_validates_path(tmp_path: Path):
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+
+    with pytest.raises(ValueError):
+        api.store_file(tmp_path / "missing.bin")
+
+
+def test_retrieve_image_rejects_file_category(tmp_path: Path):
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+    file_path = api._config_manager.config.file_storage_path / "not-image.txt"  # pylint: disable=protected-access
+    file_path.write_text("content")
+    file_record = api.store_file(file_path)
+
+    with pytest.raises(KeyError):
+        api.retrieve_image(file_record.file_id)


### PR DESCRIPTION
## Summary
- add a FileRecord table and FileAttachment dataclass for file/image metadata with timestamps and sizes
- expose ReticulumTelemetryHubAPI helpers to store, list, and retrieve files or images through HubStorage
- document the file metadata workflow and cover new behaviors with dedicated tests

## Testing
- source venv_linux/bin/activate && pytest
- source venv_linux/bin/activate && flake8

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69517322b8848325918e30da58fcf033)