### PR TITLE
Normalize RetrieveSubscriber command name and add legacy alias

### DIFF
--- a/reticulum_telemetry_hub/reticulum_server/command_manager.py
+++ b/reticulum_telemetry_hub/reticulum_server/command_manager.py
@@ -41,7 +41,7 @@ class CommandManager:
     CMD_LIST_TOPIC = "ListTopic"
     CMD_PATCH_TOPIC = "PatchTopic"
     CMD_SUBSCRIBE_TOPIC = "SubscribeTopic"
-    CMD_RETRIEVE_SUBSCRIBER = "RetreiveSubscriber"
+    CMD_RETRIEVE_SUBSCRIBER = "RetrieveSubscriber"
     CMD_ADD_SUBSCRIBER = "AddSubscriber"
     CMD_CREATE_SUBSCRIBER = "CreateSubscriber"
     CMD_DELETE_SUBSCRIBER = "DeleteSubscriber"
@@ -161,6 +161,9 @@ class CommandManager:
                 self._command_aliases_cache.setdefault(alias, command_name)
         self._command_aliases_cache.setdefault(
             "retrievesubscriber", self.CMD_RETRIEVE_SUBSCRIBER
+        )
+        self._command_aliases_cache.setdefault(
+            "retreivesubscriber", self.CMD_RETRIEVE_SUBSCRIBER
         )
         return self._command_aliases_cache
 


### PR DESCRIPTION
### Motivation
- Fix a typo in the RetrieveSubscriber command name so it matches the API specification.
- Ensure positional field lookups and handler dispatch use the corrected canonical command string via the constant.
- Preserve backward compatibility by accepting the historical misspelling as an alias.

### Description
- Change `CMD_RETRIEVE_SUBSCRIBER` value from `"RetreiveSubscriber"` to `"RetrieveSubscriber"` in `reticulum_telemetry_hub/reticulum_server/command_manager.py`.
- Continue using the `CMD_RETRIEVE_SUBSCRIBER` constant in `POSITIONAL_FIELDS` and command dispatch so callers automatically pick up the corrected name.
- Add alias mappings in `_command_alias_map` so both `retrievesubscriber` and the legacy `retreivesubscriber` map to the canonical command.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f6b233a88325a4cbbe61193aabdc)