### PR TITLE
Guard LXMF router registration hooks

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -64,3 +64,4 @@
 - 2025-12-28: ✅ Replace CI flake8 linting with Ruff and remove the flake8 configuration file.
 - 2025-12-28: ✅ Improve test coverage and resolve Ruff lint findings.
 - 2025-12-28: ✅ Resolve reported pylint import and undefined variable errors.
+- 2025-12-29: ✅ Resolve DummyRouter pylint no-member warnings in Reticulum server initialization.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.77.0"
+version = "0.78.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- add a reusable helper that validates required LXMF router callables before use
- wire the hub initialization through the helper to avoid DummyRouter no-member warnings and register callbacks safely
- bump the project version to 0.78.0 and document the completed lint task

## Testing
- source venv_linux/bin/activate && ruff check
- source venv_linux/bin/activate && pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951ae201798832584281c2c0a87af46)