### PR TITLE
ci: build desktop installers on release and attach assets

### DIFF
--- a/.github/workflows/electron-macos.yml
+++ b/.github/workflows/electron-macos.yml
@@ -45,16 +45,18 @@ jobs:
           cd electron
           npm run dist -- --mac
 
-      - name: Upload macOS artifacts
+      - name: Upload macOS DMG workflow artifact
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: rch-desktop-macos
-          path: electron/dist-release/**
+          name: rch-desktop-macos-dmg
+          path: electron/dist-release/*.dmg
+          if-no-files-found: error
 
-      - name: Attach artifacts to GitHub release
+      - name: Attach DMG to GitHub release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            electron/dist-release/**/*
-          fail_on_unmatched_files: false
+            electron/dist-release/*.dmg
+          fail_on_unmatched_files: true

--- a/.github/workflows/electron-windows.yml
+++ b/.github/workflows/electron-windows.yml
@@ -2,9 +2,11 @@ name: Build Windows Electron App
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build-windows:
@@ -36,15 +38,25 @@ jobs:
         run: npm ci --prefix ui
 
       - name: Install Electron dependencies
-        run: npm install --prefix electron
+        run: npm ci --prefix electron
 
       - name: Build Windows installer + portable exe
         run: |
           cd electron
           npm run dist -- --win
 
-      - name: Upload Windows artifacts
+      - name: Upload Windows workflow artifacts
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: rch-desktop-windows
-          path: electron/dist-release/**
+          name: rch-desktop-windows-exe
+          path: electron/dist-release/*.exe
+          if-no-files-found: error
+
+      - name: Attach EXE files to GitHub release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            electron/dist-release/*.exe
+          fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary
- run both macOS and Windows desktop workflows when a release is published
- build platform installers and attach them to the release
- keep manual runs available via workflow dispatch

## macOS
- workflow artifact (manual runs only) now targets `electron/dist-release/*.dmg`
- release uploads now attach only `*.dmg` files

## Windows
- add `release` trigger (`published`)
- set `contents: write` so release assets can be uploaded
- switch Electron install to `npm ci`
- workflow artifact (manual runs only) targets `electron/dist-release/*.exe`
- release uploads attach `*.exe` files

## Files changed
- `.github/workflows/electron-macos.yml`
- `.github/workflows/electron-windows.yml`
