### PR TITLE
Add northbound file/image route tests and bump version to 0.109.0

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -1,4 +1,5 @@
 ﻿# TASKS
+- 2026-01-12: ✅ Add northbound file/image route tests and bump version.
 - 2026-01-12: ✅ Create venv_linux for running tests.
 - 2026-01-13: ✅ Address websocket broadcaster test coverage and sync execution.
 - 2026-01-13: ✅ Fix northbound websocket topic filtering and event dispatch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.108.0"
+version = "0.109.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"

--- a/tests/northbound/test_file_routes.py
+++ b/tests/northbound/test_file_routes.py
@@ -1,0 +1,106 @@
+"""Tests for file/image routes in the northbound API."""
+# pylint: disable=import-error
+
+from pathlib import Path
+from typing import Tuple
+
+from fastapi.testclient import TestClient
+
+from reticulum_telemetry_hub.api import ReticulumTelemetryHubAPI
+from reticulum_telemetry_hub.lxmf_telemetry.telemetry_controller import (
+    TelemetryController,
+)
+from reticulum_telemetry_hub.northbound.app import create_app
+from tests.test_rth_api import make_config_manager
+
+
+def _build_client(tmp_path: Path) -> Tuple[TestClient, ReticulumTelemetryHubAPI]:
+    """Create a TestClient with a configured API instance.
+
+    Args:
+        tmp_path (Path): Temporary directory for test storage.
+
+    Returns:
+        Tuple[TestClient, ReticulumTelemetryHubAPI]: Client and API instance.
+    """
+
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+    app = create_app(
+        api=api,
+        telemetry_controller=TelemetryController(db_path=tmp_path / "telemetry.db", api=api),
+    )
+    return TestClient(app), api
+
+
+def test_file_routes_return_empty_lists(tmp_path: Path) -> None:
+    """Ensure empty file and image lists return empty payloads."""
+
+    client, _ = _build_client(tmp_path)
+
+    file_response = client.get("/File")
+    image_response = client.get("/Image")
+
+    assert file_response.status_code == 200
+    assert image_response.status_code == 200
+    assert file_response.json() == []
+    assert image_response.json() == []
+
+
+def test_file_routes_return_metadata(tmp_path: Path) -> None:
+    """Verify file and image metadata routes return stored attachments."""
+
+    client, api = _build_client(tmp_path)
+    file_path = api._config_manager.config.file_storage_path / "note.txt"  # pylint: disable=protected-access
+    file_path.write_text("hello")
+    file_record = api.store_file(file_path, media_type="text/plain")
+    image_path = api._config_manager.config.image_storage_path / "photo.jpg"  # pylint: disable=protected-access
+    image_path.write_bytes(b"img")
+    image_record = api.store_image(image_path, media_type="image/jpeg")
+
+    file_response = client.get(f"/File/{file_record.file_id}")
+    image_response = client.get(f"/Image/{image_record.file_id}")
+
+    assert file_response.status_code == 200
+    assert image_response.status_code == 200
+    assert file_response.json()["FileID"] == file_record.file_id
+    assert file_response.json()["MediaType"] == "text/plain"
+    assert image_response.json()["FileID"] == image_record.file_id
+    assert image_response.json()["MediaType"] == "image/jpeg"
+
+
+def test_file_routes_return_raw_bytes(tmp_path: Path) -> None:
+    """Ensure raw routes return file bytes and media types."""
+
+    client, api = _build_client(tmp_path)
+    file_path = api._config_manager.config.file_storage_path / "note.txt"  # pylint: disable=protected-access
+    file_path.write_bytes(b"payload")
+    file_record = api.store_file(file_path, media_type="text/plain")
+    image_path = api._config_manager.config.image_storage_path / "photo.jpg"  # pylint: disable=protected-access
+    image_path.write_bytes(b"binary")
+    image_record = api.store_image(image_path, media_type="image/jpeg")
+
+    file_response = client.get(f"/File/{file_record.file_id}/raw")
+    image_response = client.get(f"/Image/{image_record.file_id}/raw")
+
+    assert file_response.status_code == 200
+    assert image_response.status_code == 200
+    assert file_response.content == b"payload"
+    assert image_response.content == b"binary"
+    assert "text/plain" in file_response.headers["content-type"]
+    assert "image/jpeg" in image_response.headers["content-type"]
+
+
+def test_file_routes_missing_entries_return_404(tmp_path: Path) -> None:
+    """Validate missing file and image lookups return 404 errors."""
+
+    client, _ = _build_client(tmp_path)
+
+    file_response = client.get("/File/999")
+    image_response = client.get("/Image/999")
+    file_raw_response = client.get("/File/999/raw")
+    image_raw_response = client.get("/Image/999/raw")
+
+    assert file_response.status_code == 404
+    assert image_response.status_code == 404
+    assert file_raw_response.status_code == 404
+    assert image_raw_response.status_code == 404


### PR DESCRIPTION
### Motivation

- Improve test coverage for the northbound file and image endpoints to meet the project coverage requirements.  
- Verify that list, metadata, and raw byte routes behave correctly and return proper 404s for missing entries.  
- Keep package metadata consistent by bumping the project version for the change and recording the task completion.  

### Description

- Add `tests/northbound/test_file_routes.py` with tests for empty lists, metadata retrieval, raw bytes, and missing-record 404s.  
- Update test assertions to match the API's `FileAttachment.to_dict()` keys (`FileID`, `MediaType`) and exercise the `/raw` endpoints.  
- Bump `version` in `pyproject.toml` to `0.109.0`.  
- Record the completed work in `TASK.md` with a new entry for the file/image route tests and version bump.  

### Testing

- Ran `ruff check .` and lint checks passed.  
- Ran `pytest --cov --cov-report=term-missing` and all tests succeeded (286 passed) with total coverage `93.94%`, exceeding the required `90%`.  
- The test run produced warnings only (no failures) related to Pydantic deprecation and third-party library notices.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696531abf7f88325b4826c1529095aab)