### PR TITLE
Add northbound message bridge for LXMF traffic

### DIFF
--- a/API/ReticulumTelemetryHub-OAS.yaml
+++ b/API/ReticulumTelemetryHub-OAS.yaml
@@ -141,6 +141,34 @@ paths:
       responses:
         '101':
           description: Switching Protocols (WebSocket upgrade).
+  /messages/stream:
+    get:
+      x-scope: protected
+      x-websocket: true
+      tags:
+       - WebSocket
+      summary: WebSocket stream for inbound/outbound messages.
+      security:
+        - bearerAuth: []
+        - apiKeyAuth: []
+      description: >-
+        WebSocket endpoint using the RTH-WS v1 envelope. See docs/ui-design.md.
+      x-ws-protocol: rth-ws-v1
+      x-ws-server-messages:
+        - $ref: '#/components/schemas/WsAuthOkMessage'
+        - $ref: '#/components/schemas/WsMessageReceiveMessage'
+        - $ref: '#/components/schemas/WsMessageSubscribedMessage'
+        - $ref: '#/components/schemas/WsMessageSentMessage'
+        - $ref: '#/components/schemas/WsPingMessage'
+        - $ref: '#/components/schemas/WsErrorMessage'
+      x-ws-client-messages:
+        - $ref: '#/components/schemas/WsAuthMessage'
+        - $ref: '#/components/schemas/WsMessageSubscribeMessage'
+        - $ref: '#/components/schemas/WsMessageSendMessage'
+        - $ref: '#/components/schemas/WsPongMessage'
+      responses:
+        '101':
+          description: Switching Protocols (WebSocket upgrade).
   /Config:
     get:
       x-scope: protected
@@ -248,6 +276,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReticulumInfo'
+  /Message:
+    post:
+      x-scope: protected
+      tags:
+       - Message
+      summary: Send a message into the hub.
+      security:
+        - bearerAuth: []
+        - apiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageRequest'
+      responses:
+        '200':
+          description: Message dispatch acknowledgement.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageSendResult'
   /Command/DumpRouting:
     get:
       x-scope: protected
@@ -925,6 +975,41 @@ components:
           type: string
         metadata:
           type: object
+    MessageEntry:
+      type: object
+      description: Inbound LXMF message entry.
+      properties:
+        timestamp:
+          type: string
+        source:
+          type: string
+        source_hash:
+          type: string
+        topic_id:
+          type: string
+          nullable: true
+        content:
+          type: string
+    MessageRequest:
+      type: object
+      description: Message payload for dispatching to the hub.
+      required:
+        - Content
+      properties:
+        Content:
+          type: string
+        TopicID:
+          type: string
+          nullable: true
+        Destination:
+          type: string
+          nullable: true
+    MessageSendResult:
+      type: object
+      description: Message dispatch acknowledgement.
+      properties:
+        sent:
+          type: boolean
     TelemetryResponse:
       type: object
       description: Telemetry stream response payload.
@@ -1199,6 +1284,96 @@ components:
               properties:
                 entry:
                   $ref: '#/components/schemas/TelemetryEntry'
+              additionalProperties: false
+    WsMessageSubscribeMessage:
+      allOf:
+        - $ref: '#/components/schemas/WsEnvelope'
+        - type: object
+          properties:
+            type:
+              type: string
+              enum: [message.subscribe]
+            data:
+              type: object
+              properties:
+                topic_id:
+                  type: string
+                  nullable: true
+                source_hash:
+                  type: string
+                  nullable: true
+                follow:
+                  type: boolean
+              additionalProperties: false
+    WsMessageSubscribedMessage:
+      allOf:
+        - $ref: '#/components/schemas/WsEnvelope'
+        - type: object
+          properties:
+            type:
+              type: string
+              enum: [message.subscribed]
+            data:
+              type: object
+              properties:
+                topic_id:
+                  type: string
+                  nullable: true
+                source_hash:
+                  type: string
+                  nullable: true
+                follow:
+                  type: boolean
+              additionalProperties: false
+    WsMessageSendMessage:
+      allOf:
+        - $ref: '#/components/schemas/WsEnvelope'
+        - type: object
+          properties:
+            type:
+              type: string
+              enum: [message.send]
+            data:
+              type: object
+              required:
+                - content
+              properties:
+                content:
+                  type: string
+                topic_id:
+                  type: string
+                  nullable: true
+                destination:
+                  type: string
+                  nullable: true
+              additionalProperties: false
+    WsMessageSentMessage:
+      allOf:
+        - $ref: '#/components/schemas/WsEnvelope'
+        - type: object
+          properties:
+            type:
+              type: string
+              enum: [message.sent]
+            data:
+              type: object
+              properties:
+                ok:
+                  type: boolean
+              additionalProperties: false
+    WsMessageReceiveMessage:
+      allOf:
+        - $ref: '#/components/schemas/WsEnvelope'
+        - type: object
+          properties:
+            type:
+              type: string
+              enum: [message.receive]
+            data:
+              type: object
+              properties:
+                entry:
+                  $ref: '#/components/schemas/MessageEntry'
               additionalProperties: false
   securitySchemes:
     bearerAuth:

--- a/reticulum_telemetry_hub/northbound/app.py
+++ b/reticulum_telemetry_hub/northbound/app.py
@@ -28,6 +28,7 @@ from .routes_topics import register_topic_routes
 from .routes_ws import register_ws_routes
 from .services import NorthboundServices
 from .websocket import EventBroadcaster
+from .websocket import MessageBroadcaster
 from .websocket import TelemetryBroadcaster
 
 
@@ -54,6 +55,10 @@ def create_app(
     routing_provider: Optional[Callable[[], list[str]]] = None,
     started_at: Optional[datetime] = None,
     auth: Optional[ApiAuth] = None,
+    message_dispatcher: Optional[Callable[[str, Optional[str], Optional[str]], None]] = None,
+    message_listener: Optional[
+        Callable[[Callable[[dict[str, object]], None]], Callable[[], None]]
+    ] = None,
 ) -> FastAPI:
     """Create the northbound FastAPI application.
 
@@ -84,6 +89,7 @@ def create_app(
         started_at=started_at or datetime.now(timezone.utc),
         command_manager=command_manager,
         routing_provider=routing_provider,
+        message_dispatcher=message_dispatcher,
     )
     auth = auth or ApiAuth()
     require_protected = build_protected_dependency(auth)
@@ -91,6 +97,7 @@ def create_app(
     app = FastAPI(title="ReticulumTelemetryHub", version="northbound")
     event_broadcaster = EventBroadcaster(event_log)
     telemetry_broadcaster = TelemetryBroadcaster(telemetry_controller, api)
+    message_broadcaster = MessageBroadcaster(message_listener)
 
     register_core_routes(
         app,
@@ -119,6 +126,7 @@ def create_app(
         auth=auth,
         event_broadcaster=event_broadcaster,
         telemetry_broadcaster=telemetry_broadcaster,
+        message_broadcaster=message_broadcaster,
     )
 
     return app

--- a/reticulum_telemetry_hub/northbound/models.py
+++ b/reticulum_telemetry_hub/northbound/models.py
@@ -67,3 +67,17 @@ class ConfigRollbackPayload(BaseModel):
 
         allow_population_by_field_name = True
         allow_population_by_alias = True
+
+
+class MessagePayload(BaseModel):
+    """Payload for sending chat messages into the hub."""
+
+    content: str = Field(alias="Content")
+    topic_id: Optional[str] = Field(default=None, alias="TopicID")
+    destination: Optional[str] = Field(default=None, alias="Destination")
+
+    class Config:
+        """Pydantic configuration."""
+
+        allow_population_by_field_name = True
+        allow_population_by_alias = True

--- a/reticulum_telemetry_hub/northbound/services.py
+++ b/reticulum_telemetry_hub/northbound/services.py
@@ -35,6 +35,9 @@ class NorthboundServices:
     started_at: datetime
     command_manager: Optional[Any] = None
     routing_provider: Optional[Callable[[], List[str]]] = None
+    message_dispatcher: Optional[
+        Callable[[str, Optional[str], Optional[str]], None]
+    ] = None
 
     def help_text(self) -> str:
         """Return the Help command text.
@@ -192,6 +195,19 @@ class NorthboundServices:
         """
 
         return self.api.get_app_info()
+
+    def send_message(
+        self,
+        content: str,
+        *,
+        topic_id: Optional[str] = None,
+        destination: Optional[str] = None,
+    ) -> None:
+        """Dispatch a message from northbound into the core hub."""
+
+        if not self.message_dispatcher:
+            raise RuntimeError("Message dispatch is not configured")
+        self.message_dispatcher(content, topic_id, destination)
 
     def reload_config(self) -> ReticulumInfo:
         """Reload configuration from disk.


### PR DESCRIPTION
### Motivation
- Enable two-way messaging between the LXMF delivery/core runtime and the northbound FastAPI/WebSocket layer so inbound LXMF messages are visible to northbound consumers and northbound-originating messages can be dispatched into the hub.
- Provide admin UI and API consumers a way to subscribe to inbound messages and to send messages into the hub programmatically.

### Description
- Added inbound message listener/dispatch support to the core runtime: `register_message_listener`, `_notify_message_listeners`, `_record_message_event`, and `dispatch_northbound_message` in `reticulum_telemetry_hub/reticulum_server/__main__.py` and adapted `send_message` to optionally target a `destination`.
- Exposed a northbound REST `POST /Message` endpoint and a WS `/messages/stream` endpoint, plus a `MessagePayload` Pydantic model, and a `send_message` helper on `NorthboundServices` to route northbound sends into the core (files: `reticulum_telemetry_hub/northbound/routes_rest.py`, `reticulum_telemetry_hub/northbound/models.py`, `reticulum_telemetry_hub/northbound/services.py`).
- Implemented a `MessageBroadcaster` to fan out inbound LXMF messages to WS subscribers and added `handle_message_socket` to support `message.subscribe` and `message.send` WS messages (file: `reticulum_telemetry_hub/northbound/websocket.py`).
- Wired the components into the FastAPI app and OpenAPI spec: `create_app` now accepts message hooks and instantiates `MessageBroadcaster`, `register_ws_routes` mounts `/messages/stream`, and `API/ReticulumTelemetryHub-OAS.yaml` was updated with message schemas and WS envelopes.

### Testing
- No automated tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696548468f1083258520933b0e9935a6)