### PR TITLE
Add Codex auto-fix workflow for Python application CI

### DIFF
--- a/.github/codex/prompts/autofix-ci.md
+++ b/.github/codex/prompts/autofix-ci.md
@@ -1,0 +1,10 @@
+You are an automated fix agent for this repository.
+
+Goal:
+- Fix failures from the "Python application" workflow (ruff + pytest).
+
+Constraints:
+- Prefer minimal, targeted changes.
+- Preserve existing behavior unless required by tests or lint.
+- Keep files under 500 lines.
+- Use Python 3.10-compatible syntax.

--- a/.github/workflows/codex-auto-fix.yml
+++ b/.github/workflows/codex-auto-fix.yml
@@ -1,0 +1,80 @@
+name: Codex Auto-Fix on Failure
+
+on:
+  workflow_run:
+    workflows:
+      - "Python application"
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-fix-ci:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      !startsWith(github.event.workflow_run.head_branch, 'codex/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      FAILED_WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+      FAILED_RUN_URL: ${{ github.event.workflow_run.html_url }}
+      FAILED_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      FAILED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Checkout failing ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.FAILED_HEAD_SHA }}
+          fetch-depth: 0
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install ruff pytest pytest-cov
+
+      - name: Skip if OpenAI API Key missing
+        if: ${{ env.OPENAI_API_KEY == '' }}
+        run: echo "OPENAI_API_KEY is not available (likely a fork PR). Skipping Codex auto-fix."
+
+      - name: Run Codex
+        if: ${{ env.OPENAI_API_KEY != '' }}
+        uses: openai/codex-action@v1
+        id: codex
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt-file: .github/codex/prompts/autofix-ci.md
+          sandbox: workspace-write
+
+      - name: Verify ruff
+        if: ${{ env.OPENAI_API_KEY != '' }}
+        run: |
+          ruff check .
+
+      - name: Verify tests
+        if: ${{ env.OPENAI_API_KEY != '' }}
+        run: |
+          pytest
+
+      - name: Create pull request with fixes
+        if: ${{ success() && env.OPENAI_API_KEY != '' }}
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "fix(ci): auto-fix failing tests via Codex"
+          branch: codex/auto-fix-ci-${{ github.event.workflow_run.run_id }}
+          base: ${{ env.FAILED_HEAD_BRANCH }}
+          title: "Auto-fix failing CI via Codex"
+          body: |
+            Codex automatically generated this PR in response to a CI failure on workflow `${{ env.FAILED_WORKFLOW_NAME }}`.
+            Failed run: ${{ env.FAILED_RUN_URL }}
+            Head branch: `${{ env.FAILED_HEAD_BRANCH }}`
+            This PR contains minimal changes intended solely to make the CI pass.

--- a/TASK.md
+++ b/TASK.md
@@ -1,4 +1,5 @@
 ﻿# TASKS
+- 2026-01-12: ✅ Adjust Codex auto-fix workflow to match repository CI.
 - 2026-01-12: ✅ Add northbound file/image route tests and bump version.
 - 2026-01-12: ✅ Create venv_linux for running tests.
 - 2026-01-13: ✅ Address websocket broadcaster test coverage and sync execution.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ReticulumTelemetryHub"
-version = "0.109.0"
+version = "0.110.0"
 description = "Reticulum-Telemetry-Hub (RTH) manages a complete TCP node across a Reticulum-based network, enabling communication and data sharing between clients like Sideband or Meshchat."
 authors = ["naman108, corvo"]
 readme = "README.md"


### PR DESCRIPTION
### Motivation
- Provide an automated way to generate minimal fixes when the repository CI (`Python application`) fails.  
- Allow an AI-driven agent to propose targeted changes that make `ruff` and `pytest` pass so maintainers can review them quickly.  
- Align the auto-fix workflow with this repository's existing CI layout and tooling (Python 3.10, `ruff`, `pytest`).  

### Description
- Add a new workflow file at `.github/workflows/codex-auto-fix.yml` that triggers on completed `workflow_run` events for the `Python application` workflow and runs only for failed PR runs.  
- The workflow checks out the failing ref, sets up `Python 3.10`, installs project dependencies and lint/test tools, invokes `openai/codex-action@v1` with a repository-specific prompt, runs `ruff check .` and `pytest`, and creates a fix PR using `peter-evans/create-pull-request@v8`.  
- Add the Codex prompt at `.github/codex/prompts/autofix-ci.md` tailored to focusing on minimal, behavior-preserving fixes for `ruff` and `pytest` failures.  
- Bump package version in `pyproject.toml` to `0.110.0` and record the task in `TASK.md`.

### Testing
- No automated tests were executed as part of this change because it is a workflow-only update.  
- The workflow is configured to run in GitHub Actions when the `Python application` workflow completes and would run its own lint/test steps (`ruff` and `pytest`) when triggered.  
- Creating the PR was not exercised in this environment and requires an actual failing `workflow_run` plus a configured `OPENAI_API_KEY` secret to exercise end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654145119883259506d337fcf75914)