### PR TITLE
Fix command typos and update RetrieveTopic name

### DIFF
--- a/API/ReticulumTelemetryHub-OAS.yaml
+++ b/API/ReticulumTelemetryHub-OAS.yaml
@@ -48,7 +48,7 @@ paths:
        - Topic
       description: >-
       summary: retrieve an existing Topic record based on the provided ID.
-      operationId: RetreiveTopic
+      operationId: RetrieveTopic
       parameters:
         - $ref: '#/components/parameters/id'
       responses:

--- a/TASK.md
+++ b/TASK.md
@@ -84,3 +84,4 @@
 - 2026-01-02: バ. Document file/image attachment workflows in README.
 - 2026-01-03: ✅ Test project and fix lint issues.
 - 2026-01-03: ✅ Resolve command handler lint warnings in delivery callback.
+- 2026-01-05: ✅ Fix unknown command response typo and rename RetrieveTopic command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.94.0"
+version = "0.95.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/reticulum_telemetry_hub/reticulum_server/command_manager.py
+++ b/reticulum_telemetry_hub/reticulum_server/command_manager.py
@@ -32,7 +32,7 @@ class CommandManager:
     CMD_JOIN = "join"
     CMD_LEAVE = "leave"
     CMD_LIST_CLIENTS = "ListClients"
-    CMD_RETRIEVE_TOPIC = "RetreiveTopic"
+    CMD_RETRIEVE_TOPIC = "RetrieveTopic"
     CMD_CREATE_TOPIC = "CreateTopic"
     CMD_DELETE_TOPIC = "DeleteTopic"
     CMD_LIST_TOPIC = "ListTopic"
@@ -637,7 +637,7 @@ class CommandManager:
         sender = self._identity_hex(message.source.identity)
         RNS.log(f"Unknown command '{name}' from {sender}", getattr(RNS, "LOG_ERROR", 1))
         help_text = build_help_text(self)
-        payload = f"Unknow command\n\n{help_text}"
+        payload = f"Unknown command\n\n{help_text}"
         return self._reply(message, payload)
 
     def _prompt_for_fields(

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -426,7 +426,7 @@ def test_unknown_command_logs_error(monkeypatch):
 
     assert responses
     reply_text = responses[0].content_as_string()
-    assert "Unknow command" in reply_text
+    assert "Unknown command" in reply_text
     assert logs
     relevant = [entry for entry in logs if "NotACommand" in entry[0]]
     assert relevant
@@ -1409,5 +1409,5 @@ def test_unknown_command_returns_help_text():
 
     reply = manager.handle_command(command, message)
     text = reply.content_as_string()
-    assert text.startswith("Unknow command")
+    assert text.startswith("Unknown command")
     assert "# Command list" in text


### PR DESCRIPTION
## Summary
- fix the unknown command reply text and adjust tests to match
- rename the RetrieveTopic command in both the command manager and OpenAPI spec
- bump the project version and log the completed task

## Testing
- source venv_linux/bin/activate && pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c1d1f35888325a3e6d756efd80561)