### PR TITLE
fix(ci): remove unsupported --stop-on-success from Codex auto-fix workflow

### DIFF
--- a/.github/workflows/codex-auto-fix.yml
+++ b/.github/workflows/codex-auto-fix.yml
@@ -65,8 +65,7 @@ jobs:
           # Pass arguments directly to Codex CLI
           # --max-steps limits runaway reasoning loops
           codex-args: >
-           -- --max-steps=120
-            --stop-on-success
+            -- --max-steps=120
 
           prompt-file: .github/codex/prompts/autofix-ci.md
           sandbox: workspace-write


### PR DESCRIPTION
### Motivation
- The Codex action was failing because the Codex CLI rejects the `--stop-on-success` argument, causing the auto-fix workflow to exit with an error; removing the flag prevents the action from failing.

### Description
- Remove the unsupported `--stop-on-success` entry from `codex-args` in `.github/workflows/codex-auto-fix.yml`, keeping `-- --max-steps=120` as the passed argument.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69822e401dd483258dc19e03bf091c18)