### PR TITLE
Document TopicID tagging for file/image listings

### DIFF
--- a/API/ReticulumTelemetryHub-OAS.yaml
+++ b/API/ReticulumTelemetryHub-OAS.yaml
@@ -89,7 +89,7 @@ paths:
       operationId: ListFiles
       responses:
         '200':
-          description: Stored file metadata.
+          description: Stored file metadata (includes TopicID when tagged via the upload command or AssociateTopicID).
           content:
             application/json:
               schema:
@@ -121,7 +121,7 @@ paths:
       operationId: ListImages
       responses:
         '200':
-          description: Stored image metadata.
+          description: Stored image metadata (includes TopicID when tagged via the upload command or AssociateTopicID).
           content:
             application/json:
               schema:

--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ File and image directories still default to `<storage_dir>/files` and `<storage_
 
 ### Exchanging attachments over LXMF
 
-- LXMF clients can discover stored artifacts with `ListFiles` and `ListImages` commands and fetch them with `RetrieveFile` / `RetrieveImage`. Retrieval replies include metadata in the message body **and** ship the binary payloads in the LXMF-standard fields (`FIELD_FILE_ATTACHMENTS` for files, `FIELD_IMAGE` for images) so Sideband, Meshchat, and similar tools can save them without extra parsing.
+- LXMF clients can discover stored artifacts with `ListFiles` and `ListImages` commands and fetch them with `RetrieveFile` / `RetrieveImage`. List responses include `TopicID` when one is tagged, and retrieval replies include metadata in the message body **and** ship the binary payloads in the LXMF-standard fields (`FIELD_FILE_ATTACHMENTS` for files, `FIELD_IMAGE` for images) so Sideband, Meshchat, and similar tools can save them without extra parsing.
 - Attachment payloads are sent in list form for client compatibility: `["filename.ext", <bytes>, "mime/type"]`. Images include `FIELD_IMAGE` and are also mirrored in `FIELD_FILE_ATTACHMENTS`.
-- Incoming LXMF messages that already include `FIELD_FILE_ATTACHMENTS` or `FIELD_IMAGE` fields are persisted automatically to the configured storage directories. The hub replies with the assigned index so you can reference the attachment in subsequent retrievals.
+- Incoming LXMF messages that already include `FIELD_FILE_ATTACHMENTS` or `FIELD_IMAGE` fields are persisted automatically to the configured storage directories. Tag attachments by including `TopicID` in the command payload or by sending `AssociateTopicID`. The hub replies with the assigned index so you can reference the attachment in subsequent retrievals.
 
 ## Service
 

--- a/docs/supportedCommands.md
+++ b/docs/supportedCommands.md
@@ -14,8 +14,8 @@ the following commands are supported by RTH
 | `leave` | Remove your destination from the hub's connection list. | ``\\\[{"Command":"leave"}]`` |
 | `ListClients` | List the LXMF destinations currently joined to the hub. | ``\\\[{"Command":"ListClients"}]`` |
 | `getAppInfo` | Return the configured app name, version, and description from `config.ini`. | ``\\\[{"Command":"getAppInfo"}]`` |
-| `ListFiles` | List file attachments stored by the hub (from API calls or inbound LXMF). | ``\\\[{"Command":"ListFiles"}]`` |
-| `ListImages` | List image attachments stored by the hub (from API calls or inbound LXMF). | ``\\\[{"Command":"ListImages"}]`` |
+| `ListFiles` | List file attachments stored by the hub (from API calls or inbound LXMF). List responses include `TopicID` when available; tag attachments by including `TopicID` in the upload command or by sending `AssociateTopicID`. | ``\\\[{"Command":"ListFiles"}]`` |
+| `ListImages` | List image attachments stored by the hub (from API calls or inbound LXMF). List responses include `TopicID` when available; tag attachments by including `TopicID` in the upload command or by sending `AssociateTopicID`. | ``\\\[{"Command":"ListImages"}]`` |
 | `ListTopic` | List every registered topic and its ID. | ``\\\[{"Command":"ListTopic"}]`` |
 | `CreateTopic` | Create a topic with a name and path. | ``\\\[{"Command":"CreateTopic","TopicName":"Weather","TopicPath":"environment/weather"}]`` |
 | `RetrieveTopic` | Fetch a topic by `TopicID`. | ``\\\[{"Command":"RetrieveTopic","TopicID":"<TopicID>"}]`` |


### PR DESCRIPTION
### Motivation

- Clarify how attachments can be associated with topics so clients can discover/topic-filter stored artifacts.
- Ensure documentation and the API spec consistently reflect that list responses may include a `TopicID` when attachments are tagged.

### Description

- Update `docs/supportedCommands.md` to note that `ListFiles` and `ListImages` responses include `TopicID` when available and how to tag attachments via `TopicID` in the upload command or `AssociateTopicID`.
- Update `README.md` attachment workflow to mention topic tagging and that list responses include `TopicID` when set, and note using `AssociateTopicID` for tagging.
- Update `API/ReticulumTelemetryHub-OAS.yaml` to add brief descriptions on the `/File` and `/Image` list endpoints indicating `TopicID` may be included when attachments are tagged.

### Testing

- No automated tests were run because these are documentation-only changes.
- Linting or CI was not executed as part of this changeset.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69615154522c83258f67043e92f1db1d)