### PR TITLE
Improve file and image command handling

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -67,3 +67,4 @@
 - 2025-12-28: ✅ Resolve pylint not-callable warnings for LXMF router hooks.
 - 2025-12-29: ✅ Resolve DummyRouter pylint no-member warnings in Reticulum server initialization.
 - 2025-12-31: ✅ Return help text when an unknown command is received.
+- 2026-01-02: ✅ Add coverage for file and image command CRUD flows (ListFiles/ListImages) and resolve discovered issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.80.0"
+version = "0.81.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/reticulum_server/command_manager.py
+++ b/reticulum_telemetry_hub/reticulum_server/command_manager.py
@@ -705,6 +705,10 @@ class CommandManager:
         snake_key = re.sub(r"(?<!^)(?=[A-Z])", "_", field).lower()
         alternate_keys.add(snake_key)
         alternate_keys.add(snake_key.replace("_i_d", "_id"))
+        lower_camel = field[:1].lower() + field[1:]
+        alternate_keys.add(lower_camel)
+        alternate_keys.add(field.replace("ID", "Id"))
+        alternate_keys.add(lower_camel.replace("ID", "Id"))
         for key in alternate_keys:
             if key in command:
                 return command.get(key)
@@ -844,14 +848,11 @@ class CommandManager:
 
     @staticmethod
     def _extract_file_id(command: dict) -> Optional[Any]:
-        return (
-            command.get("FileID")
-            or command.get("file_id")
-            or command.get("ImageID")
-            or command.get("image_id")
-            or command.get("ID")
-            or command.get("id")
-        )
+        for field in ("FileID", "ImageID", "ID"):
+            value = CommandManager._field_value(command, field)
+            if value is not None:
+                return value
+        return None
 
     @staticmethod
     def _coerce_int_id(value: Any) -> Optional[int]:

--- a/tests/test_command_manager_files_and_images.py
+++ b/tests/test_command_manager_files_and_images.py
@@ -1,0 +1,225 @@
+import LXMF
+import RNS
+
+from reticulum_telemetry_hub.api import ReticulumTelemetryHubAPI
+from reticulum_telemetry_hub.reticulum_server.command_manager import CommandManager
+from reticulum_telemetry_hub.reticulum_server.constants import PLUGIN_COMMAND
+from tests.test_rth_api import make_config_manager
+
+
+def ensure_reticulum() -> None:
+    if RNS.Reticulum.get_instance() is None:
+        RNS.Reticulum()
+
+
+def build_manager(api: ReticulumTelemetryHubAPI) -> tuple[CommandManager, RNS.Destination]:
+    class DummyTelemetryController:
+        def handle_command(self, command, message, dest):  # noqa: ANN001
+            return None
+
+    server_dest = RNS.Destination(
+        RNS.Identity(),
+        RNS.Destination.IN,
+        RNS.Destination.SINGLE,
+        "lxmf",
+        "delivery",
+    )
+    manager = CommandManager({}, DummyTelemetryController(), server_dest, api)
+    return manager, server_dest
+
+
+def make_message(
+    server_dest: RNS.Destination, client_dest: RNS.Destination, payload: dict
+) -> LXMF.LXMessage:
+    message = LXMF.LXMessage(
+        server_dest,
+        client_dest,
+        fields={LXMF.FIELD_COMMANDS: [payload]},
+        desired_method=LXMF.LXMessage.DIRECT,
+    )
+    message.pack()
+    message.signature_validated = True
+    return message
+
+
+def make_client_destination() -> RNS.Destination:
+    return RNS.Destination(
+        RNS.Identity(),
+        RNS.Destination.OUT,
+        RNS.Destination.SINGLE,
+        "lxmf",
+        "delivery",
+    )
+
+
+def test_list_files_and_images_when_empty(tmp_path):
+    ensure_reticulum()
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+
+    manager, server_dest = build_manager(api)
+    client_dest = make_client_destination()
+
+    list_files_msg = make_message(
+        server_dest, client_dest, {PLUGIN_COMMAND: CommandManager.CMD_LIST_FILES}
+    )
+    files_response = manager.handle_command(
+        list_files_msg.fields[LXMF.FIELD_COMMANDS][0], list_files_msg
+    )
+
+    list_images_msg = make_message(
+        server_dest, client_dest, {PLUGIN_COMMAND: CommandManager.CMD_LIST_IMAGES}
+    )
+    images_response = manager.handle_command(
+        list_images_msg.fields[LXMF.FIELD_COMMANDS][0], list_images_msg
+    )
+
+    assert files_response is not None
+    assert files_response.content_as_string() == "No files stored yet."
+    assert images_response is not None
+    assert images_response.content_as_string() == "No images stored yet."
+
+
+def test_retrieve_file_prompts_for_missing_id(tmp_path):
+    ensure_reticulum()
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+    manager, server_dest = build_manager(api)
+    client_dest = make_client_destination()
+
+    retrieve_msg = make_message(
+        server_dest,
+        client_dest,
+        {PLUGIN_COMMAND: CommandManager.CMD_RETRIEVE_FILE},
+    )
+    response = manager.handle_command(
+        retrieve_msg.fields[LXMF.FIELD_COMMANDS][0], retrieve_msg
+    )
+
+    assert response is not None
+    content = response.content_as_string()
+    assert "missing required fields" in content
+    assert "FileID" in content
+
+
+def test_retrieve_file_supports_camel_case_id(tmp_path):
+    ensure_reticulum()
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+    file_path = api._config_manager.config.file_storage_path / "camel.bin"  # pylint: disable=protected-access
+    file_bytes = b"camel"
+    file_path.write_bytes(file_bytes)
+    file_record = api.store_file(file_path)
+
+    manager, server_dest = build_manager(api)
+    client_dest = make_client_destination()
+    retrieve_msg = make_message(
+        server_dest,
+        client_dest,
+        {PLUGIN_COMMAND: CommandManager.CMD_RETRIEVE_FILE, "fileId": file_record.file_id},
+    )
+
+    response = manager.handle_command(
+        retrieve_msg.fields[LXMF.FIELD_COMMANDS][0], retrieve_msg
+    )
+
+    assert response is not None
+    attachment_payload = response.fields[LXMF.FIELD_FILE_ATTACHMENTS][0]
+    assert attachment_payload["data"] == file_bytes
+    assert str(file_record.file_id) in response.content_as_string()
+
+
+def test_retrieve_image_supports_camel_case_id(tmp_path):
+    ensure_reticulum()
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+    image_path = api._config_manager.config.image_storage_path / "camel.jpg"  # pylint: disable=protected-access
+    image_bytes = b"camel-img"
+    image_path.write_bytes(image_bytes)
+    image_record = api.store_image(image_path)
+
+    manager, server_dest = build_manager(api)
+    client_dest = make_client_destination()
+    retrieve_msg = make_message(
+        server_dest,
+        client_dest,
+        {PLUGIN_COMMAND: CommandManager.CMD_RETRIEVE_IMAGE, "imageId": image_record.file_id},
+    )
+
+    response = manager.handle_command(
+        retrieve_msg.fields[LXMF.FIELD_COMMANDS][0], retrieve_msg
+    )
+
+    assert response is not None
+    assert LXMF.FIELD_IMAGE in response.fields
+    image_field = response.fields[LXMF.FIELD_IMAGE]
+    if isinstance(image_field, dict):
+        assert image_field["data"] == image_bytes
+    else:
+        assert image_field == image_bytes
+    assert response.fields[LXMF.FIELD_FILE_ATTACHMENTS][0]["data"] == image_bytes
+
+
+def test_retrieve_file_missing_record_returns_error(tmp_path):
+    ensure_reticulum()
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+    manager, server_dest = build_manager(api)
+    client_dest = make_client_destination()
+
+    retrieve_msg = make_message(
+        server_dest,
+        client_dest,
+        {PLUGIN_COMMAND: CommandManager.CMD_RETRIEVE_FILE, "FileID": 999},
+    )
+    response = manager.handle_command(
+        retrieve_msg.fields[LXMF.FIELD_COMMANDS][0], retrieve_msg
+    )
+
+    assert response is not None
+    assert "File '999' not found" in response.content_as_string()
+    assert not response.fields
+
+
+def test_retrieve_file_missing_from_disk_returns_helpful_message(tmp_path):
+    ensure_reticulum()
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+    file_path = api._config_manager.config.file_storage_path / "ghost.bin"  # pylint: disable=protected-access
+    file_path.write_text("ghost")
+    file_record = api.store_file(file_path)
+    file_path.unlink()
+
+    manager, server_dest = build_manager(api)
+    client_dest = make_client_destination()
+    retrieve_msg = make_message(
+        server_dest,
+        client_dest,
+        {PLUGIN_COMMAND: CommandManager.CMD_RETRIEVE_FILE, "FileID": file_record.file_id},
+    )
+    response = manager.handle_command(
+        retrieve_msg.fields[LXMF.FIELD_COMMANDS][0], retrieve_msg
+    )
+
+    assert response is not None
+    assert "not found on disk" in response.content_as_string()
+    assert LXMF.FIELD_FILE_ATTACHMENTS not in response.fields
+
+
+def test_retrieve_image_missing_from_disk_returns_helpful_message(tmp_path):
+    ensure_reticulum()
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+    image_path = api._config_manager.config.image_storage_path / "ghost.jpg"  # pylint: disable=protected-access
+    image_path.write_text("ghost-image")
+    image_record = api.store_image(image_path)
+    image_path.unlink()
+
+    manager, server_dest = build_manager(api)
+    client_dest = make_client_destination()
+    retrieve_msg = make_message(
+        server_dest,
+        client_dest,
+        {PLUGIN_COMMAND: CommandManager.CMD_RETRIEVE_IMAGE, "FileID": image_record.file_id},
+    )
+    response = manager.handle_command(
+        retrieve_msg.fields[LXMF.FIELD_COMMANDS][0], retrieve_msg
+    )
+
+    assert response is not None
+    assert "not found on disk" in response.content_as_string()
+    assert LXMF.FIELD_IMAGE not in response.fields
+    assert LXMF.FIELD_FILE_ATTACHMENTS not in response.fields


### PR DESCRIPTION
## Summary
- add focused tests covering file and image list and retrieval command flows, including empty stores, missing IDs, absent records, and missing files on disk
- accept camelCase fileId/imageId command fields while normalizing identifiers for retrieve commands
- bump the package version to 0.81.0 and mark the related task complete

## Testing
- ruff check .
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957de21dc748325b20871d878b2bc06)