### PR TITLE
Clarify topic tagging in command help

### DIFF
--- a/reticulum_telemetry_hub/reticulum_server/command_text.py
+++ b/reticulum_telemetry_hub/reticulum_server/command_text.py
@@ -26,6 +26,8 @@ def build_help_text(command_manager: Any) -> str:
         "# Command list",
         "",
         "Use the `Command` field (`0`) to choose an action when building payloads.",
+        "Tip: tag file/image attachments with a `TopicID` (or send `AssociateTopicID`) "
+        "to link them to a topic.",
         "",
         "## Supported commands",
     ]
@@ -118,12 +120,20 @@ def command_reference(command_manager: Any) -> List[dict]:
         },
         {
             "title": command_manager.CMD_LIST_FILES,
-            "description": "List stored file attachments saved on the hub.",
+            "description": (
+                "List stored file attachments saved on the hub. Tagged attachments include "
+                "a TopicID in the listing (set it via `TopicID`, `topic_id`, `topic`, or "
+                "`Topic`, or send `AssociateTopicID`)."
+            ),
             "example": example(command_manager.CMD_LIST_FILES),
         },
         {
             "title": command_manager.CMD_LIST_IMAGES,
-            "description": "List stored image attachments saved on the hub.",
+            "description": (
+                "List stored image attachments saved on the hub. Tagged attachments include "
+                "a TopicID in the listing (set it via `TopicID`, `topic_id`, `topic`, or "
+                "`Topic`, or send `AssociateTopicID`)."
+            ),
             "example": example(command_manager.CMD_LIST_IMAGES),
         },
         {
@@ -158,8 +168,13 @@ def command_reference(command_manager: Any) -> List[dict]:
         },
         {
             "title": command_manager.CMD_ASSOCIATE_TOPIC_ID,
-            "description": "Associate uploaded attachments with a TopicID.",
-            "example": example(command_manager.CMD_ASSOCIATE_TOPIC_ID, TopicID="<TopicID>"),
+            "description": (
+                "Associate uploaded attachments with a TopicID. Accepted keys: `TopicID`, "
+                "`topic_id`, `topic`, or `Topic`."
+            ),
+            "example": example(
+                command_manager.CMD_ASSOCIATE_TOPIC_ID, TopicID="weather"
+            ),
         },
         {
             "title": command_manager.CMD_RETRIEVE_TOPIC,


### PR DESCRIPTION
### Motivation
- Make it clearer how to associate stored attachments with topics when using LXMF command payloads.
- Ensure help and example output explicitly mention accepted keys for topic assignment so clients can construct valid payloads.

### Description
- Add a tip to `build_help_text` informing users they can tag file/image attachments with a `TopicID` or send `AssociateTopicID` to link them to a topic.
- Update `ListFiles` and `ListImages` entries to mention that tagged attachments include a `TopicID` in the listing and to show the accepted keys (`TopicID`, `topic_id`, `topic`, `Topic`).
- Expand the `AssociateTopicID` command entry to list accepted keys and provide a concrete example payload (`TopicID="weather"`).

### Testing
- No automated tests were run since this is a documentation/help text change.
- Static checks and formatting were not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614e955d90832595d8a4cbc8e1f9da)