### PR TITLE
Fix lint import handling and router type checks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,6 +7,9 @@
 # mirrors upstream implementations and will be refactored separately.
 ignore=reticulum_telemetry_hub/lxmf_daemon,reticulum_telemetry_hub/reticulum_server,reticulum_telemetry_hub/embedded_lxmd,reticulum_telemetry_hub/lxmf_telemetry,tests
 
+[TYPECHECK]
+ignored-modules=dotenv,qrcode,nacl,nacl.encoding,nacl.hash
+
 [FORMAT]
 max-line-length=120
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.76.0"
+version = "0.77.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -34,6 +34,7 @@ import mimetypes
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import cast
 
 import LXMF
 import RNS
@@ -265,7 +266,12 @@ class ReticulumTelemetryHub:
             ReticulumTelemetryHub._shared_lxm_router = LXMF.LXMRouter(
                 storagepath=str(self.storage_path)
             )
-        self.lxm_router = ReticulumTelemetryHub._shared_lxm_router
+        shared_router = ReticulumTelemetryHub._shared_lxm_router
+        if shared_router is None:
+            msg = "Shared LXMF router failed to initialize"
+            raise RuntimeError(msg)
+
+        self.lxm_router = cast(LXMF.LXMRouter, shared_router)
 
         self.my_lxmf_dest = self.lxm_router.register_delivery_identity(
             identity, display_name=display_name


### PR DESCRIPTION
## Summary
- add pylint ignored modules for optional third-party dependencies
- guard LXMF receipt handling to avoid false no-member lint errors
- enforce LXMF router initialization, cast to the LXMF router type, and bump the package version

## Testing
- ./venv_linux/bin/ruff check
- ./venv_linux/bin/pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951ab56c88c83259fced72cd86761ed)