### PR TITLE
Add Examples command and update help markdown output

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -68,3 +68,4 @@
 - 2025-12-29: ✅ Resolve DummyRouter pylint no-member warnings in Reticulum server initialization.
 - 2025-12-31: ✅ Return help text when an unknown command is received.
 - 2026-01-02: ✅ Add coverage for file and image command CRUD flows (ListFiles/ListImages) and resolve discovered issues.
+- 2026-01-02: ✅ Add Examples command returning detailed help while Help lists commands only.

--- a/docs/supportedCommands.md
+++ b/docs/supportedCommands.md
@@ -8,7 +8,8 @@ the following commands are supported by RTH
 
 | Command | Description | Example in chat|
 | --- | --- | --- |
-| `Help` | Returns a short help message with the available commands and examples. | ``\\\[{"Command":"Help"}]`` |
+| `Help` | Returns a Markdown list of available commands (no descriptions). | ``\\\[{"Command":"Help"}]`` |
+| `Examples` | Returns a Markdown list with command descriptions and JSON payload examples. | ``\\\[{"Command":"Examples"}]`` |
 | `join` | Register your LXMF destination with the hub so you can receive replies. | ``\\\[{"Command":"join"}]`` |
 | `leave` | Remove your destination from the hub's connection list. | ``\\\[{"Command":"leave"}]`` |
 | `ListClients` | List the LXMF destinations currently joined to the hub. | ``\\\[{"Command":"ListClients"}]`` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.81.0"
+version = "0.82.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/reticulum_server/command_manager.py
+++ b/reticulum_telemetry_hub/reticulum_server/command_manager.py
@@ -14,6 +14,7 @@ from reticulum_telemetry_hub.api.service import ReticulumTelemetryHubAPI
 from .constants import PLUGIN_COMMAND
 from .command_text import (
     build_help_text,
+    build_examples_text,
     format_attachment_list,
     format_subscriber_list,
     format_topic_list,
@@ -27,6 +28,7 @@ class CommandManager:
 
     # Command names based on the API specification
     CMD_HELP = "Help"
+    CMD_EXAMPLES = "Examples"
     CMD_JOIN = "join"
     CMD_LEAVE = "leave"
     CMD_LIST_CLIENTS = "ListClients"
@@ -83,6 +85,7 @@ class CommandManager:
 
         return [
             self.CMD_HELP,
+            self.CMD_EXAMPLES,
             self.CMD_JOIN,
             self.CMD_LEAVE,
             self.CMD_LIST_CLIENTS,
@@ -359,6 +362,8 @@ class CommandManager:
         if name is not None:
             if name == self.CMD_HELP:
                 return self._handle_help(message)
+            if name == self.CMD_EXAMPLES:
+                return self._handle_examples(message)
             if name == self.CMD_JOIN:
                 return self._handle_join(message)
             if name == self.CMD_LEAVE:
@@ -610,6 +615,9 @@ class CommandManager:
 
     def _handle_help(self, message: LXMF.LXMessage) -> LXMF.LXMessage:
         return self._reply(message, build_help_text(self))
+
+    def _handle_examples(self, message: LXMF.LXMessage) -> LXMF.LXMessage:
+        return self._reply(message, build_examples_text(self))
 
     def _handle_unknown_command(
         self, name: str, message: LXMF.LXMessage

--- a/reticulum_telemetry_hub/reticulum_server/command_text.py
+++ b/reticulum_telemetry_hub/reticulum_server/command_text.py
@@ -12,33 +12,70 @@ from reticulum_telemetry_hub.lxmf_telemetry.telemetry_controller import (
 
 
 def build_help_text(command_manager: Any) -> str:
-    """Assemble human-friendly help text for LXMF clients.
+    """Assemble a Markdown list of supported commands for LXMF clients.
 
     Args:
         command_manager (Any): An object exposing the command name constants.
 
     Returns:
-        str: A formatted help payload describing each supported command.
+        str: Markdown-formatted list of supported commands.
+    """
+
+    command_names = command_manager._all_command_names()  # noqa: SLF001
+    lines = [
+        "# Command list",
+        "",
+        "Use the `Command` field (`0`) to choose an action when building payloads.",
+        "",
+        "## Supported commands",
+    ]
+    for command_name in command_names:
+        lines.append(f"- `{command_name}`")
+    lines.append("- `TelemetryRequest` (`1`)")
+    return "\n".join(lines)
+
+
+def build_examples_text(command_manager: Any) -> str:
+    """Assemble Markdown examples for LXMF clients.
+
+    Args:
+        command_manager (Any): An object exposing the command name constants.
+
+    Returns:
+        str: Markdown-formatted description and payload examples for commands.
     """
 
     lines = [
-        "Available commands:",
-        "  Use the 'Command' field (numeric key 0 / PLUGIN_COMMAND) to choose an action.",
+        "# Command examples",
+        "",
+        "Use the `Command` field (`0`) to choose an action when building payloads.",
+        "",
+        "## Examples",
     ]
     for entry in command_reference(command_manager):
-        lines.append(f"- {entry['title']}: {entry['description']}")
-        lines.append(f"  Example: {entry['example']}")
-    telemetry_example = json.dumps(
+        lines.append(f"- **{entry['title']}**")
+        lines.append(f"  - Description: {entry['description']}")
+        lines.append(f"  - Example: `{entry['example']}`")
+    telemetry_example = _telemetry_request_example()
+    lines.append("- **TelemetryRequest (numeric key `1`)**")
+    lines.append(
+        "  - Description: Request telemetry snapshots using the `TelemetryRequest` numeric key."
+    )
+    lines.append(
+        "  - Example: `"
+        f"{telemetry_example}"
+        "` (timestamp = earliest UNIX time to include)"
+    )
+    return "\n".join(lines)
+
+
+def _telemetry_request_example() -> str:
+    """Return an example telemetry request payload."""
+
+    return json.dumps(
         {str(TelemetryController.TELEMETRY_REQUEST): "<unix timestamp>"},
         sort_keys=True,
     )
-    lines.append(
-        "- TelemetryRequest: Request telemetry snapshots using numeric key 1 (TelemetryController.TELEMETRY_REQUEST)."
-    )
-    lines.append(
-        f"  Example: {telemetry_example} (timestamp = earliest UNIX time to include)"
-    )
-    return "\n".join(lines)
 
 
 def command_reference(command_manager: Any) -> List[dict]:

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -48,6 +48,7 @@ def make_command_manager(api):
 
 COMMAND_HANDLER_MAP = [
     (CommandManager.CMD_HELP, "_handle_help"),
+    (CommandManager.CMD_EXAMPLES, "_handle_examples"),
     (CommandManager.CMD_JOIN, "_handle_join"),
     (CommandManager.CMD_LEAVE, "_handle_leave"),
     (CommandManager.CMD_LIST_CLIENTS, "_handle_list_clients"),
@@ -763,6 +764,9 @@ def test_help_command_lists_examples(tmp_path):
     class DummyAPI:
         pass
 
+    if RNS.Reticulum.get_instance() is None:
+        RNS.Reticulum()
+
     manager, server_dest = make_command_manager(DummyAPI())
     client_id = RNS.Identity()
     client_dest = RNS.Destination(
@@ -773,7 +777,30 @@ def test_help_command_lists_examples(tmp_path):
     reply = manager.handle_command(help_command, help_msg)
     assert reply is not None
     text = reply.content_as_string()
-    assert "Available commands" in text
+    assert "# Command list" in text
+    assert "- `Help`" in text
+    assert "- `TelemetryRequest` (`1`)" in text
+
+
+def test_examples_command_returns_help_payload(tmp_path):
+    class DummyAPI:
+        pass
+
+    if RNS.Reticulum.get_instance() is None:
+        RNS.Reticulum()
+
+    manager, server_dest = make_command_manager(DummyAPI())
+    client_id = RNS.Identity()
+    client_dest = RNS.Destination(
+        client_id, RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery"
+    )
+    examples_command = {PLUGIN_COMMAND: CommandManager.CMD_EXAMPLES}
+    examples_msg = make_message(server_dest, client_dest, CommandManager.CMD_EXAMPLES)
+    reply = manager.handle_command(examples_command, examples_msg)
+    assert reply is not None
+    text = reply.content_as_string()
+    assert "# Command examples" in text
+    assert "Description" in text
     assert CommandManager.CMD_CREATE_TOPIC in text
     assert "TelemetryRequest" in text
 
@@ -1374,4 +1401,4 @@ def test_unknown_command_returns_help_text():
     reply = manager.handle_command(command, message)
     text = reply.content_as_string()
     assert text.startswith("Unknow command")
-    assert "Available commands" in text
+    assert "# Command list" in text


### PR DESCRIPTION
## Summary
- add an `Examples` command that returns markdown with command descriptions and payload samples
- simplify the `Help` command to a markdown command list and update tests and docs accordingly
- bump the package version to 0.82.0 and mark the task complete

## Testing
- `python -m pytest tests/test_command_manager.py -k "help or examples"` *(fails coverage gate at 90% when running this subset; the targeted tests passed)*
- `python -m ruff check reticulum_telemetry_hub/reticulum_server/command_text.py reticulum_telemetry_hub/reticulum_server/command_manager.py tests/test_command_manager.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957ea2d868c8325afcb547b4f13e75f)