### PR TITLE
Resolve pylint warnings and bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.71.0"
+version = "0.72.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/api/service.py
+++ b/reticulum_telemetry_hub/api/service.py
@@ -19,7 +19,7 @@ from .models import Topic
 from .storage import HubStorage
 
 
-class ReticulumTelemetryHubAPI:
+class ReticulumTelemetryHubAPI:  # pylint: disable=too-many-public-methods
     """Persistence-backed implementation of the ReticulumTelemetryHub API."""
 
     def __init__(
@@ -454,7 +454,7 @@ class ReticulumTelemetryHubAPI:
         info_dict = self._config_manager.reticulum_info_snapshot()
         return ReticulumInfo(**info_dict)
 
-    def _store_attachment(
+    def _store_attachment(  # pylint: disable=too-many-arguments
         self,
         *,
         file_path: str | Path,


### PR DESCRIPTION
## Summary
- silence pylint design warnings in the API service to keep lint output clean
- bump the project version to 0.72.0

## Testing
- source venv_linux/bin/activate && pylint reticulum_telemetry_hub tests
- source venv_linux/bin/activate && flake8
- source venv_linux/bin/activate && pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695194856da88325be864db369959d81)