### PR TITLE
Add alias for RetrieveSubscriber command

### DIFF
--- a/reticulum_telemetry_hub/reticulum_server/command_manager.py
+++ b/reticulum_telemetry_hub/reticulum_server/command_manager.py
@@ -124,6 +124,9 @@ class CommandManager:
             }
             for alias in aliases:
                 self._command_aliases_cache.setdefault(alias, command_name)
+        self._command_aliases_cache.setdefault(
+            "retrievesubscriber", self.CMD_RETRIEVE_SUBSCRIBER
+        )
         return self._command_aliases_cache
 
     @staticmethod


### PR DESCRIPTION
### Motivation
- The API contains a legacy/misspelled command `RetreiveSubscriber` that must remain supported for backward compatibility.
- Clients may send the correctly spelled `RetrieveSubscriber`, so the server should normalize both spellings to the same handler. 
- Ensure normalization/alias mapping explicitly accepts the correct spelling without changing the existing canonical name `CMD_RETRIEVE_SUBSCRIBER`.

### Description
- Add an explicit lowercase alias mapping for `"retrievesubscriber"` to `CMD_RETRIEVE_SUBSCRIBER` in `_command_alias_map`. 
- Leave the existing `CMD_RETRIEVE_SUBSCRIBER` constant unchanged to preserve backward compatibility. 
- Add `test_handle_command_accepts_retrieve_subscriber_alias` to `tests/test_command_manager.py` that stubs the handler and asserts `"RetrieveSubscriber"` routes to the same canonical command. 

### Testing
- Ran `pytest -k retrieve_subscriber tests/test_command_manager.py`, which executed the new test and related command-manager tests. 
- The selected tests passed (`3 passed, 76 deselected`).
- The overall test run failed due to the repository-wide coverage threshold (`TOTAL coverage 31% < fail-under 90%`).
- The new unit test verifies normalization and handler dispatch for the `RetrieveSubscriber` alias.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961528ac5ec8325a524ec829eca7f8c)