### PR TITLE
Handle unknown command help response

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -66,3 +66,4 @@
 - 2025-12-28: ✅ Resolve reported pylint import and undefined variable errors.
 - 2025-12-28: ✅ Resolve pylint not-callable warnings for LXMF router hooks.
 - 2025-12-29: ✅ Resolve DummyRouter pylint no-member warnings in Reticulum server initialization.
+- 2025-12-31: ✅ Return help text when an unknown command is received.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.79.0"
+version = "0.80.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/reticulum_server/command_manager.py
+++ b/reticulum_telemetry_hub/reticulum_server/command_manager.py
@@ -617,7 +617,7 @@ class CommandManager:
         sender = self._identity_hex(message.source.identity)
         RNS.log(f"Unknown command '{name}' from {sender}", getattr(RNS, "LOG_ERROR", 1))
         help_text = build_help_text(self)
-        payload = f"Unknown command '{name}'.\n{help_text}"
+        payload = f"Unknow command\n\n{help_text}"
         return self._reply(message, payload)
 
     def _prompt_for_fields(

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -425,7 +425,7 @@ def test_unknown_command_logs_error(monkeypatch):
 
     assert responses
     reply_text = responses[0].content_as_string()
-    assert "Unknown command" in reply_text
+    assert "Unknow command" in reply_text
     assert logs
     relevant = [entry for entry in logs if "NotACommand" in entry[0]]
     assert relevant
@@ -1373,5 +1373,5 @@ def test_unknown_command_returns_help_text():
 
     reply = manager.handle_command(command, message)
     text = reply.content_as_string()
-    assert "Unknown command 'NotReal'" in text
+    assert text.startswith("Unknow command")
     assert "Available commands" in text


### PR DESCRIPTION
## Summary
- respond with the standardized "Unknow command" reply and append the help output when unexpected commands are received
- update command manager tests to verify the new response content
- bump the package version and document the completed task

## Testing
- source venv_linux/bin/activate && pytest
- source venv_linux/bin/activate && ruff check .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69553aa8d25c8325babf1f9df893e442)