### PR TITLE
Store failed outbound messages in propagation node and support propagation flag aliases

### DIFF
--- a/reticulum_telemetry_hub/config/manager.py
+++ b/reticulum_telemetry_hub/config/manager.py
@@ -285,7 +285,16 @@ class HubConfigurationManager:  # pylint: disable=too-many-instance-attributes
         cfg_lxmf_section = dict(self._get_section("lxmf"))
         lxmf_section = {**file_lxmf_section, **cfg_lxmf_section}
 
-        enable_node = self._get_bool(propagation_section, "enable_node", True)
+        enable_node_value = propagation_section.get("enable_node")
+        if enable_node_value is None:
+            enable_node_value = propagation_section.get("propagation_node")
+        if enable_node_value is None:
+            enable_node_value = lxmf_section.get("enable_node")
+        if enable_node_value is None:
+            enable_node_value = lxmf_section.get("propagation_node")
+        enable_node = self._get_bool(
+            {"enable_node": enable_node_value}, "enable_node", True
+        )
         announce_interval = self._coerce_int(
             propagation_section.get("announce_interval"), 10
         )


### PR DESCRIPTION
### Motivation
- Ensure the hub respects multiple config layouts by accepting both `enable_node` and `propagation_node` keys in either `[propagation]` or `[lxmf]` sections when parsing LXMF config.
- Provide store-and-forward behavior so messages that exhaust delivery retries are not silently dropped when a propagation node is enabled.

### Description
- Update `_load_lxmf_config` to search for `enable_node` or `propagation_node` in both the `[propagation]` and `[lxmf]` sections and normalize the value via `self._get_bool` to `LXMFRouterConfig.enable_node`.
- Add `_propagate_failed_message` to `OutboundMessageQueue` and call it when an outbound payload exceeds retry attempts, which packs the message and calls `lxm_router.lxmf_propagation` when `propagation_node` is enabled.
- When a recipient is not available and propagation is enabled, RTH will store/send failed messages to itself as the propagation node to enable later delivery.

### Testing
- No automated tests were executed for these changes.
- Existing unit tests were not modified as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69611c6bb05883259b09b7428dcebd30)