### PR TITLE
Add RTH Core UI application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,7 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 docs/example_telemetry.json
+
+# UI artifacts
+ui/node_modules/
+ui/dist/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ complete REST surface, including:
 - `GET /Config`, `PUT /Config`, `POST /Config/Validate`, `POST /Config/Rollback`
 - `GET /Identities`, `POST /Client/{id}/Ban`, `POST /Client/{id}/Unban`, `POST /Client/{id}/Blackhole`
 
+## Admin UI
+
+The RTH Core UI lives in `ui/` and provides the administrative control plane described in
+`docs/ui-design.md` and `docs/ui-wireframe.md`. To run it locally:
+
+```bash
+cd ui
+npm install
+npm run dev
+```
+
+Set `VITE_RTH_BASE_URL` when you want to target a hub that is not served from the same origin.
+
 ## Quickstart
 
 Follow these steps to bring up a local hub using the bundled defaults:

--- a/TASK.md
+++ b/TASK.md
@@ -1,4 +1,5 @@
 ﻿# TASKS
+- 2026-01-11: ✅ Implement RTH Core UI application as documented.
 - 2026-01-09: âœ… Fix config backup timestamp timezone usage.
 - 2026-01-09: âœ… Add protected/public commands, REST docs, telemetry topic filtering, and config management.
 - 2026-01-09: âœ… Align UI design doc with current command/API surface.
@@ -89,4 +90,3 @@
 - 2026-01-03: ✅ Test project and fix lint issues.
 - 2026-01-03: ✅ Resolve command handler lint warnings in delivery callback.
 - 2026-01-05: ✅ Fix unknown command response typo and rename RetrieveTopic command.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.99.0"
+version = "0.100.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,39 @@
+# RTH Core UI
+
+The RTH Core UI is the administrative console for the Reticulum Telemetry Hub. It is a Vue 3 + Vite + TypeScript SPA that talks to the hub's REST and WebSocket endpoints.
+
+## Requirements
+
+- Node.js 20 LTS (recommended)
+- npm 10+
+
+## Development
+
+```bash
+cd ui
+npm install
+npm run dev
+```
+
+By default, the UI talks to the same origin. To target a different hub, set `VITE_RTH_BASE_URL`:
+
+```bash
+VITE_RTH_BASE_URL="https://example-hub" npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+npm run preview
+```
+
+## Environment Variables
+
+- `VITE_RTH_BASE_URL`: Optional base URL for the REST/WS endpoints. When unset, the UI uses the browser origin.
+- `VITE_RTH_WS_BASE_URL`: Optional explicit WebSocket base URL (defaults to the REST base URL with ws/wss).
+
+## Deployment Modes
+
+- **Embedded UI**: Serve the `dist/` folder from the hub service (same-origin).
+- **External UI**: Host the `dist/` folder behind a reverse proxy and use the Connect screen to set base URL and credentials.

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RTH Core UI</title>
+  </head>
+  <body class="bg-rth-bg text-rth-text">
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,2771 @@
+{
+  "name": "rth-core-ui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rth-core-ui",
+      "version": "0.1.0",
+      "dependencies": {
+        "maplibre-gl": "^4.7.1",
+        "pinia": "^2.1.7",
+        "vue": "^3.4.31",
+        "vue-router": "^4.3.2"
+      },
+      "devDependencies": {
+        "@types/maplibre-gl": "^1.14.0",
+        "@vitejs/plugin-vue": "^5.1.2",
+        "autoprefixer": "^10.4.19",
+        "postcss": "^8.4.39",
+        "tailwindcss": "^3.4.9",
+        "typescript": "^5.5.4",
+        "vite": "^5.4.1"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+      "license": "ISC",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
+      "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
+      "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
+      "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
+      "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
+      "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
+      "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
+      "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
+      "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
+      "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
+      "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
+      "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
+      "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
+      "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
+      "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
+      "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
+      "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
+      "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
+      "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
+      "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
+      "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
+      "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
+      "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
+      "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
+      "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/mapbox__point-geometry": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mapbox__vector-tile": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/mapbox__point-geometry": "*",
+        "@types/pbf": "*"
+      }
+    },
+    "node_modules/@types/maplibre-gl": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@types/maplibre-gl/-/maplibre-gl-1.14.0.tgz",
+      "integrity": "sha512-I6ibscT7UdL1oOqqCz9s1gjcolLaUPkHIIfMLusczTvlsMhjORyS6sE1g4V/NESAOL5KhNQX3/31LJH+OCGjkg==",
+      "deprecated": "This is a stub types definition. maplibre-gl provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "maplibre-gl": "*"
+      }
+    },
+    "node_modules/@types/pbf": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.26.tgz",
+      "integrity": "sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/shared": "3.5.26",
+        "entities": "^7.0.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.26.tgz",
+      "integrity": "sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.26",
+        "@vue/shared": "3.5.26"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.26.tgz",
+      "integrity": "sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/compiler-core": "3.5.26",
+        "@vue/compiler-dom": "3.5.26",
+        "@vue/compiler-ssr": "3.5.26",
+        "@vue/shared": "3.5.26",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.26.tgz",
+      "integrity": "sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.26",
+        "@vue/shared": "3.5.26"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.26.tgz",
+      "integrity": "sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.26"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.26.tgz",
+      "integrity": "sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.26",
+        "@vue/shared": "3.5.26"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.26.tgz",
+      "integrity": "sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.26",
+        "@vue/runtime-core": "3.5.26",
+        "@vue/shared": "3.5.26",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.26.tgz",
+      "integrity": "sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.26",
+        "@vue/shared": "3.5.26"
+      },
+      "peerDependencies": {
+        "vue": "3.5.26"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.26.tgz",
+      "integrity": "sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==",
+      "license": "MIT"
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.23",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.23.tgz",
+      "integrity": "sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001760",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
+      "integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001764",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
+      "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.267",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
+      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.0.tgz",
+      "integrity": "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/geojson-vt": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
+      "license": "ISC"
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
+      "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^4.1.3",
+        "kind-of": "^6.0.3",
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/maplibre-gl": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
+      "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.1",
+        "@types/geojson": "^7946.0.14",
+        "@types/geojson-vt": "3.2.5",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "earcut": "^3.0.0",
+        "geojson-vt": "^4.0.2",
+        "gl-matrix": "^3.4.3",
+        "global-prefix": "^4.0.0",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.3.0",
+        "potpack": "^2.0.0",
+        "quickselect": "^3.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0",
+        "vt-pbf": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.3.1.tgz",
+      "integrity": "sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.4.4",
+        "vue": "^2.7.0 || ^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
+      "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.55.1",
+        "@rollup/rollup-android-arm64": "4.55.1",
+        "@rollup/rollup-darwin-arm64": "4.55.1",
+        "@rollup/rollup-darwin-x64": "4.55.1",
+        "@rollup/rollup-freebsd-arm64": "4.55.1",
+        "@rollup/rollup-freebsd-x64": "4.55.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.55.1",
+        "@rollup/rollup-linux-arm64-musl": "4.55.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.55.1",
+        "@rollup/rollup-linux-loong64-musl": "4.55.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.55.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.55.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-musl": "4.55.1",
+        "@rollup/rollup-openbsd-x64": "4.55.1",
+        "@rollup/rollup-openharmony-arm64": "4.55.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.55.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.55.1",
+        "@rollup/rollup-win32-x64-gnu": "4.55.1",
+        "@rollup/rollup-win32-x64-msvc": "4.55.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
+      "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.26",
+        "@vue/compiler-sfc": "3.5.26",
+        "@vue/runtime-dom": "3.5.26",
+        "@vue/server-renderer": "3.5.26",
+        "@vue/shared": "3.5.26"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "rth-core-ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext .ts,.vue"
+  },
+  "dependencies": {
+    "maplibre-gl": "^4.7.1",
+    "pinia": "^2.1.7",
+    "vue": "^3.4.31",
+    "vue-router": "^4.3.2"
+  },
+  "devDependencies": {
+    "@types/maplibre-gl": "^1.14.0",
+    "@vitejs/plugin-vue": "^5.1.2",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.39",
+    "tailwindcss": "^3.4.9",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.1"
+  }
+}

--- a/ui/postcss.config.cjs
+++ b/ui/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1,0 +1,12 @@
+<template>
+  <AppShell>
+    <RouterView />
+  </AppShell>
+  <BaseToast />
+</template>
+
+<script setup lang="ts">
+import { RouterView } from "vue-router";
+import AppShell from "./components/AppShell.vue";
+import BaseToast from "./components/BaseToast.vue";
+</script>

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -1,0 +1,94 @@
+import { useConnectionStore } from "../stores/connection";
+
+export interface ApiError extends Error {
+  status?: number;
+  body?: unknown;
+}
+
+export interface RequestOptions {
+  method?: string;
+  body?: unknown;
+  timeoutMs?: number;
+}
+
+const createError = (message: string, status?: number, body?: unknown): ApiError => {
+  const error = new Error(message) as ApiError;
+  error.status = status;
+  error.body = body;
+  return error;
+};
+
+const withTimeout = async (promise: Promise<Response>, timeoutMs: number): Promise<Response> => {
+  let timeoutId: number | undefined;
+  const timeoutPromise = new Promise<Response>((_, reject) => {
+    timeoutId = window.setTimeout(() => {
+      reject(createError("Request timed out"));
+    }, timeoutMs);
+  });
+  const response = await Promise.race([promise, timeoutPromise]);
+  if (timeoutId) {
+    clearTimeout(timeoutId);
+  }
+  return response as Response;
+};
+
+export const request = async <T>(path: string, options: RequestOptions = {}): Promise<T> => {
+  const connectionStore = useConnectionStore();
+  const url = connectionStore.resolveUrl(path);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json"
+  };
+
+  const authHeader = connectionStore.authHeader;
+  if (authHeader) {
+    headers.Authorization = authHeader;
+  }
+  if ((connectionStore.authMode === "apiKey" || connectionStore.authMode === "both") && connectionStore.apiKey) {
+    headers["X-API-Key"] = connectionStore.apiKey;
+  }
+
+  const requestInit: RequestInit = {
+    method: options.method ?? "GET",
+    headers
+  };
+  if (options.body !== undefined) {
+    requestInit.body = JSON.stringify(options.body);
+  }
+
+  try {
+    const response = await withTimeout(fetch(url, requestInit), options.timeoutMs ?? 10000);
+    if (!response.ok) {
+      let errorBody: unknown = undefined;
+      try {
+        errorBody = await response.json();
+      } catch (error) {
+        errorBody = await response.text();
+      }
+      throw createError(`Request failed: ${response.status}`, response.status, errorBody);
+    }
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    const contentType = response.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      return (await response.json()) as T;
+    }
+    return (await response.text()) as T;
+  } catch (error) {
+    connectionStore.setOffline(error instanceof Error ? error.message : "Unknown error");
+    throw error;
+  }
+};
+
+export const get = async <T>(path: string): Promise<T> => request<T>(path);
+
+export const post = async <T>(path: string, body?: unknown): Promise<T> =>
+  request<T>(path, { method: "POST", body });
+
+export const put = async <T>(path: string, body?: unknown): Promise<T> =>
+  request<T>(path, { method: "PUT", body });
+
+export const patch = async <T>(path: string, body?: unknown): Promise<T> =>
+  request<T>(path, { method: "PATCH", body });
+
+export const del = async <T>(path: string): Promise<T> => request<T>(path, { method: "DELETE" });

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -1,0 +1,19 @@
+export const endpoints = {
+  status: "/Status",
+  events: "/Events",
+  topics: "/Topic",
+  subscribers: "/Subscriber",
+  subscribersAdd: "/Subscriber/Add",
+  telemetry: "/Telemetry",
+  files: "/File",
+  images: "/Image",
+  clients: "/Client",
+  identities: "/Identities",
+  config: "/Config",
+  configValidate: "/Config/Validate",
+  configRollback: "/Config/Rollback",
+  help: "/Help",
+  examples: "/Examples",
+  command: "/Command",
+  appInfo: "/api/v1/app/info"
+};

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -1,0 +1,86 @@
+export interface StatusResponse {
+  app_info?: {
+    name?: string;
+    version?: string;
+  };
+  clients?: number;
+  topics?: number;
+  subscribers?: number;
+  telemetry?: {
+    total?: number;
+    last_ingest_at?: string;
+  };
+  uptime?: number;
+}
+
+export interface EventEntry {
+  id?: string;
+  created_at?: string;
+  message?: string;
+  level?: string;
+  category?: string;
+}
+
+export interface Topic {
+  id?: string;
+  name?: string;
+  path?: string;
+  description?: string;
+}
+
+export interface Subscriber {
+  id?: string;
+  topic_id?: string;
+  destination?: string;
+  reject_tests?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface FileEntry {
+  id?: string;
+  name?: string;
+  content_type?: string;
+  size?: number;
+  created_at?: string;
+}
+
+export interface IdentityEntry {
+  id?: string;
+  display_name?: string;
+  address?: string;
+  banned?: boolean;
+  blackholed?: boolean;
+}
+
+export interface ClientEntry {
+  id?: string;
+  last_seen_at?: string;
+  identity_id?: string;
+  display_name?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface TelemetryEntry {
+  id?: string;
+  identity_id?: string;
+  identity?: string;
+  identity_label?: string;
+  display_name?: string;
+  topic_id?: string;
+  created_at?: string;
+  location?: {
+    lat?: number;
+    lon?: number;
+    alt?: number;
+  };
+  data?: Record<string, unknown>;
+}
+
+export interface AppInfo {
+  name?: string;
+  version?: string;
+  description?: string;
+  rns_version?: string;
+  lxmf_version?: string;
+  storage_paths?: Record<string, string>;
+}

--- a/ui/src/api/ws.ts
+++ b/ui/src/api/ws.ts
@@ -1,0 +1,84 @@
+import { useConnectionStore } from "../stores/connection";
+
+export interface WsMessage<T = unknown> {
+  type: string;
+  ts: string;
+  data: T;
+}
+
+export type WsHandler = (message: WsMessage) => void;
+
+export class WsClient {
+  private socket: WebSocket | null = null;
+  private readonly url: string;
+  private readonly handler: WsHandler;
+  private readonly onOpen?: () => void;
+  private retryCount = 0;
+  private readonly maxRetry = 5;
+
+  constructor(path: string, handler: WsHandler, onOpen?: () => void) {
+    const connectionStore = useConnectionStore();
+    this.url = connectionStore.resolveWsUrl(path);
+    this.handler = handler;
+    this.onOpen = onOpen;
+  }
+
+  connect(): void {
+    this.socket = new WebSocket(this.url);
+    this.socket.onopen = () => {
+      this.retryCount = 0;
+      this.sendAuth();
+      if (this.onOpen) {
+        this.onOpen();
+      }
+    };
+    this.socket.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data) as WsMessage;
+        if (payload.type === "ping") {
+          this.send({ type: "pong", ts: new Date().toISOString(), data: payload.data });
+        } else {
+          this.handler(payload);
+        }
+      } catch (error) {
+        console.error("Invalid WS payload", error);
+      }
+    };
+    this.socket.onclose = () => {
+      this.scheduleReconnect();
+    };
+  }
+
+  send<T>(message: WsMessage<T>): void {
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      this.socket.send(JSON.stringify(message));
+    }
+  }
+
+  close(): void {
+    this.socket?.close();
+  }
+
+  private sendAuth(): void {
+    const connectionStore = useConnectionStore();
+    this.send({
+      type: "auth",
+      ts: new Date().toISOString(),
+      data: {
+        token: connectionStore.token || undefined,
+        api_key: connectionStore.apiKey || undefined
+      }
+    });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.retryCount >= this.maxRetry) {
+      return;
+    }
+    const delay = Math.min(1000 * 2 ** this.retryCount, 15000);
+    this.retryCount += 1;
+    window.setTimeout(() => {
+      this.connect();
+    }, delay);
+  }
+}

--- a/ui/src/assets/base.css
+++ b/ui/src/assets/base.css
@@ -1,0 +1,17 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.scrollbar-thin {
+  scrollbar-width: thin;
+}

--- a/ui/src/components/AppShell.vue
+++ b/ui/src/components/AppShell.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="flex min-h-screen">
+    <SidebarNav />
+    <div class="flex flex-1 flex-col">
+      <HeaderBar />
+      <ConnectionBanner />
+      <main class="flex-1 overflow-y-auto p-6">
+        <slot />
+      </main>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import ConnectionBanner from "./ConnectionBanner.vue";
+import HeaderBar from "./HeaderBar.vue";
+import SidebarNav from "./SidebarNav.vue";
+</script>

--- a/ui/src/components/BaseBadge.vue
+++ b/ui/src/components/BaseBadge.vue
@@ -1,0 +1,26 @@
+<template>
+  <span class="rounded border border-rth-border px-2 py-1 text-xs font-semibold" :class="badgeClass">
+    <slot />
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = withDefaults(defineProps<{ tone?: "neutral" | "success" | "warning" | "danger" }>(), {
+  tone: "neutral"
+});
+
+const badgeClass = computed(() => {
+  if (props.tone === "success") {
+    return "bg-emerald-500/20 text-emerald-200";
+  }
+  if (props.tone === "warning") {
+    return "bg-amber-500/20 text-amber-200";
+  }
+  if (props.tone === "danger") {
+    return "bg-rose-500/20 text-rose-200";
+  }
+  return "bg-slate-800 text-slate-200";
+});
+</script>

--- a/ui/src/components/BaseButton.vue
+++ b/ui/src/components/BaseButton.vue
@@ -1,0 +1,24 @@
+<template>
+  <button :type="type" class="inline-flex items-center justify-center gap-2 rounded border border-rth-border bg-rth-border px-3 py-2 text-sm font-medium text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50" :class="variantClass">
+    <slot />
+  </button>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = withDefaults(defineProps<{ variant?: "primary" | "secondary" | "ghost"; type?: "button" | "submit" | "reset" }>(), {
+  variant: "primary",
+  type: "button"
+});
+
+const variantClass = computed(() => {
+  if (props.variant === "ghost") {
+    return "bg-transparent border-transparent hover:bg-rth-border";
+  }
+  if (props.variant === "secondary") {
+    return "bg-slate-800";
+  }
+  return "bg-rth-accent text-slate-900 hover:bg-sky-300";
+});
+</script>

--- a/ui/src/components/BaseCard.vue
+++ b/ui/src/components/BaseCard.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="rounded border border-rth-border bg-rth-panel p-4 shadow-sm">
+    <div v-if="title" class="mb-2 text-sm font-semibold text-slate-100">{{ title }}</div>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ title?: string }>();
+</script>

--- a/ui/src/components/BaseDrawer.vue
+++ b/ui/src/components/BaseDrawer.vue
@@ -1,0 +1,18 @@
+<template>
+  <div v-if="open" class="fixed inset-0 z-50 flex justify-end bg-black/60">
+    <div class="h-full w-full max-w-md border-l border-rth-border bg-rth-panel p-6 shadow-lg">
+      <div class="flex items-start justify-between">
+        <h3 class="text-lg font-semibold">{{ title }}</h3>
+        <button class="text-slate-400 hover:text-white" @click="emit('close')">✕</button>
+      </div>
+      <div class="mt-4">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ open: boolean; title: string }>();
+const emit = defineEmits<{ (event: "close"): void }>();
+</script>

--- a/ui/src/components/BaseInput.vue
+++ b/ui/src/components/BaseInput.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="flex flex-col gap-1">
+    <label v-if="label" class="text-xs text-slate-400">{{ label }}</label>
+    <input :type="type" :value="modelValue" class="rounded border border-rth-border bg-slate-900 px-3 py-2 text-sm text-slate-100" @input="onInput" />
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = withDefaults(defineProps<{ label?: string; type?: string; modelValue?: string }>(), {
+  type: "text",
+  modelValue: ""
+});
+
+const emit = defineEmits<{ (event: "update:modelValue", value: string): void }>();
+
+const onInput = (event: Event) => {
+  const target = event.target as HTMLInputElement;
+  emit("update:modelValue", target.value);
+};
+</script>

--- a/ui/src/components/BaseModal.vue
+++ b/ui/src/components/BaseModal.vue
@@ -1,0 +1,18 @@
+<template>
+  <div v-if="open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+    <div class="w-full max-w-xl rounded border border-rth-border bg-rth-panel p-6 shadow-lg">
+      <div class="flex items-start justify-between">
+        <h3 class="text-lg font-semibold">{{ title }}</h3>
+        <button class="text-slate-400 hover:text-white" @click="emit('close')">✕</button>
+      </div>
+      <div class="mt-4">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ open: boolean; title: string }>();
+const emit = defineEmits<{ (event: "close"): void }>();
+</script>

--- a/ui/src/components/BaseSelect.vue
+++ b/ui/src/components/BaseSelect.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="flex flex-col gap-1">
+    <label v-if="label" class="text-xs text-slate-400">{{ label }}</label>
+    <select :value="modelValue" class="rounded border border-rth-border bg-slate-900 px-3 py-2 text-sm text-slate-100" @change="onChange">
+      <option v-for="option in options" :key="option.value" :value="option.value">
+        {{ option.label }}
+      </option>
+    </select>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface OptionItem {
+  label: string;
+  value: string;
+}
+
+const props = defineProps<{ label?: string; options: OptionItem[]; modelValue?: string }>();
+const emit = defineEmits<{ (event: "update:modelValue", value: string): void }>();
+
+const onChange = (event: Event) => {
+  const target = event.target as HTMLSelectElement;
+  emit("update:modelValue", target.value);
+};
+</script>

--- a/ui/src/components/BaseTable.vue
+++ b/ui/src/components/BaseTable.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="overflow-hidden rounded border border-rth-border">
+    <table class="w-full text-left text-sm">
+      <thead class="bg-slate-900 text-xs uppercase text-slate-400">
+        <tr>
+          <th v-for="header in headers" :key="header" class="px-4 py-3">
+            {{ header }}
+          </th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-rth-border">
+        <tr v-for="(row, index) in rows" :key="index" class="bg-rth-panel">
+          <td v-for="cell in row" :key="cell" class="px-4 py-3 text-slate-200">
+            {{ cell }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface TableRow {
+  [key: string]: string | number;
+}
+
+defineProps<{ headers: string[]; rows: Array<Array<string | number> | TableRow> }>();
+</script>

--- a/ui/src/components/BaseToast.vue
+++ b/ui/src/components/BaseToast.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="fixed bottom-6 right-6 z-50 flex flex-col gap-2">
+    <div v-for="toast in toastStore.messages" :key="toast.id" class="rounded border border-rth-border bg-slate-900 px-4 py-2 text-sm shadow" :class="toneClass(toast.tone)">
+      {{ toast.message }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useToastStore } from "../stores/toasts";
+
+const toastStore = useToastStore();
+
+const toneClass = (tone: string) => {
+  if (tone === "success") {
+    return "text-emerald-200";
+  }
+  if (tone === "error") {
+    return "text-rose-200";
+  }
+  if (tone === "warning") {
+    return "text-amber-200";
+  }
+  return "text-slate-200";
+};
+</script>

--- a/ui/src/components/ConnectionBanner.vue
+++ b/ui/src/components/ConnectionBanner.vue
@@ -1,0 +1,15 @@
+<template>
+  <div v-if="showBanner" class="border-b border-rth-border bg-amber-500/10 px-6 py-2 text-sm text-amber-200">
+    <span class="font-semibold">Connection issue:</span> {{ message }}
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useConnectionStore } from "../stores/connection";
+
+const connectionStore = useConnectionStore();
+
+const showBanner = computed(() => connectionStore.status === "offline");
+const message = computed(() => connectionStore.statusMessage || "Unable to reach the hub. Retrying..." );
+</script>

--- a/ui/src/components/HeaderBar.vue
+++ b/ui/src/components/HeaderBar.vue
@@ -1,0 +1,35 @@
+<template>
+  <header class="flex items-center justify-between border-b border-rth-border bg-rth-panel px-6 py-4">
+    <div class="text-lg font-semibold">{{ title }}</div>
+    <div class="flex items-center gap-3 text-xs text-slate-300">
+      <span class="rounded bg-rth-border px-2 py-1">{{ connectionLabel }}</span>
+      <span>{{ baseUrl }}</span>
+    </div>
+  </header>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRoute } from "vue-router";
+import { useConnectionStore } from "../stores/connection";
+
+const route = useRoute();
+const connectionStore = useConnectionStore();
+
+const title = computed(() => {
+  const mapping: Record<string, string> = {
+    "/": "Dashboard",
+    "/webmap": "WebMap",
+    "/topics": "Topics",
+    "/files": "Files",
+    "/users": "Users",
+    "/configure": "Configure",
+    "/about": "About",
+    "/connect": "Connect"
+  };
+  return mapping[route.path] ?? "RTH Core UI";
+});
+
+const baseUrl = computed(() => connectionStore.baseUrlDisplay);
+const connectionLabel = computed(() => connectionStore.statusLabel);
+</script>

--- a/ui/src/components/LoadingSkeleton.vue
+++ b/ui/src/components/LoadingSkeleton.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="animate-pulse space-y-3">
+    <div class="h-4 w-1/3 rounded bg-slate-800"></div>
+    <div class="h-4 w-2/3 rounded bg-slate-800"></div>
+    <div class="h-4 w-full rounded bg-slate-800"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/ui/src/components/SidebarNav.vue
+++ b/ui/src/components/SidebarNav.vue
@@ -1,0 +1,36 @@
+<template>
+  <aside class="flex w-64 flex-col border-r border-rth-border bg-rth-panel p-4">
+    <div class="mb-6 text-lg font-semibold">RTH Core UI</div>
+    <nav class="flex flex-col gap-2 text-sm">
+      <RouterLink v-for="item in navItems" :key="item.to" :to="item.to" class="rounded px-3 py-2 hover:bg-rth-border" :class="route.path === item.to ? 'bg-rth-border text-white' : 'text-slate-300'">
+        {{ item.label }}
+      </RouterLink>
+    </nav>
+    <div class="mt-auto pt-6 text-xs text-slate-400">
+      <div>Build: {{ buildInfo }}</div>
+    </div>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRoute } from "vue-router";
+import { RouterLink } from "vue-router";
+
+const route = useRoute();
+
+const navItems = [
+  { label: "Home", to: "/" },
+  { label: "WebMap", to: "/webmap" },
+  { label: "Topics", to: "/topics" },
+  { label: "Files", to: "/files" },
+  { label: "Users", to: "/users" },
+  { label: "Configure", to: "/configure" },
+  { label: "About", to: "/about" },
+  { label: "Connect", to: "/connect" }
+];
+
+const buildInfo = computed(() => {
+  return import.meta.env.VITE_BUILD_ID ?? "local";
+});
+</script>

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,0 +1,11 @@
+import { createApp } from "vue";
+import { createPinia } from "pinia";
+import App from "./App.vue";
+import router from "./router";
+import "./assets/base.css";
+
+const app = createApp(App);
+
+app.use(createPinia());
+app.use(router);
+app.mount("#app");

--- a/ui/src/pages/AboutPage.vue
+++ b/ui/src/pages/AboutPage.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="space-y-6">
+    <BaseCard title="App Info">
+      <div class="space-y-2 text-sm text-slate-300">
+        <div>Name: {{ appInfo?.name }}</div>
+        <div>Version: {{ appInfo?.version }}</div>
+        <div>Description: {{ appInfo?.description }}</div>
+        <div>RNS: {{ appInfo?.rns_version }}</div>
+        <div>LXMF: {{ appInfo?.lxmf_version }}</div>
+      </div>
+    </BaseCard>
+
+    <BaseCard title="Storage Paths">
+      <div v-if="appInfo?.storage_paths" class="space-y-2 text-sm text-slate-300">
+        <div v-for="(value, key) in appInfo.storage_paths" :key="key">{{ key }}: {{ value }}</div>
+      </div>
+    </BaseCard>
+
+    <BaseCard title="Documentation">
+      <ul class="list-disc space-y-2 pl-5 text-sm text-slate-300">
+        <li><a class="text-sky-300 hover:underline" href="/docs/" target="_blank" rel="noreferrer">Project Docs</a></li>
+        <li><a class="text-sky-300 hover:underline" href="/API/ReticulumTelemetryHub-OAS.yaml" target="_blank" rel="noreferrer">OpenAPI Reference</a></li>
+      </ul>
+    </BaseCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { ref } from "vue";
+import BaseCard from "../components/BaseCard.vue";
+import { endpoints } from "../api/endpoints";
+import { get } from "../api/client";
+import type { AppInfo } from "../api/types";
+
+const appInfo = ref<AppInfo | null>(null);
+
+onMounted(async () => {
+  appInfo.value = await get<AppInfo>(endpoints.appInfo);
+});
+</script>

--- a/ui/src/pages/ConfigurePage.vue
+++ b/ui/src/pages/ConfigurePage.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="space-y-6">
+    <BaseCard title="Configuration">
+      <div class="mb-4 flex flex-wrap gap-2">
+        <BaseButton variant="secondary" @click="configStore.loadConfig">Load</BaseButton>
+        <BaseButton variant="secondary" @click="configStore.validateConfig">Validate</BaseButton>
+        <BaseButton @click="configStore.applyConfig">Apply</BaseButton>
+        <BaseButton variant="ghost" @click="configStore.rollbackConfig">Rollback</BaseButton>
+      </div>
+      <textarea v-model="configStore.configText" class="h-64 w-full rounded border border-rth-border bg-slate-900 p-3 text-xs text-slate-200"></textarea>
+      <div class="mt-4 space-y-3 text-xs text-slate-300">
+        <div v-if="configStore.validation">Validation: {{ configStore.validation }}</div>
+        <div v-if="configStore.applyResult">Apply result: {{ configStore.applyResult }}</div>
+        <div v-if="configStore.rollbackResult">Rollback result: {{ configStore.rollbackResult }}</div>
+      </div>
+    </BaseCard>
+
+    <BaseCard title="Tools">
+      <div class="flex flex-wrap gap-2">
+        <BaseButton variant="secondary" @click="runTool('Ping')">Ping</BaseButton>
+        <BaseButton variant="secondary" @click="runTool('DumpRouting')">Dump Routing</BaseButton>
+        <BaseButton variant="secondary" @click="runTool('ListClients')">List Clients</BaseButton>
+        <BaseButton variant="secondary" @click="loadHelp">Help</BaseButton>
+        <BaseButton variant="secondary" @click="loadExamples">Examples</BaseButton>
+      </div>
+      <pre v-if="toolResponse" class="mt-4 max-h-80 overflow-auto rounded bg-slate-900 p-3 text-xs text-slate-200">{{ toolResponse }}</pre>
+    </BaseCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import BaseButton from "../components/BaseButton.vue";
+import BaseCard from "../components/BaseCard.vue";
+import { endpoints } from "../api/endpoints";
+import { get } from "../api/client";
+import { useConfigStore } from "../stores/config";
+
+const configStore = useConfigStore();
+const toolResponse = ref("");
+
+const runTool = async (command: string) => {
+  toolResponse.value = await get<string>(`${endpoints.command}/${command}`);
+};
+
+const loadHelp = async () => {
+  toolResponse.value = await get<string>(endpoints.help);
+};
+
+const loadExamples = async () => {
+  toolResponse.value = await get<string>(endpoints.examples);
+};
+</script>

--- a/ui/src/pages/ConnectPage.vue
+++ b/ui/src/pages/ConnectPage.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="space-y-6">
+    <BaseCard title="Connection Settings">
+      <div class="grid gap-4 md:grid-cols-2">
+        <BaseInput v-model="connectionStore.baseUrl" label="Base URL" />
+        <BaseInput v-model="connectionStore.wsBaseUrl" label="WebSocket Base URL" />
+        <BaseSelect v-model="connectionStore.authMode" label="Auth Mode" :options="authOptions" />
+        <BaseInput v-model="connectionStore.token" label="Bearer Token" />
+        <BaseInput v-model="connectionStore.apiKey" label="API Key" />
+      </div>
+      <div class="mt-4 flex gap-2">
+        <BaseButton @click="save">Save</BaseButton>
+        <BaseButton variant="secondary" @click="testConnection">Test Connection</BaseButton>
+      </div>
+      <div v-if="testResult" class="mt-3 text-sm text-slate-300">{{ testResult }}</div>
+    </BaseCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import BaseButton from "../components/BaseButton.vue";
+import BaseCard from "../components/BaseCard.vue";
+import BaseInput from "../components/BaseInput.vue";
+import BaseSelect from "../components/BaseSelect.vue";
+import { endpoints } from "../api/endpoints";
+import { get } from "../api/client";
+import { useConnectionStore } from "../stores/connection";
+import { useToastStore } from "../stores/toasts";
+
+const connectionStore = useConnectionStore();
+const toastStore = useToastStore();
+const testResult = ref("");
+
+const authOptions = [
+  { label: "None", value: "none" },
+  { label: "Bearer", value: "bearer" },
+  { label: "API Key", value: "apiKey" },
+  { label: "Both", value: "both" }
+];
+
+const save = () => {
+  connectionStore.persist();
+  toastStore.push("Connection settings saved", "success");
+};
+
+const testConnection = async () => {
+  const appInfo = await get(endpoints.appInfo);
+  const status = await get(endpoints.status);
+  testResult.value = `Connected: ${JSON.stringify(appInfo)} / ${JSON.stringify(status)}`;
+  toastStore.push("Connection successful", "success");
+  connectionStore.setOnline();
+};
+</script>

--- a/ui/src/pages/DashboardPage.vue
+++ b/ui/src/pages/DashboardPage.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="space-y-6">
+    <div class="grid gap-4 md:grid-cols-4">
+      <BaseCard title="Uptime">
+        <div class="text-2xl font-semibold">{{ uptime }}</div>
+      </BaseCard>
+      <BaseCard title="Clients">
+        <div class="text-2xl font-semibold">{{ formatNumber(dashboard.status?.clients) }}</div>
+      </BaseCard>
+      <BaseCard title="Topics">
+        <div class="text-2xl font-semibold">{{ formatNumber(dashboard.status?.topics) }}</div>
+      </BaseCard>
+      <BaseCard title="Subscribers">
+        <div class="text-2xl font-semibold">{{ formatNumber(dashboard.status?.subscribers) }}</div>
+      </BaseCard>
+    </div>
+
+    <BaseCard title="Telemetry">
+      <div class="flex flex-wrap items-center gap-4 text-sm text-slate-300">
+        <div>Total: {{ formatNumber(dashboard.status?.telemetry?.total) }}</div>
+        <div>Last ingest: {{ formatTimestamp(dashboard.status?.telemetry?.last_ingest_at) }}</div>
+        <BaseBadge v-if="isTelemetryStale" tone="warning">Stale</BaseBadge>
+      </div>
+    </BaseCard>
+
+    <BaseCard title="Recent Events">
+      <LoadingSkeleton v-if="dashboard.loading" />
+      <ul v-else class="space-y-2 text-sm text-slate-200">
+        <li v-for="event in dashboard.events" :key="event.id" class="rounded border border-rth-border bg-slate-900 p-3">
+          <div class="flex items-center justify-between">
+            <span class="font-semibold">{{ event.message }}</span>
+            <span class="text-xs text-slate-400">{{ formatTimestamp(event.created_at) }}</span>
+          </div>
+          <div class="mt-1 text-xs text-slate-400">{{ event.category }} · {{ event.level }}</div>
+        </li>
+      </ul>
+    </BaseCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { onMounted } from "vue";
+import BaseBadge from "../components/BaseBadge.vue";
+import BaseCard from "../components/BaseCard.vue";
+import LoadingSkeleton from "../components/LoadingSkeleton.vue";
+import { WsClient } from "../api/ws";
+import { useDashboardStore } from "../stores/dashboard";
+import { formatNumber } from "../utils/format";
+import { formatTimestamp } from "../utils/format";
+
+const dashboard = useDashboardStore();
+
+const uptime = computed(() => {
+  const value = dashboard.status?.uptime;
+  if (!value) {
+    return "-";
+  }
+  const hours = Math.floor(value / 3600);
+  const minutes = Math.floor((value % 3600) / 60);
+  return `${hours}h ${minutes}m`;
+});
+
+const isTelemetryStale = computed(() => {
+  const last = dashboard.status?.telemetry?.last_ingest_at;
+  if (!last) {
+    return false;
+  }
+  const lastDate = new Date(last).getTime();
+  if (Number.isNaN(lastDate)) {
+    return false;
+  }
+  return Date.now() - lastDate > 10 * 60 * 1000;
+});
+
+onMounted(async () => {
+  await dashboard.refresh();
+  const ws = new WsClient("/events/system", (payload) => {
+    if (payload.type === "system.status") {
+      dashboard.updateStatus(payload.data as any);
+    }
+    if (payload.type === "system.event") {
+      dashboard.pushEvent(payload.data as any);
+    }
+  });
+  ws.connect();
+});
+</script>

--- a/ui/src/pages/FilesPage.vue
+++ b/ui/src/pages/FilesPage.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="space-y-6">
+    <BaseCard title="Files">
+      <div class="mb-4 flex gap-3">
+        <BaseButton variant="secondary" @click="filesStore.fetchFiles">Refresh</BaseButton>
+      </div>
+      <LoadingSkeleton v-if="filesStore.loading" />
+      <div v-else class="space-y-3">
+        <div v-for="file in filesStore.files" :key="file.id" class="flex flex-wrap items-center justify-between rounded border border-rth-border bg-slate-900 p-3">
+          <div>
+            <div class="font-semibold">{{ file.name }}</div>
+            <div class="text-xs text-slate-400">{{ file.content_type }} · {{ file.size }} bytes</div>
+          </div>
+          <a class="text-sm text-sky-300 hover:underline" :href="fileUrl(file.id)" target="_blank" rel="noreferrer">Download</a>
+        </div>
+      </div>
+    </BaseCard>
+
+    <BaseCard title="Images">
+      <LoadingSkeleton v-if="filesStore.loading" />
+      <div v-else class="grid gap-3 md:grid-cols-2">
+        <div v-for="image in filesStore.images" :key="image.id" class="rounded border border-rth-border bg-slate-900 p-3">
+          <div class="font-semibold">{{ image.name }}</div>
+          <div class="text-xs text-slate-400">{{ image.content_type }} · {{ image.size }} bytes</div>
+          <div class="mt-3 flex gap-2">
+            <BaseButton variant="secondary" @click="openPreview(image)">Preview</BaseButton>
+            <a class="text-sm text-sky-300 hover:underline" :href="imageUrl(image.id)" target="_blank" rel="noreferrer">Download</a>
+          </div>
+        </div>
+      </div>
+    </BaseCard>
+
+    <BaseModal :open="previewOpen" title="Image Preview" @close="previewOpen = false">
+      <div v-if="previewUrl" class="flex flex-col items-center gap-4">
+        <img :src="previewUrl" class="max-h-[400px] rounded" alt="Preview" />
+        <a class="text-sm text-sky-300 hover:underline" :href="previewUrl" target="_blank" rel="noreferrer">Open raw</a>
+      </div>
+    </BaseModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { ref } from "vue";
+import BaseButton from "../components/BaseButton.vue";
+import BaseCard from "../components/BaseCard.vue";
+import BaseModal from "../components/BaseModal.vue";
+import LoadingSkeleton from "../components/LoadingSkeleton.vue";
+import type { FileEntry } from "../api/types";
+import { useConnectionStore } from "../stores/connection";
+import { useFilesStore } from "../stores/files";
+
+const filesStore = useFilesStore();
+const connectionStore = useConnectionStore();
+const previewOpen = ref(false);
+const previewUrl = ref("");
+
+const fileUrl = (id?: string) => {
+  if (!id) {
+    return "#";
+  }
+  return connectionStore.resolveUrl(filesStore.fileRawUrl(id));
+};
+
+const imageUrl = (id?: string) => {
+  if (!id) {
+    return "#";
+  }
+  return connectionStore.resolveUrl(filesStore.imageRawUrl(id));
+};
+
+const openPreview = (image: FileEntry) => {
+  if (!image.id) {
+    return;
+  }
+  previewUrl.value = imageUrl(image.id);
+  previewOpen.value = true;
+};
+
+onMounted(() => {
+  filesStore.fetchFiles();
+});
+</script>

--- a/ui/src/pages/TopicsPage.vue
+++ b/ui/src/pages/TopicsPage.vue
@@ -1,0 +1,148 @@
+<template>
+  <div class="space-y-6">
+    <BaseCard title="Topics">
+      <div class="mb-4 flex flex-wrap gap-3">
+        <BaseButton @click="openTopicModal(null)">New Topic</BaseButton>
+        <BaseButton variant="secondary" @click="topicsStore.fetchTopics">Refresh</BaseButton>
+      </div>
+      <LoadingSkeleton v-if="topicsStore.loading" />
+      <div v-else class="space-y-3">
+        <div v-for="topic in topicsStore.topics" :key="topic.id" class="flex flex-wrap items-center justify-between rounded border border-rth-border bg-slate-900 p-3">
+          <div>
+            <div class="font-semibold">{{ topic.name }}</div>
+            <div class="text-xs text-slate-400">{{ topic.path }}</div>
+          </div>
+          <div class="flex gap-2">
+            <BaseButton variant="secondary" @click="openTopicModal(topic)">Edit</BaseButton>
+            <BaseButton variant="ghost" @click="removeTopic(topic.id)">Delete</BaseButton>
+          </div>
+        </div>
+      </div>
+    </BaseCard>
+
+    <BaseCard title="Subscribers">
+      <div class="mb-4 flex flex-wrap gap-3">
+        <BaseButton @click="openSubscriberModal(null)">Add Subscriber</BaseButton>
+        <BaseButton variant="secondary" @click="subscribersStore.fetchSubscribers">Refresh</BaseButton>
+      </div>
+      <LoadingSkeleton v-if="subscribersStore.loading" />
+      <div v-else class="space-y-3">
+        <div v-for="subscriber in subscribersStore.subscribers" :key="subscriber.id" class="flex flex-wrap items-center justify-between rounded border border-rth-border bg-slate-900 p-3">
+          <div>
+            <div class="font-semibold">{{ subscriber.destination }}</div>
+            <div class="text-xs text-slate-400">Topic: {{ subscriber.topic_id }}</div>
+          </div>
+          <div class="flex gap-2">
+            <BaseButton variant="secondary" @click="openSubscriberModal(subscriber)">Edit</BaseButton>
+            <BaseButton variant="ghost" @click="removeSubscriber(subscriber.id)">Delete</BaseButton>
+          </div>
+        </div>
+      </div>
+    </BaseCard>
+
+    <BaseModal :open="topicModalOpen" title="Topic" @close="topicModalOpen = false">
+      <div class="space-y-3">
+        <BaseInput v-model="topicDraft.name" label="Name" />
+        <BaseInput v-model="topicDraft.path" label="Path" />
+        <BaseInput v-model="topicDraft.description" label="Description" />
+        <BaseButton @click="saveTopic">Save Topic</BaseButton>
+      </div>
+    </BaseModal>
+
+    <BaseModal :open="subscriberModalOpen" title="Subscriber" @close="subscriberModalOpen = false">
+      <div class="space-y-3">
+        <BaseInput v-model="subscriberDraft.topic_id" label="Topic ID" />
+        <BaseInput v-model="subscriberDraft.destination" label="Destination" />
+        <BaseInput v-model="subscriberDraft.reject_tests" label="Reject Tests (true/false)" />
+        <BaseButton @click="saveSubscriber">Save Subscriber</BaseButton>
+      </div>
+    </BaseModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { ref } from "vue";
+import BaseButton from "../components/BaseButton.vue";
+import BaseCard from "../components/BaseCard.vue";
+import BaseInput from "../components/BaseInput.vue";
+import BaseModal from "../components/BaseModal.vue";
+import LoadingSkeleton from "../components/LoadingSkeleton.vue";
+import type { Subscriber } from "../api/types";
+import type { Topic } from "../api/types";
+import { useSubscribersStore } from "../stores/subscribers";
+import { useTopicsStore } from "../stores/topics";
+import { useToastStore } from "../stores/toasts";
+
+const topicsStore = useTopicsStore();
+const subscribersStore = useSubscribersStore();
+const toastStore = useToastStore();
+
+const topicModalOpen = ref(false);
+const subscriberModalOpen = ref(false);
+const topicDraft = ref<Topic>({ name: "", path: "", description: "" });
+const subscriberDraft = ref<Subscriber>({ topic_id: "", destination: "", reject_tests: false });
+
+const openTopicModal = (topic: Topic | null) => {
+  topicDraft.value = topic ? { ...topic } : { name: "", path: "", description: "" };
+  topicModalOpen.value = true;
+};
+
+const openSubscriberModal = (subscriber: Subscriber | null) => {
+  subscriberDraft.value = subscriber
+    ? { ...subscriber }
+    : { topic_id: "", destination: "", reject_tests: false };
+  subscriberModalOpen.value = true;
+};
+
+const saveTopic = async () => {
+  try {
+    if (topicDraft.value.id) {
+      await topicsStore.updateTopic(topicDraft.value);
+      toastStore.push("Topic updated", "success");
+    } else {
+      await topicsStore.createTopic(topicDraft.value);
+      toastStore.push("Topic created", "success");
+    }
+  } finally {
+    topicModalOpen.value = false;
+  }
+};
+
+const saveSubscriber = async () => {
+  const rejectTests = String(subscriberDraft.value.reject_tests).toLowerCase() === "true";
+  subscriberDraft.value.reject_tests = rejectTests;
+  try {
+    if (subscriberDraft.value.id) {
+      await subscribersStore.updateSubscriber(subscriberDraft.value);
+      toastStore.push("Subscriber updated", "success");
+    } else {
+      await subscribersStore.addSubscriber(subscriberDraft.value);
+      toastStore.push("Subscriber added", "success");
+    }
+  } finally {
+    subscriberModalOpen.value = false;
+  }
+};
+
+const removeTopic = async (id?: string) => {
+  if (!id || !confirm("Delete this topic?")) {
+    return;
+  }
+  await topicsStore.removeTopic(id);
+  toastStore.push("Topic removed", "warning");
+};
+
+const removeSubscriber = async (id?: string) => {
+  if (!id || !confirm("Delete this subscriber?")) {
+    return;
+  }
+  await subscribersStore.removeSubscriber(id);
+  toastStore.push("Subscriber removed", "warning");
+};
+
+onMounted(() => {
+  topicsStore.fetchTopics();
+  subscribersStore.fetchSubscribers();
+});
+</script>

--- a/ui/src/pages/UsersPage.vue
+++ b/ui/src/pages/UsersPage.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="space-y-6">
+    <BaseCard title="Clients">
+      <div class="mb-4 flex gap-3">
+        <BaseButton variant="secondary" @click="usersStore.fetchUsers">Refresh</BaseButton>
+      </div>
+      <LoadingSkeleton v-if="usersStore.loading" />
+      <div v-else class="space-y-3">
+        <div v-for="client in usersStore.clients" :key="client.id" class="rounded border border-rth-border bg-slate-900 p-3">
+          <div class="flex flex-wrap items-center justify-between">
+            <div>
+              <div class="font-semibold">{{ client.display_name || client.id }}</div>
+              <div class="text-xs text-slate-400">Last seen: {{ formatTimestamp(client.last_seen_at) }}</div>
+            </div>
+            <div class="flex gap-2">
+              <BaseButton variant="secondary" @click="actOnClient(client.id, 'Ban')">Ban</BaseButton>
+              <BaseButton variant="secondary" @click="actOnClient(client.id, 'Unban')">Unban</BaseButton>
+              <BaseButton variant="ghost" @click="actOnClient(client.id, 'Blackhole')">Blackhole</BaseButton>
+            </div>
+          </div>
+        </div>
+      </div>
+    </BaseCard>
+
+    <BaseCard title="Identities">
+      <LoadingSkeleton v-if="usersStore.loading" />
+      <div v-else class="grid gap-3 md:grid-cols-2">
+        <div v-for="identity in usersStore.identities" :key="identity.id" class="rounded border border-rth-border bg-slate-900 p-3">
+          <div class="font-semibold">{{ identity.display_name || identity.id }}</div>
+          <div class="text-xs text-slate-400">{{ identity.address }}</div>
+          <div class="mt-2 flex gap-2">
+            <BaseBadge v-if="identity.banned" tone="danger">Banned</BaseBadge>
+            <BaseBadge v-if="identity.blackholed" tone="warning">Blackholed</BaseBadge>
+          </div>
+        </div>
+      </div>
+    </BaseCard>
+
+    <BaseCard title="Routing Snapshot">
+      <BaseButton variant="secondary" @click="loadRouting">Load Routing</BaseButton>
+      <pre v-if="routing" class="mt-3 max-h-80 overflow-auto rounded bg-slate-900 p-3 text-xs text-slate-200">{{ routing }}</pre>
+    </BaseCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { ref } from "vue";
+import BaseBadge from "../components/BaseBadge.vue";
+import BaseButton from "../components/BaseButton.vue";
+import BaseCard from "../components/BaseCard.vue";
+import LoadingSkeleton from "../components/LoadingSkeleton.vue";
+import { endpoints } from "../api/endpoints";
+import { get } from "../api/client";
+import { useUsersStore } from "../stores/users";
+import { useToastStore } from "../stores/toasts";
+import { formatTimestamp } from "../utils/format";
+
+const usersStore = useUsersStore();
+const toastStore = useToastStore();
+const routing = ref("");
+
+const actOnClient = async (clientId?: string, action?: "Ban" | "Unban" | "Blackhole") => {
+  if (!clientId || !action) {
+    return;
+  }
+  await usersStore.actOnClient(clientId, action);
+  toastStore.push(`Client ${action.toLowerCase()} action sent`, "success");
+};
+
+const loadRouting = async () => {
+  routing.value = await get<string>(`${endpoints.command}/DumpRouting`);
+};
+
+onMounted(() => {
+  usersStore.fetchUsers();
+});
+</script>

--- a/ui/src/pages/WebMapPage.vue
+++ b/ui/src/pages/WebMapPage.vue
@@ -1,0 +1,155 @@
+<template>
+  <div class="grid gap-6 lg:grid-cols-[2fr,1fr]">
+    <BaseCard title="Telemetry Map">
+      <div class="mb-4 flex flex-wrap gap-4">
+        <BaseInput v-model="topicFilter" label="Topic ID" />
+        <BaseInput v-model="search" label="Search Identity" />
+        <BaseButton variant="secondary" @click="applyFilters">Apply</BaseButton>
+      </div>
+      <div ref="mapContainer" class="h-[480px] rounded border border-rth-border"></div>
+    </BaseCard>
+
+    <div class="space-y-4">
+      <BaseCard title="Live Markers">
+        <ul class="space-y-2 text-sm">
+          <li v-for="marker in filteredMarkers" :key="marker.id" class="cursor-pointer rounded border border-rth-border bg-slate-900 p-3" @click="selectMarker(marker)">
+            <div class="font-semibold">{{ marker.name }}</div>
+            <div class="text-xs text-slate-400">{{ marker.lat.toFixed(4) }}, {{ marker.lon.toFixed(4) }}</div>
+          </li>
+        </ul>
+      </BaseCard>
+      <BaseCard title="Telemetry Inspector">
+        <div v-if="selected">
+          <div class="text-sm text-slate-300">{{ selected.name }}</div>
+          <pre class="mt-2 max-h-80 overflow-auto rounded bg-slate-900 p-3 text-xs text-slate-200">{{ JSON.stringify(selected.raw, null, 2) }}</pre>
+        </div>
+        <div v-else class="text-sm text-slate-400">Select a marker to inspect telemetry.</div>
+      </BaseCard>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { onMounted } from "vue";
+import { ref } from "vue";
+import maplibregl from "maplibre-gl";
+import BaseButton from "../components/BaseButton.vue";
+import BaseCard from "../components/BaseCard.vue";
+import BaseInput from "../components/BaseInput.vue";
+import { WsClient } from "../api/ws";
+import { useTelemetryStore } from "../stores/telemetry";
+import type { TelemetryMarker } from "../utils/telemetry";
+
+const telemetry = useTelemetryStore();
+const mapContainer = ref<HTMLDivElement | null>(null);
+const mapInstance = ref<maplibregl.Map | null>(null);
+const search = ref("");
+const topicFilter = ref("");
+const selected = ref<TelemetryMarker | null>(null);
+
+const filteredMarkers = computed(() => {
+  const query = search.value.toLowerCase();
+  return telemetry.markers.filter((marker) => {
+    if (query && !marker.name.toLowerCase().includes(query)) {
+      return false;
+    }
+    return true;
+  });
+});
+
+const applyFilters = async () => {
+  telemetry.topicId = topicFilter.value;
+  await telemetry.fetchTelemetry(Math.floor(Date.now() / 1000) - 3600);
+  renderMarkers();
+};
+
+const selectMarker = (marker: TelemetryMarker) => {
+  selected.value = marker;
+  if (mapInstance.value) {
+    mapInstance.value.flyTo({ center: [marker.lon, marker.lat], zoom: 9 });
+  }
+};
+
+const renderMarkers = () => {
+  if (!mapInstance.value) {
+    return;
+  }
+  const map = mapInstance.value;
+  const existing = map.getSource("telemetry") as maplibregl.GeoJSONSource | undefined;
+  const featureCollection = {
+    type: "FeatureCollection",
+    features: telemetry.markers.map((marker) => ({
+      type: "Feature",
+      geometry: {
+        type: "Point",
+        coordinates: [marker.lon, marker.lat]
+      },
+      properties: {
+        id: marker.id,
+        name: marker.name
+      }
+    }))
+  } as GeoJSON.FeatureCollection;
+
+  if (existing) {
+    existing.setData(featureCollection);
+    return;
+  }
+
+  map.addSource("telemetry", {
+    type: "geojson",
+    data: featureCollection
+  });
+  map.addLayer({
+    id: "telemetry-points",
+    type: "circle",
+    source: "telemetry",
+    paint: {
+      "circle-radius": 6,
+      "circle-color": "#38bdf8",
+      "circle-stroke-color": "#0f172a",
+      "circle-stroke-width": 2
+    }
+  });
+};
+
+onMounted(async () => {
+  if (mapContainer.value) {
+    mapInstance.value = new maplibregl.Map({
+      container: mapContainer.value,
+      style: "https://demotiles.maplibre.org/style.json",
+      center: [0, 0],
+      zoom: 1
+    });
+  }
+  await telemetry.fetchTelemetry(Math.floor(Date.now() / 1000) - 3600);
+  renderMarkers();
+
+  const ws = new WsClient(
+    "/telemetry/stream",
+    (payload) => {
+    if (payload.type === "telemetry.snapshot") {
+      telemetry.applySnapshot((payload.data as any).entries ?? []);
+      renderMarkers();
+    }
+    if (payload.type === "telemetry.update") {
+      telemetry.applyUpdate((payload.data as any).entry);
+      renderMarkers();
+    }
+    },
+    () => {
+      ws.send({
+        type: "telemetry.subscribe",
+        ts: new Date().toISOString(),
+        data: {
+          since: Math.floor(Date.now() / 1000) - 3600,
+          topic_id: telemetry.topicId || undefined,
+          follow: true
+        }
+      });
+    }
+  );
+  ws.connect();
+});
+</script>

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -1,0 +1,26 @@
+import { createRouter } from "vue-router";
+import { createWebHistory } from "vue-router";
+import AboutPage from "../pages/AboutPage.vue";
+import ConfigurePage from "../pages/ConfigurePage.vue";
+import ConnectPage from "../pages/ConnectPage.vue";
+import DashboardPage from "../pages/DashboardPage.vue";
+import FilesPage from "../pages/FilesPage.vue";
+import TopicsPage from "../pages/TopicsPage.vue";
+import UsersPage from "../pages/UsersPage.vue";
+import WebMapPage from "../pages/WebMapPage.vue";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: "/", name: "dashboard", component: DashboardPage },
+    { path: "/webmap", name: "webmap", component: WebMapPage },
+    { path: "/topics", name: "topics", component: TopicsPage },
+    { path: "/files", name: "files", component: FilesPage },
+    { path: "/users", name: "users", component: UsersPage },
+    { path: "/configure", name: "configure", component: ConfigurePage },
+    { path: "/about", name: "about", component: AboutPage },
+    { path: "/connect", name: "connect", component: ConnectPage }
+  ]
+});
+
+export default router;

--- a/ui/src/stores/config.ts
+++ b/ui/src/stores/config.ts
@@ -1,0 +1,47 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import { endpoints } from "../api/endpoints";
+import { get } from "../api/client";
+import { post } from "../api/client";
+import { put } from "../api/client";
+
+export const useConfigStore = defineStore("config", () => {
+  const configText = ref("");
+  const validation = ref<unknown>(null);
+  const applyResult = ref<unknown>(null);
+  const rollbackResult = ref<unknown>(null);
+  const loading = ref(false);
+
+  const loadConfig = async () => {
+    loading.value = true;
+    try {
+      configText.value = await get<string>(endpoints.config);
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const validateConfig = async () => {
+    validation.value = await post<unknown>(endpoints.configValidate, { config: configText.value });
+  };
+
+  const applyConfig = async () => {
+    applyResult.value = await put<unknown>(endpoints.config, { config: configText.value });
+  };
+
+  const rollbackConfig = async () => {
+    rollbackResult.value = await post<unknown>(endpoints.configRollback);
+  };
+
+  return {
+    configText,
+    validation,
+    applyResult,
+    rollbackResult,
+    loading,
+    loadConfig,
+    validateConfig,
+    applyConfig,
+    rollbackConfig
+  };
+});

--- a/ui/src/stores/connection.ts
+++ b/ui/src/stores/connection.ts
@@ -1,0 +1,107 @@
+import { computed } from "vue";
+import { ref } from "vue";
+import { defineStore } from "pinia";
+import { loadJson } from "../utils/storage";
+import { saveJson } from "../utils/storage";
+
+export type AuthMode = "none" | "bearer" | "apiKey" | "both";
+export type ConnectionStatus = "online" | "offline" | "unknown";
+
+interface ConnectionState {
+  baseUrl: string;
+  wsBaseUrl?: string;
+  authMode: AuthMode;
+  token: string;
+  apiKey: string;
+}
+
+const STORAGE_KEY = "rth-ui-connection";
+
+export const useConnectionStore = defineStore("connection", () => {
+  const stored = loadJson<ConnectionState>(STORAGE_KEY, {
+    baseUrl: import.meta.env.VITE_RTH_BASE_URL ?? "",
+    wsBaseUrl: import.meta.env.VITE_RTH_WS_BASE_URL ?? "",
+    authMode: "none",
+    token: "",
+    apiKey: ""
+  });
+
+  const baseUrl = ref<string>(stored.baseUrl ?? "");
+  const wsBaseUrl = ref<string>(stored.wsBaseUrl ?? "");
+  const authMode = ref<AuthMode>(stored.authMode ?? "none");
+  const token = ref<string>(stored.token ?? "");
+  const apiKey = ref<string>(stored.apiKey ?? "");
+  const status = ref<ConnectionStatus>("unknown");
+  const statusMessage = ref<string>("");
+
+  const resolveUrl = (path: string): string => {
+    const origin = baseUrl.value || window.location.origin;
+    return `${origin}${path}`;
+  };
+
+  const resolveWsUrl = (path: string): string => {
+    if (wsBaseUrl.value) {
+      return `${wsBaseUrl.value}${path}`;
+    }
+    const origin = baseUrl.value || window.location.origin;
+    const scheme = origin.startsWith("https") ? "wss" : "ws";
+    const host = origin.replace(/^https?:\/\//, "");
+    return `${scheme}://${host}${path}`;
+  };
+
+  const authHeader = computed(() => {
+    if (authMode.value === "bearer" || authMode.value === "both") {
+      return token.value ? `Bearer ${token.value}` : "";
+    }
+    return "";
+  });
+
+  const baseUrlDisplay = computed(() => baseUrl.value || "(same origin)");
+  const statusLabel = computed(() => {
+    if (status.value === "online") {
+      return "Online";
+    }
+    if (status.value === "offline") {
+      return "Offline";
+    }
+    return "Unknown";
+  });
+
+  const setOffline = (message: string) => {
+    status.value = "offline";
+    statusMessage.value = message;
+  };
+
+  const setOnline = () => {
+    status.value = "online";
+    statusMessage.value = "";
+  };
+
+  const persist = () => {
+    saveJson(STORAGE_KEY, {
+      baseUrl: baseUrl.value,
+      wsBaseUrl: wsBaseUrl.value,
+      authMode: authMode.value,
+      token: token.value,
+      apiKey: apiKey.value
+    });
+  };
+
+  return {
+    baseUrl,
+    wsBaseUrl,
+    authMode,
+    token,
+    apiKey,
+    status,
+    statusMessage,
+    resolveUrl,
+    resolveWsUrl,
+    authHeader,
+    baseUrlDisplay,
+    statusLabel,
+    setOffline,
+    setOnline,
+    persist
+  };
+});

--- a/ui/src/stores/dashboard.ts
+++ b/ui/src/stores/dashboard.ts
@@ -1,0 +1,42 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import { endpoints } from "../api/endpoints";
+import { get } from "../api/client";
+import type { EventEntry } from "../api/types";
+import type { StatusResponse } from "../api/types";
+import { useConnectionStore } from "./connection";
+
+export const useDashboardStore = defineStore("dashboard", () => {
+  const status = ref<StatusResponse | null>(null);
+  const events = ref<EventEntry[]>([]);
+  const loading = ref(false);
+
+  const refresh = async () => {
+    loading.value = true;
+    const connectionStore = useConnectionStore();
+    try {
+      status.value = await get<StatusResponse>(endpoints.status);
+      events.value = await get<EventEntry[]>(endpoints.events);
+      connectionStore.setOnline();
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const pushEvent = (event: EventEntry) => {
+    events.value = [event, ...events.value].slice(0, 50);
+  };
+
+  const updateStatus = (payload: StatusResponse) => {
+    status.value = payload;
+  };
+
+  return {
+    status,
+    events,
+    loading,
+    refresh,
+    pushEvent,
+    updateStatus
+  };
+});

--- a/ui/src/stores/files.ts
+++ b/ui/src/stores/files.ts
@@ -1,0 +1,33 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import { endpoints } from "../api/endpoints";
+import { get } from "../api/client";
+import type { FileEntry } from "../api/types";
+
+export const useFilesStore = defineStore("files", () => {
+  const files = ref<FileEntry[]>([]);
+  const images = ref<FileEntry[]>([]);
+  const loading = ref(false);
+
+  const fetchFiles = async () => {
+    loading.value = true;
+    try {
+      files.value = await get<FileEntry[]>(endpoints.files);
+      images.value = await get<FileEntry[]>(endpoints.images);
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const fileRawUrl = (id: string) => `${endpoints.files}/${id}/raw`;
+  const imageRawUrl = (id: string) => `${endpoints.images}/${id}/raw`;
+
+  return {
+    files,
+    images,
+    loading,
+    fetchFiles,
+    fileRawUrl,
+    imageRawUrl
+  };
+});

--- a/ui/src/stores/subscribers.ts
+++ b/ui/src/stores/subscribers.ts
@@ -1,0 +1,51 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import { endpoints } from "../api/endpoints";
+import { del } from "../api/client";
+import { get } from "../api/client";
+import { patch } from "../api/client";
+import { post } from "../api/client";
+import type { Subscriber } from "../api/types";
+
+export const useSubscribersStore = defineStore("subscribers", () => {
+  const subscribers = ref<Subscriber[]>([]);
+  const loading = ref(false);
+
+  const fetchSubscribers = async () => {
+    loading.value = true;
+    try {
+      subscribers.value = await get<Subscriber[]>(endpoints.subscribers);
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const addSubscriber = async (payload: Subscriber) => {
+    const created = await post<Subscriber>(endpoints.subscribersAdd, payload);
+    subscribers.value = [...subscribers.value, created];
+  };
+
+  const updateSubscriber = async (payload: Subscriber) => {
+    if (!payload.id) {
+      return;
+    }
+    const updated = await patch<Subscriber>(`${endpoints.subscribers}?id=${payload.id}`, payload);
+    subscribers.value = subscribers.value.map((subscriber) =>
+      subscriber.id === payload.id ? updated : subscriber
+    );
+  };
+
+  const removeSubscriber = async (id: string) => {
+    await del<void>(`${endpoints.subscribers}?id=${id}`);
+    subscribers.value = subscribers.value.filter((subscriber) => subscriber.id !== id);
+  };
+
+  return {
+    subscribers,
+    loading,
+    fetchSubscribers,
+    addSubscriber,
+    updateSubscriber,
+    removeSubscriber
+  };
+});

--- a/ui/src/stores/telemetry.ts
+++ b/ui/src/stores/telemetry.ts
@@ -1,0 +1,47 @@
+import { defineStore } from "pinia";
+import { computed } from "vue";
+import { ref } from "vue";
+import { endpoints } from "../api/endpoints";
+import { get } from "../api/client";
+import type { TelemetryEntry } from "../api/types";
+import { deriveMarkers } from "../utils/telemetry";
+import type { TelemetryMarker } from "../utils/telemetry";
+
+export const useTelemetryStore = defineStore("telemetry", () => {
+  const entries = ref<TelemetryEntry[]>([]);
+  const loading = ref(false);
+  const topicId = ref<string>("");
+
+  const markers = computed<TelemetryMarker[]>(() => deriveMarkers(entries.value));
+
+  const fetchTelemetry = async (since: number) => {
+    loading.value = true;
+    const params = new URLSearchParams({ since: String(since) });
+    if (topicId.value) {
+      params.set("topic_id", topicId.value);
+    }
+    try {
+      entries.value = await get<TelemetryEntry[]>(`${endpoints.telemetry}?${params.toString()}`);
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const applySnapshot = (snapshot: TelemetryEntry[]) => {
+    entries.value = snapshot;
+  };
+
+  const applyUpdate = (entry: TelemetryEntry) => {
+    entries.value = [entry, ...entries.value.filter((item) => item.id !== entry.id)].slice(0, 200);
+  };
+
+  return {
+    entries,
+    loading,
+    topicId,
+    markers,
+    fetchTelemetry,
+    applySnapshot,
+    applyUpdate
+  };
+});

--- a/ui/src/stores/toasts.ts
+++ b/ui/src/stores/toasts.ts
@@ -1,0 +1,25 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+export interface ToastMessage {
+  id: string;
+  message: string;
+  tone: "success" | "error" | "warning" | "info";
+}
+
+export const useToastStore = defineStore("toast", () => {
+  const messages = ref<ToastMessage[]>([]);
+
+  const push = (message: string, tone: ToastMessage["tone"] = "info") => {
+    const id = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    messages.value = [...messages.value, { id, message, tone }];
+    setTimeout(() => {
+      messages.value = messages.value.filter((item) => item.id !== id);
+    }, 5000);
+  };
+
+  return {
+    messages,
+    push
+  };
+});

--- a/ui/src/stores/topics.ts
+++ b/ui/src/stores/topics.ts
@@ -1,0 +1,49 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import { endpoints } from "../api/endpoints";
+import { del } from "../api/client";
+import { get } from "../api/client";
+import { patch } from "../api/client";
+import { post } from "../api/client";
+import type { Topic } from "../api/types";
+
+export const useTopicsStore = defineStore("topics", () => {
+  const topics = ref<Topic[]>([]);
+  const loading = ref(false);
+
+  const fetchTopics = async () => {
+    loading.value = true;
+    try {
+      topics.value = await get<Topic[]>(endpoints.topics);
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const createTopic = async (payload: Topic) => {
+    const created = await post<Topic>(endpoints.topics, payload);
+    topics.value = [...topics.value, created];
+  };
+
+  const updateTopic = async (payload: Topic) => {
+    if (!payload.id) {
+      return;
+    }
+    const updated = await patch<Topic>(`${endpoints.topics}?id=${payload.id}`, payload);
+    topics.value = topics.value.map((topic) => (topic.id === payload.id ? updated : topic));
+  };
+
+  const removeTopic = async (id: string) => {
+    await del<void>(`${endpoints.topics}?id=${id}`);
+    topics.value = topics.value.filter((topic) => topic.id !== id);
+  };
+
+  return {
+    topics,
+    loading,
+    fetchTopics,
+    createTopic,
+    updateTopic,
+    removeTopic
+  };
+});

--- a/ui/src/stores/users.ts
+++ b/ui/src/stores/users.ts
@@ -1,0 +1,35 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import { endpoints } from "../api/endpoints";
+import { get } from "../api/client";
+import { post } from "../api/client";
+import type { ClientEntry } from "../api/types";
+import type { IdentityEntry } from "../api/types";
+
+export const useUsersStore = defineStore("users", () => {
+  const clients = ref<ClientEntry[]>([]);
+  const identities = ref<IdentityEntry[]>([]);
+  const loading = ref(false);
+
+  const fetchUsers = async () => {
+    loading.value = true;
+    try {
+      clients.value = await get<ClientEntry[]>(endpoints.clients);
+      identities.value = await get<IdentityEntry[]>(endpoints.identities);
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const actOnClient = async (clientId: string, action: "Ban" | "Unban" | "Blackhole") => {
+    await post<void>(`${endpoints.clients}/${clientId}/${action}`);
+  };
+
+  return {
+    clients,
+    identities,
+    loading,
+    fetchUsers,
+    actOnClient
+  };
+});

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -1,0 +1,17 @@
+export const formatTimestamp = (value?: string | number | null): string => {
+  if (!value) {
+    return "-";
+  }
+  const date = typeof value === "number" ? new Date(value * 1000) : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "-";
+  }
+  return date.toLocaleString();
+};
+
+export const formatNumber = (value?: number | null): string => {
+  if (value === undefined || value === null) {
+    return "-";
+  }
+  return new Intl.NumberFormat().format(value);
+};

--- a/ui/src/utils/storage.ts
+++ b/ui/src/utils/storage.ts
@@ -1,0 +1,15 @@
+export const loadJson = <T>(key: string, fallback: T): T => {
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) {
+      return fallback;
+    }
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    return fallback;
+  }
+};
+
+export const saveJson = (key: string, value: unknown): void => {
+  window.localStorage.setItem(key, JSON.stringify(value));
+};

--- a/ui/src/utils/telemetry.ts
+++ b/ui/src/utils/telemetry.ts
@@ -1,0 +1,25 @@
+import type { TelemetryEntry } from "../api/types";
+
+export interface TelemetryMarker {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  updatedAt?: string;
+  topicId?: string;
+  raw: TelemetryEntry;
+}
+
+export const deriveMarkers = (entries: TelemetryEntry[]): TelemetryMarker[] => {
+  return entries
+    .filter((entry) => entry.location?.lat !== undefined && entry.location?.lon !== undefined)
+    .map((entry) => ({
+      id: entry.identity_id ?? entry.identity ?? "unknown",
+      name: entry.display_name ?? entry.identity_label ?? "Unknown",
+      lat: entry.location?.lat ?? 0,
+      lon: entry.location?.lon ?? 0,
+      updatedAt: entry.created_at,
+      topicId: entry.topic_id,
+      raw: entry
+    }));
+};

--- a/ui/tailwind.config.cjs
+++ b/ui/tailwind.config.cjs
@@ -1,0 +1,17 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./index.html", "./src/**/*.{vue,ts}"] ,
+  darkMode: "class",
+  theme: {
+    extend: {
+      colors: {
+        "rth-bg": "#0b1120",
+        "rth-panel": "#111827",
+        "rth-border": "#1f2937",
+        "rth-accent": "#38bdf8",
+        "rth-text": "#e5e7eb"
+      }
+    }
+  },
+  plugins: []
+};

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    port: 5173,
+    strictPort: true
+  }
+});


### PR DESCRIPTION
### Motivation

- Provide a first-class administrative UI that implements the design and WebSocket/REST contracts described in `docs/ui-design.md` and `docs/ui-wireframe.md`.
- Offer an embedded or external SPA to manage topics, subscribers, telemetry, files/images, clients/identities, and configuration.
- Make the UI easy to run locally for development and to serve as a static embedded frontend from the hub.

### Description

- Scaffold a Vue 3 + Vite + TypeScript app under `ui/` with Tailwind, Pinia, routing, and base UI components (buttons, cards, modals, toasts, skeletons). 
- Add typed REST client (`ui/src/api/client.ts`), a WebSocket wrapper (`ui/src/api/ws.ts`), API endpoint/types (`ui/src/api/*`), Pinia stores for connection/dashboard/topics/subscribers/files/users/config/telemetry/toasts, and telemetry marker helpers (`ui/src/utils/*`).
- Implement pages for Dashboard, WebMap (MapLibre), Topics (with subscribers), Files/Images, Users, Configure (tools), About, and Connect, wired to the API and WS streams; also add UI router and app shell components.
- Adjust project metadata and docs by bumping the package version in `pyproject.toml` to `0.100.0`, adding `ui/` docs to `README.md`, updating `TASK.md`, and adding UI ignores to `.gitignore`.

### Testing

- Ran `cd ui && npm install` (resolved an `@types/maplibre-gl` version mismatch and reinstalled) and the install completed successfully.
- Started the dev server with `npm run dev` and Vite reported the app served locally (visible at the printed Local/Network URLs).
- Performed an automated browser smoke check using Playwright that loaded `http://127.0.0.1:4173/` and produced a screenshot at `artifacts/rth-ui-dashboard.png`.
- No unit tests for the UI were added in this change (no Python/pytest runs were executed as part of this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964153d9be48325a8ac88d78722e03f)