### PR TITLE
Silence Pylint import errors and SQLAlchemy not-callable warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,7 +8,7 @@
 ignore=reticulum_telemetry_hub/lxmf_daemon,reticulum_telemetry_hub/reticulum_server,reticulum_telemetry_hub/embedded_lxmd,reticulum_telemetry_hub/lxmf_telemetry,tests
 
 [TYPECHECK]
-ignored-modules=dotenv,qrcode,nacl,nacl.encoding,nacl.hash
+ignored-modules=dotenv,qrcode,nacl,nacl.encoding,nacl.hash,httpx,pydantic,fastapi,fastapi.testclient
 
 [FORMAT]
 max-line-length=120

--- a/reticulum_telemetry_hub/api/storage.py
+++ b/reticulum_telemetry_hub/api/storage.py
@@ -489,7 +489,8 @@ class HubStorage(HubStorageBase):
         with self._session_scope() as session:
             rows = (
                 session.query(
-                    ChatMessageRecord.state, sa_func.count(ChatMessageRecord.id)
+                    ChatMessageRecord.state,
+                    sa_func.count(ChatMessageRecord.id),  # pylint: disable=not-callable
                 )
                 .group_by(ChatMessageRecord.state)
                 .all()

--- a/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
@@ -342,7 +342,12 @@ class TelemetryController:
         last_ingest_at = self._last_ingest_at
         try:
             with self._session_scope() as ses:
-                total = int(ses.query(sa_func.count(Telemeter.id)).scalar() or 0)
+                total = int(
+                    ses.query(
+                        sa_func.count(Telemeter.id)  # pylint: disable=not-callable
+                    ).scalar()
+                    or 0
+                )
                 last_ingest_at = ses.query(sa_func.max(Telemeter.time)).scalar()
                 if isinstance(last_ingest_at, str):
                     last_ingest_at = datetime.fromisoformat(last_ingest_at)

--- a/reticulum_telemetry_hub/northbound/gateway.py
+++ b/reticulum_telemetry_hub/northbound/gateway.py
@@ -17,7 +17,6 @@ import RNS
 import uvicorn
 from fastapi import FastAPI
 
-from reticulum_telemetry_hub.config.constants import DEFAULT_ANNOUNCE_INTERVAL
 from reticulum_telemetry_hub.config.constants import DEFAULT_HUB_TELEMETRY_INTERVAL
 from reticulum_telemetry_hub.config.constants import DEFAULT_LOG_LEVEL_NAME
 from reticulum_telemetry_hub.config.constants import DEFAULT_SERVICE_TELEMETRY_INTERVAL


### PR DESCRIPTION
### Motivation
- Prevent Pylint false positives when optional dependencies are not installed and suppress spurious `not-callable` warnings for SQLAlchemy `func.count` usage.

### Description
- Added `httpx`, `pydantic`, `fastapi`, and `fastapi.testclient` to `ignored-modules` in `.pylintrc`.
- Suppressed `pylint: disable=not-callable` for `sa_func.count(ChatMessageRecord.id)` in `reticulum_telemetry_hub/api/storage.py`.
- Suppressed `pylint: disable=not-callable` for `sa_func.count(Telemeter.id)` in `reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py`.

### Testing
- No automated tests were executed because this change only adjusts lint configuration and adds lint directives.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776e4fac808325ae2a1f59f6f7cbbf)