### PR TITLE
Constrain stored attachments to base path

### DIFF
--- a/reticulum_telemetry_hub/api/service.py
+++ b/reticulum_telemetry_hub/api/service.py
@@ -489,11 +489,19 @@ class ReticulumTelemetryHubAPI:  # pylint: disable=too-many-public-methods
         if not resolved_name:
             raise ValueError("name is required")
         base_path.mkdir(parents=True, exist_ok=True)
-        stat_result = path_obj.stat()
+        resolved_base_path = base_path.resolve()
+        resolved_path = path_obj.resolve()
+        try:
+            resolved_path.relative_to(resolved_base_path)
+        except ValueError as exc:
+            raise ValueError(
+                f"File '{file_path}' must be stored within '{resolved_base_path}'"
+            ) from exc
+        stat_result = resolved_path.stat()
         timestamp = datetime.now(timezone.utc)
         attachment = FileAttachment(
             name=resolved_name,
-            path=str(path_obj),
+            path=str(resolved_path),
             category=category,
             size=stat_result.st_size,
             media_type=media_type,

--- a/tests/test_file_api.py
+++ b/tests/test_file_api.py
@@ -36,6 +36,15 @@ def test_store_file_validates_path(tmp_path: Path):
         api.store_file(tmp_path / "missing.bin")
 
 
+def test_store_file_rejects_outside_base_path(tmp_path: Path):
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+    outside_path = tmp_path / "outside.bin"
+    outside_path.write_text("outside")
+
+    with pytest.raises(ValueError):
+        api.store_file(outside_path)
+
+
 def test_retrieve_image_rejects_file_category(tmp_path: Path):
     api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
     file_path = api._config_manager.config.file_storage_path / "not-image.txt"  # pylint: disable=protected-access


### PR DESCRIPTION
### Motivation

- Ensure files recorded by the API are constrained to the configured storage directories to avoid referencing arbitrary filesystem locations.
- Prevent storing metadata that points outside the hub's configured `file_storage_path`/`image_storage_path` for safety and portability.

### Description

- Resolve both `base_path` and the provided `file_path` to absolute paths and validate the attachment path is inside `base_path` using `relative_to`.
- Raise `ValueError` when a file is outside the configured base directory with a clear message.
- Persist the resolved path in the `FileAttachment` metadata (store `str(resolved_path)` instead of the original input).
- Add `tests/test_file_api.py::test_store_file_rejects_outside_base_path` to verify rejection of files outside the configured directory.

### Testing

- Ran `pytest -q tests/test_file_api.py` to exercise file-related functionality.
- The test run reported `4 passed` for the file-specific tests.
- The overall test run failed due to the repository-wide coverage threshold (total coverage 37% < `fail-under=90`), causing the pytest invocation to exit non-zero.
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961525f74f48325b7743419900b1f26)