### PR TITLE
Add remote-login auth flow and route protection in UI

### DIFF
--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -113,7 +113,6 @@ const requestRaw = async (path: string, options: RequestOptions = {}): Promise<R
         throw createError(`Request failed: ${response.status}`, response.status, errorBody);
       }
       connectionStore.setOnline();
-      connectionStore.setAuthStatus("ok");
       return response;
     } catch (error) {
       const apiError = error instanceof Error ? (error as ApiError) : createError("Unknown error");

--- a/ui/src/components/ConnectionBanner.vue
+++ b/ui/src/components/ConnectionBanner.vue
@@ -11,22 +11,33 @@ import { useConnectionStore } from "../stores/connection";
 const connectionStore = useConnectionStore();
 
 const showOffline = computed(() => connectionStore.status === "offline");
-const showAuth = computed(
-  () => connectionStore.authStatus === "unauthenticated" || connectionStore.authStatus === "forbidden"
-);
-const showBanner = computed(() => showOffline.value || showAuth.value);
+const showLoginRequired = computed(() => connectionStore.requiresLogin);
+const showForbidden = computed(() => connectionStore.authStatus === "forbidden");
+const showBanner = computed(() => showOffline.value || showLoginRequired.value || showForbidden.value);
 
 const bannerClass = computed(() => {
-  if (showAuth.value) {
+  if (showLoginRequired.value || showForbidden.value) {
     return "bg-[#ef4444]/15 text-[#fecaca]";
   }
   return "bg-[#f59e0b]/15 text-[#fcd34d]";
 });
 
-const label = computed(() => (showAuth.value ? "Auth issue:" : "Connection issue:"));
+const label = computed(() => {
+  if (showLoginRequired.value) {
+    return "Login required:";
+  }
+  if (showForbidden.value) {
+    return "Auth issue:";
+  }
+  return "Connection offline:";
+});
+
 const message = computed(() => {
-  if (showAuth.value) {
-    return connectionStore.authMessage || connectionStore.authLabel || "Check credentials and permissions.";
+  if (showLoginRequired.value) {
+    return connectionStore.authMessage || "Authenticate on the Connect page to access this remote hub.";
+  }
+  if (showForbidden.value) {
+    return connectionStore.authMessage || "Your credentials are valid but do not have permission.";
   }
   return connectionStore.statusMessage || "Unable to reach the hub. Retrying...";
 });

--- a/ui/src/components/SidebarNav.vue
+++ b/ui/src/components/SidebarNav.vue
@@ -164,7 +164,7 @@ const buildInfo = computed(() => {
 const isTitlePaused = computed(() => {
   return (
     connectionStore.status === "offline" ||
-    connectionStore.authStatus === "unauthenticated" ||
+    connectionStore.requiresLogin ||
     connectionStore.authStatus === "forbidden"
   );
 });

--- a/ui/src/pages/ConnectPage.vue
+++ b/ui/src/pages/ConnectPage.vue
@@ -1,17 +1,34 @@
 ﻿<template>
   <div class="space-y-6">
-    <BaseCard title="Connection Settings">
+    <BaseCard :title="connectionStore.isRemoteTarget ? 'Remote Login' : 'Connection Settings'">
       <div class="grid gap-4 md:grid-cols-2">
         <BaseInput v-model="connectionStore.baseUrl" label="Base URL" />
         <BaseInput v-model="connectionStore.wsBaseUrl" label="WebSocket Base URL" />
-        <BaseSelect v-model="connectionStore.authMode" label="Auth Mode" :options="authOptions" />
-        <BaseInput v-model="connectionStore.token" label="Bearer Token" />
-        <BaseInput v-model="connectionStore.apiKey" label="API Key" />
+
+        <template v-if="connectionStore.isRemoteTarget">
+          <BaseSelect v-model="connectionStore.authMode" label="Auth Mode" :options="authOptions" />
+          <BaseInput v-model="connectionStore.token" label="Bearer Token" type="password" />
+          <BaseInput v-model="connectionStore.apiKey" label="API Key" type="password" />
+          <div class="md:col-span-2">
+            <BaseCheckbox v-model="connectionStore.rememberSecrets" label="Remember credentials on this device" />
+          </div>
+        </template>
       </div>
+
       <div v-if="testResult" class="mt-3 text-sm text-rth-muted">{{ testResult }}</div>
       <div class="mt-4 flex justify-end gap-2">
         <BaseButton icon-left="save" @click="save">Save</BaseButton>
-        <BaseButton variant="secondary" icon-left="link" @click="testConnection">Test Connection</BaseButton>
+        <BaseButton
+          v-if="connectionStore.isRemoteTarget"
+          icon-left="account-key"
+          :disabled="isSubmitting"
+          @click="login"
+        >
+          Log in
+        </BaseButton>
+        <BaseButton v-else variant="secondary" icon-left="link" :disabled="isSubmitting" @click="testConnection">
+          Test Connection
+        </BaseButton>
       </div>
     </BaseCard>
   </div>
@@ -19,37 +36,68 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
+import { useRouter } from "vue-router";
 import BaseButton from "../components/BaseButton.vue";
 import BaseCard from "../components/BaseCard.vue";
+import BaseCheckbox from "../components/BaseCheckbox.vue";
 import BaseInput from "../components/BaseInput.vue";
 import BaseSelect from "../components/BaseSelect.vue";
 import { endpoints } from "../api/endpoints";
 import { get } from "../api/client";
+import type { ApiError } from "../api/client";
 import { useConnectionStore } from "../stores/connection";
 import { useToastStore } from "../stores/toasts";
 
 const connectionStore = useConnectionStore();
 const toastStore = useToastStore();
+const router = useRouter();
 const testResult = ref("");
+const isSubmitting = ref(false);
 
 const authOptions = [
-  { label: "None", value: "none" },
   { label: "Bearer", value: "bearer" },
   { label: "API Key", value: "apiKey" },
   { label: "Both", value: "both" }
 ];
 
 const save = () => {
-  connectionStore.persist();
+  connectionStore.persist(connectionStore.rememberSecrets);
   toastStore.push("Connection settings saved", "success");
 };
 
+const login = async () => {
+  isSubmitting.value = true;
+  testResult.value = "";
+  connectionStore.persist(connectionStore.rememberSecrets);
+  try {
+    const status = await get(endpoints.status);
+    connectionStore.markAuthenticated();
+    testResult.value = `Authenticated: ${JSON.stringify(status)}`;
+    toastStore.push("Login successful", "success");
+    const redirect = typeof router.currentRoute.value.query.redirect === "string" ? router.currentRoute.value.query.redirect : "/";
+    await router.push(redirect);
+  } catch (error) {
+    connectionStore.setAuthStatus("unauthenticated", "Login failed. Check credentials.");
+    const apiError = error as ApiError;
+    testResult.value = `Login failed${apiError?.status ? ` (${apiError.status})` : ""}`;
+    toastStore.push("Login failed", "error");
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+
 const testConnection = async () => {
-  const appInfo = await get(endpoints.appInfo);
-  const status = await get(endpoints.status);
-  testResult.value = `Connected: ${JSON.stringify(appInfo)} / ${JSON.stringify(status)}`;
-  toastStore.push("Connection successful", "success");
-  connectionStore.setOnline();
+  isSubmitting.value = true;
+  testResult.value = "";
+  try {
+    const appInfo = await get(endpoints.appInfo);
+    const status = await get(endpoints.status);
+    testResult.value = `Connected: ${JSON.stringify(appInfo)} / ${JSON.stringify(status)}`;
+    toastStore.push("Connection successful", "success");
+    connectionStore.setOnline();
+    connectionStore.markAuthenticated();
+  } finally {
+    isSubmitting.value = false;
+  }
 };
 </script>
-

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter } from "vue-router";
 import { createWebHistory } from "vue-router";
 import { MISSION_DOMAIN_ROUTE_NAMES } from "../types/missions/routes";
+import { useConnectionStore } from "../stores/connection";
 
 const DashboardPage = () => import("../pages/DashboardPage.vue");
 const MissionsPage = () => import("../pages/MissionsPage.vue");
@@ -116,6 +117,24 @@ const router = createRouter({
     { path: "/about", name: "about", component: AboutPage },
     { path: "/connect", name: "connect", component: ConnectPage }
   ]
+});
+
+
+const PUBLIC_ROUTES = new Set(["connect", "about"]);
+
+router.beforeEach((to) => {
+  const connectionStore = useConnectionStore();
+  const isPublicRoute = PUBLIC_ROUTES.has(String(to.name ?? "")) || to.path.startsWith("/Help") || to.path.startsWith("/Examples");
+  if (isPublicRoute) {
+    return true;
+  }
+  if (connectionStore.isRemoteTarget && !connectionStore.isAuthenticated) {
+    return {
+      path: "/connect",
+      query: { redirect: to.fullPath }
+    };
+  }
+  return true;
 });
 
 export default router;

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -128,7 +128,7 @@ router.beforeEach((to) => {
   if (isPublicRoute) {
     return true;
   }
-  if (connectionStore.isRemoteTarget && !connectionStore.isAuthenticated) {
+  if (connectionStore.isRemoteTarget && !connectionStore.hasActiveAuthSession) {
     return {
       path: "/connect",
       query: { redirect: to.fullPath }


### PR DESCRIPTION
### Motivation
- Treat remote hubs differently from local/loopback so users must authenticate when pointing the UI at non-local targets.
- Prevent storing secrets by default and give an explicit opt-in for credential persistence to improve security.
- Provide an explicit in-memory auth session separate from generic request status so guarded routes can be enforced.
- Surface distinct UI states for "login required" vs "connection offline" to reduce user confusion.

### Description
- Added remote-detection and session state in the connection store (`ui/src/stores/connection.ts`) with `isRemoteTarget`, `isAuthenticated`, `lastAuthCheckAt`, `requiresLogin`, and `rememberSecrets` plus `markAuthenticated` and safer `persist` behavior. 
- Refactored `ConnectPage` (`ui/src/pages/ConnectPage.vue`) into a login-oriented UX when `isRemoteTarget` is true that shows credential inputs, an opt-in "Remember credentials" checkbox, and performs an auth check by calling the protected `/Status` endpoint; it sets the session only on success. 
- Introduced a router guard in `ui/src/router/index.ts` that redirects protected routes to `/connect` when `isRemoteTarget` is true and no `isAuthenticated` session exists, while allowing `connect`, `about`, and help/example paths. 
- Updated UI components (`ui/src/components/ConnectionBanner.vue`, `ui/src/components/SidebarNav.vue`) to reflect login-required and auth-forbidden states distinctly, and adjusted the API client (`ui/src/api/client.ts`) so successful requests do not implicitly mark auth success. 

### Testing
- Ran `npm run lint` (UI) and it completed successfully. 
- Ran `npm run build` (UI via Vite) and it completed successfully producing the production bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a427e7421083258bb8cb054197e726)