### PR TITLE
Increase job-level timeout to 120 minutes in Codex auto-fix workflow

### DIFF
--- a/.github/workflows/codex-auto-fix.yml
+++ b/.github/workflows/codex-auto-fix.yml
@@ -17,9 +17,8 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       !startsWith(github.event.workflow_run.head_branch, 'codex/')
     runs-on: ubuntu-latest
-
     # Hard job-level timeout (GitHub enforced)
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -65,8 +64,8 @@ jobs:
           # Pass arguments directly to Codex CLI
           # --max-steps limits runaway reasoning loops
           codex-args: >
-           -- --max-steps=120
-            --stop-on-success
+            -- --max-steps=120
+             --stop-on-success
 
           prompt-file: .github/codex/prompts/autofix-ci.md
           sandbox: workspace-write


### PR DESCRIPTION
This pull request makes a small but important change to the GitHub Actions workflow configuration by increasing the job-level timeout for the `codex-auto-fix` workflow from 60 minutes to 120 minutes.

- Workflow configuration update:
  * Increased the `timeout-minutes` for the `codex-auto-fix` job in `.github/workflows/codex-auto-fix.yml` to allow jobs to run up to 2 hours before being forcibly stopped.