### PR TITLE
Stabilize LXMF distribution runtime and diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,10 +154,10 @@ python -m reticulum_telemetry_hub.northbound.gateway --data-dir ./RCH_Store --po
 # Run only the API server (without hub runtime wiring)
 uvicorn reticulum_telemetry_hub.northbound.app:app --host 0.0.0.0 --port 8000
 
-# Or use the CLI
-rch start --data-dir ./RCH_Store --port 8000 --log-level info
-rch status --data-dir ./RCH_Store
-rch stop --data-dir ./RCH_Store
+# Or use the CLI (`rch` global options must come before the subcommand)
+rch --data-dir ./RCH_Store --port 8000 start --log-level info
+rch --data-dir ./RCH_Store --port 8000 status
+rch --data-dir ./RCH_Store --port 8000 stop
 
 # Combined backend + UI launchers
 ./run_server_ui.sh           # Linux/macOS local bind (127.0.0.1 defaults)
@@ -213,6 +213,10 @@ pytest -v
 
 # Update coverage report
 pytest --cov=reticulum_telemetry_hub --cov-report=html
+
+# Windows helpers (activate venv + run tests)
+test_hub.bat
+test_hu_ui.bat
 ```
 
 ### Linting
@@ -254,7 +258,7 @@ def example_function(param1: str, param2: int) -> dict[str, Any]:
 
 ### File Organization Rules
 
-1. **Maximum 500 lines per file** - split if approaching limit
+1. **Maximum 500 lines of code (LOC) per file** - split if approaching limit
 2. **Module naming**: `snake_case.py`
 3. **Class naming**: `PascalCase`
 4. **Function naming**: `snake_case`

--- a/reticulum_telemetry_hub/northbound/app.py
+++ b/reticulum_telemetry_hub/northbound/app.py
@@ -105,6 +105,8 @@ def create_app(
     message_listener: Optional[
         Callable[[Callable[[dict[str, object]], None]], Callable[[], None]]
     ] = None,
+    runtime_metrics_provider: Optional[Callable[[], dict[str, object]]] = None,
+    runtime_metrics: Optional[object] = None,
     internal_adapter: Optional[InternalAdapter] = None,
     control: Optional[ControlService] = None,
 ) -> FastAPI:
@@ -124,6 +126,9 @@ def create_app(
         emergency_action_message_service (Optional[EmergencyActionMessageService]):
             Member-status service override.
         origin_rch (Optional[str]): Originating hub identity hash.
+        runtime_metrics_provider (Optional[Callable[[], dict[str, object]]]):
+            Provider returning runtime diagnostics snapshots for REST status/diagnostics.
+        runtime_metrics (Optional[object]): Optional runtime metrics sink shared with websocket broadcasters.
         control (Optional[ControlService]): Optional gateway control surface.
 
     Returns:
@@ -204,6 +209,7 @@ def create_app(
         marker_dispatcher=marker_dispatcher,
         zone_service=zone_service,
         origin_rch=origin_rch or "",
+        runtime_metrics_provider=runtime_metrics_provider,
     )
     auth = auth or ApiAuth()
     require_protected = build_protected_dependency(auth)
@@ -217,9 +223,16 @@ def create_app(
         allow_headers=["*"],
         max_age=86400,
     )
-    event_broadcaster = EventBroadcaster(event_log)
-    telemetry_broadcaster = TelemetryBroadcaster(telemetry_controller, api)
-    message_broadcaster = MessageBroadcaster(message_listener)
+    event_broadcaster = EventBroadcaster(event_log, runtime_metrics=runtime_metrics)
+    telemetry_broadcaster = TelemetryBroadcaster(
+        telemetry_controller,
+        api,
+        runtime_metrics=runtime_metrics,
+    )
+    message_broadcaster = MessageBroadcaster(
+        message_listener,
+        runtime_metrics=runtime_metrics,
+    )
 
     register_core_routes(
         app,

--- a/reticulum_telemetry_hub/northbound/gateway.py
+++ b/reticulum_telemetry_hub/northbound/gateway.py
@@ -358,6 +358,8 @@ def build_gateway_app(
         mission_domain_service=getattr(hub, "mission_domain_service", None),
         origin_rch=getattr(hub, "_origin_rch_hex", lambda: "")(),
         message_listener=hub.register_message_listener,
+        runtime_metrics_provider=getattr(hub, "runtime_metrics_snapshot", None),
+        runtime_metrics=getattr(hub, "runtime_metrics", None),
         started_at=started_at or datetime.now(timezone.utc),
         auth=auth,
         control=control,

--- a/reticulum_telemetry_hub/northbound/routes_rest.py
+++ b/reticulum_telemetry_hub/northbound/routes_rest.py
@@ -100,6 +100,13 @@ def register_core_routes(
 
         return services.status_snapshot()
 
+    @app.get("/diagnostics/runtime", dependencies=[Depends(require_protected)])
+    @app.get("/Diagnostics/Runtime", dependencies=[Depends(require_protected)])
+    def get_runtime_diagnostics() -> dict:
+        """Return runtime delivery and websocket diagnostics."""
+
+        return services.runtime_diagnostics()
+
     @app.get("/api/v1/auth/validate", dependencies=[Depends(require_protected)])
     def validate_auth(request: Request) -> dict:
         """Validate authentication and return minimal UI metadata.

--- a/reticulum_telemetry_hub/northbound/services.py
+++ b/reticulum_telemetry_hub/northbound/services.py
@@ -114,6 +114,7 @@ class NorthboundServices:
     marker_dispatcher: Optional[Callable[[Marker, str], bool]] = None
     zone_service: ZoneService | None = None
     origin_rch: str = ""
+    runtime_metrics_provider: Optional[Callable[[], Dict[str, object]]] = None
 
     def help_text(self) -> str:
         """Return the Help command text.
@@ -152,6 +153,7 @@ class NorthboundServices:
 
         uptime = datetime.now(timezone.utc) - self.started_at
         chat_stats = self.api.chat_message_stats()
+        runtime = self.runtime_diagnostics()
         return {
             "uptime_seconds": int(uptime.total_seconds()),
             "clients": len(self.api.list_clients()),
@@ -165,7 +167,19 @@ class NorthboundServices:
                 "received": chat_stats.get("delivered", 0),
             },
             "telemetry": self.telemetry.telemetry_stats(),
+            "runtime": runtime,
         }
+
+    def runtime_diagnostics(self) -> Dict[str, object]:
+        """Return the detailed runtime metrics snapshot when available."""
+
+        provider = self.runtime_metrics_provider
+        if provider is None:
+            return {}
+        diagnostics = provider()
+        if isinstance(diagnostics, dict):
+            return diagnostics
+        return {}
 
     def list_events(self, limit: Optional[int] = None) -> List[Dict[str, object]]:
         """Return recent events.

--- a/reticulum_telemetry_hub/northbound/websocket.py
+++ b/reticulum_telemetry_hub/northbound/websocket.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import time
 import uuid
 from contextlib import suppress
@@ -18,6 +19,7 @@ from typing import Callable
 from typing import Dict
 from typing import Optional
 
+from fastapi import WebSocketDisconnect
 from fastapi import WebSocket
 
 from reticulum_telemetry_hub.api.service import ReticulumTelemetryHubAPI
@@ -33,6 +35,27 @@ DEFAULT_WS_PING_INTERVAL_SECONDS = 30.0
 DEFAULT_WS_INACTIVITY_TIMEOUT_SECONDS = 90.0
 DEFAULT_WS_DELIVERY_QUEUE_SIZE = 64
 WS_INACTIVITY_CLOSE_CODE = 4004
+LOGGER = logging.getLogger(__name__)
+
+
+def _metrics_increment(metrics: object | None, key: str, value: int = 1) -> None:
+    """Increment a runtime metric counter when supported by ``metrics``."""
+
+    if metrics is None:
+        return
+    increment = getattr(metrics, "increment", None)
+    if callable(increment):
+        increment(key, value)
+
+
+def _metrics_set_gauge(metrics: object | None, key: str, value: float) -> None:
+    """Set a runtime metric gauge when supported by ``metrics``."""
+
+    if metrics is None:
+        return
+    setter = getattr(metrics, "set_gauge", None)
+    if callable(setter):
+        setter(key, value)
 
 
 @dataclass(eq=False)
@@ -42,6 +65,8 @@ class _QueuedDelivery:
     callback: Callable[[Dict[str, object]], Awaitable[None]]
     loop: Optional[asyncio.AbstractEventLoop]
     queue_size: int = DEFAULT_WS_DELIVERY_QUEUE_SIZE
+    on_terminal_failure: Optional[Callable[["_QueuedDelivery", Exception], None]] = None
+    on_drop_oldest: Optional[Callable[[], None]] = None
     _queue: asyncio.Queue[object] | None = field(
         init=False, default=None, repr=False, compare=False
     )
@@ -49,6 +74,7 @@ class _QueuedDelivery:
         init=False, default=None, repr=False, compare=False
     )
     _closed: bool = field(init=False, default=False, repr=False, compare=False)
+    _failed: bool = field(init=False, default=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         """Initialize the worker queue when a loop is available."""
@@ -69,8 +95,9 @@ class _QueuedDelivery:
                 if item is None:
                     return
                 await self.callback(item)
-            except Exception:
-                continue
+            except Exception as exc:
+                self._handle_terminal_failure(exc)
+                return
             finally:
                 self._queue.task_done()
 
@@ -100,6 +127,9 @@ class _QueuedDelivery:
             with suppress(asyncio.QueueEmpty):
                 self._queue.get_nowait()
                 self._queue.task_done()
+                callback = self.on_drop_oldest
+                if callback is not None:
+                    callback()
         with suppress(asyncio.QueueFull):
             self._queue.put_nowait(entry)
 
@@ -110,7 +140,26 @@ class _QueuedDelivery:
             loop = asyncio.get_running_loop()
         except RuntimeError:
             return
-        loop.create_task(self.callback(entry))
+        task = loop.create_task(self.callback(entry))
+
+        def _on_done(completed: asyncio.Task[None]) -> None:
+            with suppress(asyncio.CancelledError):
+                exc = completed.exception()
+                if exc is not None:
+                    self._handle_terminal_failure(exc)
+
+        task.add_done_callback(_on_done)
+
+    def _handle_terminal_failure(self, exc: Exception) -> None:
+        """Signal terminal callback failure once for this subscriber."""
+
+        if self._failed:
+            return
+        self._failed = True
+        callback = self.on_terminal_failure
+        if callback is None:
+            return
+        callback(self, exc)
 
     def close(self) -> None:
         """Stop the worker queue for this subscriber."""
@@ -171,6 +220,7 @@ class EventBroadcaster:
         event_log: EventLog,
         *,
         delivery_queue_size: int = DEFAULT_WS_DELIVERY_QUEUE_SIZE,
+        runtime_metrics: object | None = None,
     ) -> None:
         """Initialize the event broadcaster.
 
@@ -181,7 +231,9 @@ class EventBroadcaster:
         self._event_log = event_log
         self._subscribers: set[_QueuedDelivery] = set()
         self._delivery_queue_size = max(int(delivery_queue_size), 1)
+        self._runtime_metrics = runtime_metrics
         self._event_log.add_listener(self._handle_event)
+        self._publish_subscriber_gauge()
 
     def subscribe(
         self, callback: Callable[[Dict[str, object]], Awaitable[None]]
@@ -200,8 +252,11 @@ class EventBroadcaster:
             callback=callback,
             loop=self._running_loop(),
             queue_size=self._delivery_queue_size,
+            on_terminal_failure=self._on_delivery_failure,
+            on_drop_oldest=self._record_drop_oldest,
         )
         self._subscribers.add(delivery)
+        self._publish_subscriber_gauge()
 
         def _unsubscribe() -> None:
             """Remove the event callback subscription.
@@ -210,10 +265,36 @@ class EventBroadcaster:
                 None: Removes the callback.
             """
 
-            self._subscribers.discard(delivery)
-            delivery.close()
+            self._remove_delivery(delivery)
 
         return _unsubscribe
+
+    def _publish_subscriber_gauge(self) -> None:
+        """Publish current websocket subscriber counts to runtime metrics."""
+
+        count = float(len(self._subscribers))
+        _metrics_set_gauge(self._runtime_metrics, "ws_event_subscribers", count)
+
+    def _record_drop_oldest(self) -> None:
+        """Track bounded-queue oldest-drop events."""
+
+        _metrics_increment(self._runtime_metrics, "ws_dropped_oldest_total")
+        _metrics_increment(self._runtime_metrics, "ws_event_dropped_oldest_total")
+
+    def _remove_delivery(self, delivery: _QueuedDelivery) -> None:
+        """Remove and close a queued delivery subscription."""
+
+        self._subscribers.discard(delivery)
+        delivery.close()
+        self._publish_subscriber_gauge()
+
+    def _on_delivery_failure(self, delivery: _QueuedDelivery, exc: Exception) -> None:
+        """Handle terminal subscriber callback failures."""
+
+        LOGGER.warning("WebSocket event subscriber callback failed: %s", exc)
+        _metrics_increment(self._runtime_metrics, "ws_callback_failures_total")
+        _metrics_increment(self._runtime_metrics, "ws_event_callback_failures_total")
+        self._remove_delivery(delivery)
 
     @staticmethod
     def _running_loop() -> Optional[asyncio.AbstractEventLoop]:
@@ -232,6 +313,7 @@ class EventBroadcaster:
         """
 
         for delivery in list(self._subscribers):
+            _metrics_increment(self._runtime_metrics, "ws_event_enqueued_total")
             delivery.enqueue(entry)
 
 
@@ -244,6 +326,7 @@ class TelemetryBroadcaster:
         api: Optional[ReticulumTelemetryHubAPI],
         *,
         delivery_queue_size: int = DEFAULT_WS_DELIVERY_QUEUE_SIZE,
+        runtime_metrics: object | None = None,
     ) -> None:
         """Initialize the telemetry broadcaster.
 
@@ -258,9 +341,11 @@ class TelemetryBroadcaster:
         self._subscribers: set[_TelemetrySubscriber] = set()
         self._delivery_queue_size = max(int(delivery_queue_size), 1)
         self._unsubscribe_source: Optional[Callable[[], None]] = None
+        self._runtime_metrics = runtime_metrics
         self._unsubscribe_source = self._controller.register_listener(
             self._handle_telemetry
         )
+        self._publish_subscriber_gauge()
 
     def close(self) -> None:
         """Unsubscribe from telemetry and close subscriber deliveries."""
@@ -269,8 +354,7 @@ class TelemetryBroadcaster:
             self._unsubscribe_source()
             self._unsubscribe_source = None
         for subscriber in list(self._subscribers):
-            subscriber.delivery.close()
-            self._subscribers.discard(subscriber)
+            self._remove_subscriber(subscriber)
 
     def subscribe(
         self,
@@ -302,10 +386,16 @@ class TelemetryBroadcaster:
                 callback=callback,
                 loop=EventBroadcaster._running_loop(),
                 queue_size=self._delivery_queue_size,
+                on_terminal_failure=lambda delivery, exc: self._on_delivery_failure(
+                    delivery,
+                    exc,
+                ),
+                on_drop_oldest=self._record_drop_oldest,
             ),
             allowed_destinations=allowed,
         )
         self._subscribers.add(subscriber)
+        self._publish_subscriber_gauge()
 
         def _unsubscribe() -> None:
             """Remove the telemetry callback subscription.
@@ -314,10 +404,42 @@ class TelemetryBroadcaster:
                 None: Removes the callback.
             """
 
-            self._subscribers.discard(subscriber)
-            subscriber.delivery.close()
+            self._remove_subscriber(subscriber)
 
         return _unsubscribe
+
+    def _publish_subscriber_gauge(self) -> None:
+        """Publish telemetry websocket subscriber count."""
+
+        _metrics_set_gauge(
+            self._runtime_metrics,
+            "ws_telemetry_subscribers",
+            float(len(self._subscribers)),
+        )
+
+    def _remove_subscriber(self, subscriber: _TelemetrySubscriber) -> None:
+        """Remove and close a telemetry subscriber."""
+
+        self._subscribers.discard(subscriber)
+        subscriber.delivery.close()
+        self._publish_subscriber_gauge()
+
+    def _record_drop_oldest(self) -> None:
+        """Track dropped-oldest events for telemetry websocket queues."""
+
+        _metrics_increment(self._runtime_metrics, "ws_dropped_oldest_total")
+        _metrics_increment(self._runtime_metrics, "ws_telemetry_dropped_oldest_total")
+
+    def _on_delivery_failure(self, delivery: _QueuedDelivery, exc: Exception) -> None:
+        """Handle terminal telemetry subscriber callback failures."""
+
+        LOGGER.warning("WebSocket telemetry subscriber callback failed: %s", exc)
+        _metrics_increment(self._runtime_metrics, "ws_callback_failures_total")
+        _metrics_increment(self._runtime_metrics, "ws_telemetry_callback_failures_total")
+        for subscriber in list(self._subscribers):
+            if subscriber.delivery is delivery:
+                self._remove_subscriber(subscriber)
+                break
 
     def _handle_telemetry(
         self,
@@ -353,6 +475,7 @@ class TelemetryBroadcaster:
             if subscriber.allowed_destinations is not None:
                 if peer_dest not in subscriber.allowed_destinations:
                     continue
+            _metrics_increment(self._runtime_metrics, "ws_telemetry_enqueued_total")
             subscriber.delivery.enqueue(entry)
 
 
@@ -366,14 +489,17 @@ class MessageBroadcaster:
         ] = None,
         *,
         delivery_queue_size: int = DEFAULT_WS_DELIVERY_QUEUE_SIZE,
+        runtime_metrics: object | None = None,
     ) -> None:
         """Initialize the message broadcaster."""
 
         self._subscribers: set[_MessageSubscriber] = set()
         self._delivery_queue_size = max(int(delivery_queue_size), 1)
         self._unsubscribe_source: Optional[Callable[[], None]] = None
+        self._runtime_metrics = runtime_metrics
         if register_listener is not None:
             self._unsubscribe_source = register_listener(self._handle_message)
+        self._publish_subscriber_gauge()
 
     def subscribe(
         self,
@@ -389,19 +515,57 @@ class MessageBroadcaster:
                 callback=callback,
                 loop=EventBroadcaster._running_loop(),
                 queue_size=self._delivery_queue_size,
+                on_terminal_failure=lambda delivery, exc: self._on_delivery_failure(
+                    delivery,
+                    exc,
+                ),
+                on_drop_oldest=self._record_drop_oldest,
             ),
             topic_id=topic_id,
             source_hash=_normalize_peer(source_hash) if source_hash else None,
         )
         self._subscribers.add(subscriber)
+        self._publish_subscriber_gauge()
 
         def _unsubscribe() -> None:
             """Remove the message callback subscription."""
 
-            self._subscribers.discard(subscriber)
-            subscriber.delivery.close()
+            self._remove_subscriber(subscriber)
 
         return _unsubscribe
+
+    def _publish_subscriber_gauge(self) -> None:
+        """Publish message websocket subscriber count."""
+
+        _metrics_set_gauge(
+            self._runtime_metrics,
+            "ws_message_subscribers",
+            float(len(self._subscribers)),
+        )
+
+    def _remove_subscriber(self, subscriber: _MessageSubscriber) -> None:
+        """Remove and close a message subscriber."""
+
+        self._subscribers.discard(subscriber)
+        subscriber.delivery.close()
+        self._publish_subscriber_gauge()
+
+    def _record_drop_oldest(self) -> None:
+        """Track dropped-oldest events for message websocket queues."""
+
+        _metrics_increment(self._runtime_metrics, "ws_dropped_oldest_total")
+        _metrics_increment(self._runtime_metrics, "ws_message_dropped_oldest_total")
+
+    def _on_delivery_failure(self, delivery: _QueuedDelivery, exc: Exception) -> None:
+        """Handle terminal message subscriber callback failures."""
+
+        LOGGER.warning("WebSocket message subscriber callback failed: %s", exc)
+        _metrics_increment(self._runtime_metrics, "ws_callback_failures_total")
+        _metrics_increment(self._runtime_metrics, "ws_message_callback_failures_total")
+        for subscriber in list(self._subscribers):
+            if subscriber.delivery is delivery:
+                self._remove_subscriber(subscriber)
+                break
 
     def _handle_message(self, entry: Dict[str, object]) -> None:
         """Dispatch inbound messages to subscribers."""
@@ -413,6 +577,7 @@ class MessageBroadcaster:
                 continue
             if subscriber.source_hash and subscriber.source_hash != entry_source:
                 continue
+            _metrics_increment(self._runtime_metrics, "ws_message_enqueued_total")
             subscriber.delivery.enqueue(entry)
 
 
@@ -892,7 +1057,11 @@ async def handle_system_socket(
                 return
 
             last_activity_at = time.monotonic()
-            message = parse_ws_message(payload)
+            try:
+                message = parse_ws_message(payload)
+            except ValueError as exc:
+                await websocket.send_json(build_error_message("bad_request", str(exc)))
+                continue
             msg_type = _get_message_type(message)
             if msg_type == "system.subscribe":
                 data = _get_message_data(message)
@@ -903,7 +1072,10 @@ async def handle_system_socket(
                 continue
             else:
                 await websocket.send_json(build_error_message("bad_request", "Unsupported message"))
-    except Exception:  # pragma: no cover - websocket disconnects vary
+    except (WebSocketDisconnect, RuntimeError):  # pragma: no cover - websocket disconnects vary
+        return
+    except Exception as exc:  # pragma: no cover - defensive logging
+        LOGGER.warning("System websocket loop terminated with error: %s", exc)
         return
     finally:
         unsubscribe()
@@ -954,7 +1126,11 @@ async def handle_telemetry_socket(
                 return
 
             last_activity_at = time.monotonic()
-            message = parse_ws_message(payload)
+            try:
+                message = parse_ws_message(payload)
+            except ValueError as exc:
+                await websocket.send_json(build_error_message("bad_request", str(exc)))
+                continue
             msg_type = _get_message_type(message)
             if msg_type == "telemetry.subscribe":
                 data = _get_message_data(message)
@@ -999,7 +1175,10 @@ async def handle_telemetry_socket(
                 continue
             else:
                 await websocket.send_json(build_error_message("bad_request", "Unsupported message"))
-    except Exception:  # pragma: no cover - websocket disconnects vary
+    except (WebSocketDisconnect, RuntimeError):  # pragma: no cover - websocket disconnects vary
+        return
+    except Exception as exc:  # pragma: no cover - defensive logging
+        LOGGER.warning("Telemetry websocket loop terminated with error: %s", exc)
         return
     finally:
         if unsubscribe:
@@ -1041,7 +1220,11 @@ async def handle_message_socket(
                 return
 
             last_activity_at = time.monotonic()
-            message = parse_ws_message(payload)
+            try:
+                message = parse_ws_message(payload)
+            except ValueError as exc:
+                await websocket.send_json(build_error_message("bad_request", str(exc)))
+                continue
             msg_type = _get_message_type(message)
             if msg_type == "message.subscribe":
                 data = _get_message_data(message)
@@ -1076,7 +1259,12 @@ async def handle_message_socket(
                 data = _get_message_data(message)
                 try:
                     content, topic_id, destination = _get_message_send_payload(data)
-                    message_sender(content, topic_id=topic_id, destination=destination)
+                    await asyncio.to_thread(
+                        message_sender,
+                        content,
+                        topic_id=topic_id,
+                        destination=destination,
+                    )
                 except RuntimeError as exc:
                     await websocket.send_json(
                         build_error_message("service_unavailable", str(exc))
@@ -1093,7 +1281,10 @@ async def handle_message_socket(
                 await websocket.send_json(
                     build_error_message("bad_request", "Unsupported message")
                 )
-    except Exception:  # pragma: no cover - websocket disconnects vary
+    except (WebSocketDisconnect, RuntimeError):  # pragma: no cover - websocket disconnects vary
+        return
+    except Exception as exc:  # pragma: no cover - defensive logging
+        LOGGER.warning("Message websocket loop terminated with error: %s", exc)
         return
     finally:
         if unsubscribe:

--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -1325,12 +1325,10 @@ class ReticulumTelemetryHub:
         if not has_non_command_signal:
             return False
 
-        manager = getattr(self, "command_manager", None)
-        normalize_name = getattr(manager, "_normalize_command_name", None)
-        all_names = getattr(manager, "_all_command_names", None) if manager is not None else None
-        if not callable(normalize_name) or not callable(all_names):
+        manager = self.command_manager
+        if not isinstance(manager, CommandManager):
             return False
-        known_names = set(all_names())
+        known_names = set(manager._all_command_names())  # pylint: disable=protected-access
 
         for command in commands:
             if not isinstance(command, dict):
@@ -1345,9 +1343,7 @@ class ReticulumTelemetryHub:
                 raw_name = command.get(str(PLUGIN_COMMAND))
             if not isinstance(raw_name, str):
                 return False
-            if not callable(normalize_name):
-                return False
-            normalized = normalize_name(raw_name)
+            normalized = manager._normalize_command_name(raw_name)  # pylint: disable=protected-access
             if normalized is None:
                 normalized = raw_name.strip() or None
             if normalized in known_names:

--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -41,6 +41,7 @@ import subprocess
 import time
 import threading
 import uuid
+from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -137,6 +138,9 @@ from reticulum_telemetry_hub.reticulum_server.propagation_selection import (
 )
 from reticulum_telemetry_hub.reticulum_server.runtime_events import (
     report_nonfatal_exception,
+)
+from reticulum_telemetry_hub.reticulum_server.runtime_metrics_store import (
+    RuntimeMetricsStore,
 )
 from reticulum_telemetry_hub.reticulum_server.services import (
     SERVICE_FACTORIES,
@@ -239,6 +243,77 @@ def _dispatch_coroutine(coroutine) -> None:
         return
 
     loop.create_task(coroutine)
+
+
+class _AsyncTaskRunner:
+    """Dedicated async-loop runner for scheduling hub coroutines safely."""
+
+    def __init__(self, *, name: str) -> None:
+        self._name = name
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._started = threading.Event()
+        self._stopped = threading.Event()
+
+    def start(self) -> None:
+        """Start the runner thread and event loop once."""
+
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._started.clear()
+        self._stopped.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name=self._name,
+            daemon=True,
+        )
+        self._thread.start()
+        self._started.wait(timeout=1.0)
+
+    def _run(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        self._started.set()
+        try:
+            loop.run_forever()
+        finally:
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                with suppress(Exception):
+                    loop.run_until_complete(
+                        asyncio.gather(*pending, return_exceptions=True)
+                    )
+            loop.close()
+            self._stopped.set()
+
+    def submit(self, coroutine) -> None:
+        """Submit a coroutine to the runner loop when active."""
+
+        if coroutine is None:
+            return
+        if self._loop is None or self._thread is None or not self._thread.is_alive():
+            _dispatch_coroutine(coroutine)
+            return
+        try:
+            asyncio.run_coroutine_threadsafe(coroutine, self._loop)
+        except Exception:
+            _dispatch_coroutine(coroutine)
+
+    def stop(self, *, timeout: float = 1.0) -> None:
+        """Stop the runner loop and wait for thread exit."""
+
+        loop = self._loop
+        if loop is not None:
+            with suppress(Exception):
+                loop.call_soon_threadsafe(loop.stop)
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=timeout)
+        self._thread = None
+        self._loop = None
 
 
 class AnnounceHandler:
@@ -880,6 +955,7 @@ class ReticulumTelemetryHub:
         telemetry_db_path = self.storage_path / "telemetry.db"
         event_log_path = resolve_event_log_path(self.storage_path)
         self.event_log = EventLog(event_path=event_log_path)
+        self.runtime_metrics = RuntimeMetricsStore()
         self.tel_controller = TelemetryController(
             db_path=telemetry_db_path,
             event_log=self.event_log,
@@ -890,6 +966,8 @@ class ReticulumTelemetryHub:
         self.telemeter_manager: TelemeterManager | None = None
         self._shutdown = False
         self.connections: dict[bytes, RNS.Destination] = {}
+        self._destination_cache: dict[str, RNS.Destination] = {}
+        self._destination_cache_lock = threading.Lock()
         self._daemon_started = False
         self._active_services = {}
         self._outbound_queue: OutboundMessageQueue | None = None
@@ -913,6 +991,10 @@ class ReticulumTelemetryHub:
         self._rem_app_announce_handler: AnnounceHandler | None = None
         self._propagation_node_registry = PropagationNodeRegistry()
         self._propagation_announce_handler: PropagationNodeAnnounceHandler | None = None
+        self._tak_async_runner = _AsyncTaskRunner(name="rch-tak-async")
+        self._outbound_transition_log_window_seconds = 1.0
+        self._outbound_transition_log_last_emitted: dict[str, float] = {}
+        self._outbound_transition_log_lock = threading.Lock()
 
         identity = self.load_or_generate_identity(self.identity_path)
         destination_hash = self._delivery_destination_hash(identity)
@@ -1051,6 +1133,7 @@ class ReticulumTelemetryHub:
             self.api,
             config_manager=self.config_manager,
             event_log=self.event_log,
+            destination_removed_callback=self._evict_cached_destination,
         )
         self.mission_sync_router = MissionSyncRouter(
             api=self.api,
@@ -1102,6 +1185,7 @@ class ReticulumTelemetryHub:
                     self._handle_eam_status_update
                 )
             )
+        self._tak_async_runner.start()
         self._invoke_router_hook("register_delivery_callback", self.delivery_callback)
         init_elapsed = time.monotonic() - init_started
         RNS.log(
@@ -1498,6 +1582,7 @@ class ReticulumTelemetryHub:
             else list(self.connections)
         ):
             if self._connection_hex(connection) == normalized_identity:
+                self._cache_destination(connection)
                 return
         try:
             recalled = RNS.Identity.recall(bytes.fromhex(normalized_identity))
@@ -1513,6 +1598,7 @@ class ReticulumTelemetryHub:
         except Exception:
             return
         self.connections[destination.identity.hash] = destination
+        self._cache_destination(destination)
 
     def _prune_mission_change_fanout_cache(self) -> None:
         now = time.time()
@@ -1665,19 +1751,18 @@ class ReticulumTelemetryHub:
         if not recipients["rem"] and not recipients["generic"]:
             return
         concise_body = f"mission log update {log_entry.get('entry_uid') or ''}".strip()
-        for destination in recipients["rem"]:
-            self._ensure_reachable_identity_destination(destination)
-            self.send_message(
+        if recipients["rem"]:
+            self.send_many(
                 concise_body,
-                destination=destination,
+                recipients["rem"],
                 fields=self._build_rem_log_event_fields(log_entry),
             )
         generic_fields = {MARKDOWN_RENDERER_FIELD: MARKDOWN_RENDERER_VALUE}
         markdown_body = self._render_generic_log_update_markdown(log_entry)
-        for destination in recipients["generic"]:
-            self.send_message(
+        if recipients["generic"]:
+            self.send_many(
                 markdown_body,
-                destination=destination,
+                recipients["generic"],
                 fields=generic_fields,
             )
 
@@ -1692,19 +1777,18 @@ class ReticulumTelemetryHub:
         if not recipients["rem"] and not recipients["generic"]:
             return
         concise_body = f"eam update {snapshot.get('callsign') or ''}".strip()
-        for destination in recipients["rem"]:
-            self._ensure_reachable_identity_destination(destination)
-            self.send_message(
+        if recipients["rem"]:
+            self.send_many(
                 concise_body,
-                destination=destination,
+                recipients["rem"],
                 fields=self._build_rem_eam_command_fields(event_type, snapshot),
             )
         generic_fields = {MARKDOWN_RENDERER_FIELD: MARKDOWN_RENDERER_VALUE}
         generic_body = self._render_generic_eam_markdown(event_type, snapshot)
-        for destination in recipients["generic"]:
-            self.send_message(
+        if recipients["generic"]:
+            self.send_many(
                 generic_body,
-                destination=destination,
+                recipients["generic"],
                 fields=generic_fields,
             )
 
@@ -1772,24 +1856,31 @@ class ReticulumTelemetryHub:
         concise_body = (
             f"r3akt mission delta {mission_uid} {mission_change_uid}".strip()
         )
+        r3akt_destinations: list[str] = []
+        generic_destinations: list[str] = []
         for destination in deduped_destinations:
             if self._identity_supports_r3akt(destination):
-                custom_fields = self._build_r3akt_delta_custom_fields(
-                    mission_uid=mission_uid,
-                    mission_change=mission_change,
-                    delta=delta_payload,
-                )
-                merged_fields = self._merge_standard_fields(
-                    source_fields=None,
-                    extra_fields={**base_event_fields, **custom_fields},
-                )
-                self.send_message(
-                    concise_body,
-                    destination=destination,
-                    fields=merged_fields,
-                )
-                continue
+                r3akt_destinations.append(destination)
+            else:
+                generic_destinations.append(destination)
 
+        if r3akt_destinations:
+            custom_fields = self._build_r3akt_delta_custom_fields(
+                mission_uid=mission_uid,
+                mission_change=mission_change,
+                delta=delta_payload,
+            )
+            merged_fields = self._merge_standard_fields(
+                source_fields=None,
+                extra_fields={**base_event_fields, **custom_fields},
+            )
+            self.send_many(
+                concise_body,
+                r3akt_destinations,
+                fields=merged_fields,
+            )
+
+        if generic_destinations:
             merged_fields = self._merge_standard_fields(
                 source_fields=None,
                 extra_fields={
@@ -1797,9 +1888,9 @@ class ReticulumTelemetryHub:
                     MARKDOWN_RENDERER_FIELD: MARKDOWN_RENDERER_VALUE,
                 },
             )
-            self.send_message(
+            self.send_many(
                 markdown_body,
-                destination=destination,
+                generic_destinations,
                 fields=merged_fields,
             )
 
@@ -1838,12 +1929,15 @@ class ReticulumTelemetryHub:
                 extra_fields=extra_fields,
             )
             payload_text = f"r3akt mission event {event_field.get('event_type') or ''}".strip()
-            for destination in destinations:
-                if not destination:
-                    continue
-                self.send_message(
+            explicit_destinations = [
+                str(destination).strip().lower()
+                for destination in destinations
+                if destination
+            ]
+            if explicit_destinations:
+                self.send_many(
                     payload_text,
-                    destination=destination,
+                    explicit_destinations,
                     fields=outbound_fields,
                 )
 
@@ -2257,15 +2351,18 @@ class ReticulumTelemetryHub:
             tak_connector = getattr(self, "tak_connector", None)
             if tak_connector is not None and content_text:
                 try:
-                    asyncio.run(
-                        tak_connector.send_chat_event(
-                            content=content_text,
-                            sender_label=source_label,
-                            topic_id=topic_id,
-                            source_hash=source_hash,
-                            timestamp=message_time,
-                        )
+                    coroutine = tak_connector.send_chat_event(
+                        content=content_text,
+                        sender_label=source_label,
+                        topic_id=topic_id,
+                        source_hash=source_hash,
+                        timestamp=message_time,
                     )
+                    runner = getattr(self, "_tak_async_runner", None)
+                    if runner is not None:
+                        runner.submit(coroutine)
+                    else:
+                        _dispatch_coroutine(coroutine)
                 except Exception as exc:  # pragma: no cover - defensive log
                     RNS.log(
                         f"Failed to send CoT chat event: {exc}",
@@ -2388,6 +2485,97 @@ class ReticulumTelemetryHub:
         )
         return enqueued_any
 
+    def send_many(
+        self,
+        message: str,
+        destinations: list[str],
+        *,
+        fields: dict | None = None,
+        sender: RNS.Destination | None = None,
+        chat_message_id: str | None = None,
+    ) -> bool:
+        """Send one payload body to many explicit destination identities."""
+
+        queue = self._ensure_outbound_queue()
+        if queue is None:
+            return False
+        unique_destinations = [
+            value
+            for value in dict.fromkeys(
+                normalize_hash(identity) for identity in destinations if identity
+            )
+            if value
+        ]
+        if not unique_destinations:
+            return False
+        scanned = 0
+        resolved: list[tuple[RNS.Destination, str, bytes | None]] = []
+        for identity in unique_destinations:
+            scanned += 1
+            connection = self._cached_destination(identity)
+            if connection is None:
+                self._ensure_reachable_identity_destination(identity)
+                connection = self._cached_destination(identity)
+            if connection is None:
+                continue
+            identity_obj = getattr(connection, "identity", None)
+            destination_hash = getattr(identity_obj, "hash", None)
+            resolved.append(
+                (
+                    connection,
+                    identity,
+                    destination_hash if isinstance(destination_hash, (bytes, bytearray)) else None,
+                )
+            )
+        if not resolved:
+            return False
+
+        message_id = self._delivery_message_id(fields, chat_message_id=chat_message_id)
+        shared_fields = self._prepare_outbound_delivery_fields(
+            fields=fields,
+            topic_id=None,
+            message_id=message_id,
+        )
+        payloads = [
+            OutboundPayload(
+                connection=connection,
+                message_text=message,
+                destination_hash=destination_hash,
+                destination_hex=identity_hex,
+                fields=shared_fields,
+                sender=sender or self.my_lxmf_dest,
+                chat_message_id=chat_message_id,
+                message_id=message_id,
+                topic_id=None,
+                route_type="targeted",
+            )
+            for connection, identity_hex, destination_hash in resolved
+        ]
+        enqueue_started = time.perf_counter()
+        enqueue_results = queue.queue_messages(payloads)
+        enqueue_duration_ms = round((time.perf_counter() - enqueue_started) * 1000, 3)
+        enqueued_count = sum(1 for value in enqueue_results if value)
+        queue_stats = queue.stats()
+        metrics = self._runtime_metrics_store()
+        metrics.increment("fanout_recipients_scanned_total", scanned)
+        metrics.increment("fanout_recipients_resolved_total", len(resolved))
+        self._record_outbound_route_metrics(
+            message_id=message_id,
+            route_type="fanout",
+            fanout_count=enqueued_count,
+            targeted_recipient_count=0,
+            eligible_recipient_count=len(resolved),
+            selected_recipient_count=len(resolved),
+            dropped_by_fanout_cap=max(len(resolved) - enqueued_count, 0),
+            deferred_by_fanout_cap=0,
+            drop_reason=None if enqueued_count > 0 else "no_recipients",
+            enqueue_duration_ms=enqueue_duration_ms,
+            queue_depth=queue_stats["queue_depth"],
+            active_sends=queue_stats["active_dispatches"],
+            pending_receipts=queue_stats["pending_receipts"],
+        )
+        return enqueued_count > 0
+
     def _prepare_outbound_delivery_fields(
         self,
         *,
@@ -2442,7 +2630,23 @@ class ReticulumTelemetryHub:
             self._subscribers_for_topic(topic_id) if topic_id is not None else None
         )
         recipients: list[tuple[RNS.Destination, str | None, bytes | None]] = []
+        scanned_recipients = 0
+        if route_type == "targeted" and destination:
+            scanned_recipients = 1
+            targeted_connection = self._cached_destination(destination)
+            if targeted_connection is not None:
+                targeted_identity = getattr(targeted_connection, "identity", None)
+                targeted_hash = getattr(targeted_identity, "hash", None)
+                recipients.append(
+                    (
+                        targeted_connection,
+                        destination,
+                        targeted_hash if isinstance(targeted_hash, (bytes, bytearray)) else None,
+                    )
+                )
+                available = []
         for connection in available:
+            scanned_recipients += 1
             connection_hex = self._connection_hex(connection)
             if destination and connection_hex != destination:
                 continue
@@ -2496,6 +2700,9 @@ class ReticulumTelemetryHub:
                 batch_index = index // fanout_soft_max
                 payload.next_attempt_at = time.monotonic() + (batch_index * stagger_step_seconds)
             payloads.append(payload)
+        metrics = self._runtime_metrics_store()
+        metrics.increment("fanout_recipients_scanned_total", scanned_recipients)
+        metrics.increment("fanout_recipients_resolved_total", len(recipients))
         return payloads, {
             "eligible_recipient_count": eligible_recipient_count,
             "selected_recipient_count": len(payloads),
@@ -2836,16 +3043,41 @@ class ReticulumTelemetryHub:
             return None
         return registry.best_candidate()
 
+    def _should_emit_outbound_transition_event(
+        self,
+        event_type: str,
+        payload: OutboundPayload,
+    ) -> bool:
+        """Return whether an outbound transition event should be emitted now."""
+
+        if not hasattr(self, "_outbound_transition_log_lock"):
+            self._outbound_transition_log_lock = threading.Lock()
+        if not hasattr(self, "_outbound_transition_log_last_emitted"):
+            self._outbound_transition_log_last_emitted = {}
+        if not hasattr(self, "_outbound_transition_log_window_seconds"):
+            self._outbound_transition_log_window_seconds = 1.0
+
+        message_id = payload.chat_message_id or payload.message_id or "unknown"
+        destination = payload.destination_hex or "unknown"
+        key = f"{event_type}:{message_id}:{destination}"
+        now = time.monotonic()
+        with self._outbound_transition_log_lock:
+            last_emitted_at = self._outbound_transition_log_last_emitted.get(key, 0.0)
+            if now - last_emitted_at < self._outbound_transition_log_window_seconds:
+                return False
+            self._outbound_transition_log_last_emitted[key] = now
+        return True
+
     def _handle_outbound_retry_scheduled(self, payload: OutboundPayload) -> None:
         """Record a direct-delivery retry event."""
 
-        self._persist_outbound_delivery_metadata(
-            payload,
-            state="queued",
-            delivery_metadata={"retry_scheduled": True},
-        )
         event_log = getattr(self, "event_log", None)
         if event_log is None:
+            return
+        if not self._should_emit_outbound_transition_event(
+            "message_delivery_retrying",
+            payload,
+        ):
             return
         destination_label = (
             self._lookup_identity_label(payload.destination_hex)
@@ -2861,17 +3093,13 @@ class ReticulumTelemetryHub:
     def _handle_outbound_propagation_fallback(self, payload: OutboundPayload) -> None:
         """Record that direct delivery exhausted and propagation fallback is in use."""
 
-        self._persist_outbound_delivery_metadata(
-            payload,
-            state="queued",
-            delivery_metadata={
-                "delivery_mode": payload.delivery_mode,
-                "local_propagation_fallback": payload.local_propagation_fallback,
-                "propagation_node_hex": payload.propagation_node_hex,
-            },
-        )
         event_log = getattr(self, "event_log", None)
         if event_log is None:
+            return
+        if not self._should_emit_outbound_transition_event(
+            "message_propagation_queued",
+            payload,
+        ):
             return
         destination_label = (
             self._lookup_identity_label(payload.destination_hex)
@@ -2956,16 +3184,9 @@ class ReticulumTelemetryHub:
         }
 
     def _handle_outbound_attempt_started(self, payload: OutboundPayload) -> None:
-        """Persist attempt counters when a queue worker starts delivery."""
+        """Mark attempt activity in runtime metrics without DB churn."""
 
-        self._persist_outbound_delivery_metadata(
-            payload,
-            state="queued",
-            delivery_metadata={
-                "last_attempt_at": utc_now_rfc3339(),
-                "retry_scheduled": False,
-            },
-        )
+        self._runtime_metrics_store().increment("outbound_attempt_started_total")
 
     def _handle_outbound_payload_dropped(
         self,
@@ -3523,6 +3744,7 @@ class ReticulumTelemetryHub:
                 propagation_fallback_callback=self._handle_outbound_propagation_fallback,
                 attempt_started_callback=self._handle_outbound_attempt_started,
                 payload_dropped_callback=self._handle_outbound_payload_dropped,
+                runtime_metrics=self._runtime_metrics_store(),
             )
         self._outbound_queue.start()
         return self._outbound_queue
@@ -3543,11 +3765,35 @@ class ReticulumTelemetryHub:
             return True
         return queue.wait_for_flush(timeout=timeout)
 
+    def _runtime_metrics_store(self) -> RuntimeMetricsStore:
+        """Return the runtime metrics store, creating one for test stubs if missing."""
+
+        metrics = getattr(self, "runtime_metrics", None)
+        if metrics is None:
+            metrics = RuntimeMetricsStore()
+            self.runtime_metrics = metrics
+        return metrics
+
     @property
     def outbound_queue(self) -> OutboundMessageQueue | None:
         """Return the active outbound queue instance for diagnostics/testing."""
 
         return self._outbound_queue
+
+    def runtime_metrics_snapshot(self) -> dict[str, object]:
+        """Return runtime counters, gauges, timers, and queue state."""
+
+        snapshot = self._runtime_metrics_store().snapshot()
+        queue = getattr(self, "_outbound_queue", None)
+        if queue is not None:
+            try:
+                snapshot["queue"] = queue.stats()
+            except Exception as exc:  # pragma: no cover - defensive
+                RNS.log(
+                    f"Failed to collect outbound queue diagnostics: {exc}",
+                    getattr(RNS, "LOG_WARNING", 2),
+                )
+        return snapshot
 
     def log_delivery_details(self, message, time_string, signature_string):
         RNS.log("\t+--- LXMF Delivery ---------------------------------------------")
@@ -3687,6 +3933,7 @@ class ReticulumTelemetryHub:
             except Exception:
                 continue
             self.connections[dest.identity.hash] = dest
+            self._cache_destination(dest)
             loaded += 1
 
         if loaded:
@@ -3707,13 +3954,16 @@ class ReticulumTelemetryHub:
         if tak_connector is None:
             return
         try:
-            _dispatch_coroutine(
-                tak_connector.send_telemetry_event(
-                    telemetry,
-                    peer_hash=peer_hash,
-                    timestamp=timestamp,
-                )
+            coroutine = tak_connector.send_telemetry_event(
+                telemetry,
+                peer_hash=peer_hash,
+                timestamp=timestamp,
             )
+            runner = getattr(self, "_tak_async_runner", None)
+            if runner is not None:
+                runner.submit(coroutine)
+            else:
+                _dispatch_coroutine(coroutine)
         except Exception as exc:  # pragma: no cover - defensive logging
             RNS.log(
                 f"Failed to send telemetry CoT event: {exc}",
@@ -3975,6 +4225,44 @@ class ReticulumTelemetryHub:
         hash_bytes = getattr(identity, "hash", None)
         if isinstance(hash_bytes, (bytes, bytearray)) and hash_bytes:
             return hash_bytes.hex().lower()
+        return None
+
+    def _cache_destination(self, connection: RNS.Destination) -> None:
+        """Cache a connection by normalized identity hash for fast targeted routing."""
+
+        identity_hex = self._connection_hex(connection)
+        if not identity_hex:
+            return
+        with self._destination_cache_lock:
+            self._destination_cache[identity_hex] = connection
+
+    def _evict_cached_destination(self, identity: str | None) -> None:
+        """Remove a cached destination for ``identity`` if present."""
+
+        normalized_identity = normalize_hash(identity)
+        if not normalized_identity:
+            return
+        with self._destination_cache_lock:
+            self._destination_cache.pop(normalized_identity, None)
+
+    def _cached_destination(self, identity: str) -> RNS.Destination | None:
+        """Return a cached destination for ``identity`` when available."""
+
+        normalized_identity = normalize_hash(identity)
+        if not normalized_identity:
+            return None
+        with self._destination_cache_lock:
+            cached = self._destination_cache.get(normalized_identity)
+        if cached is not None:
+            return cached
+        for connection in (
+            list(self.connections.values())
+            if hasattr(self.connections, "values")
+            else list(self.connections)
+        ):
+            if self._connection_hex(connection) == normalized_identity:
+                self._cache_destination(connection)
+                return connection
         return None
 
     def _message_source_hex(self, message: LXMF.LXMessage) -> str | None:
@@ -5071,6 +5359,9 @@ class ReticulumTelemetryHub:
         if self.embedded_lxmd is not None:
             self.embedded_lxmd.stop()
             self.embedded_lxmd = None
+        tak_runner = getattr(self, "_tak_async_runner", None)
+        if tak_runner is not None:
+            tak_runner.stop(timeout=1.0)
         self.telemetry_sampler = None
 
 

--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -1330,7 +1330,9 @@ class ReticulumTelemetryHub:
         all_names = getattr(manager, "_all_command_names", None) if manager is not None else None
         if not callable(normalize_name) or not callable(all_names):
             return False
-        known_names = set(all_names())
+        normalize_name_fn = cast(Callable[[str], str | None], normalize_name)
+        known_names_fn = cast(Callable[[], list[str] | set[str] | tuple[str, ...]], all_names)
+        known_names = set(known_names_fn())
 
         for command in commands:
             if not isinstance(command, dict):
@@ -1345,7 +1347,7 @@ class ReticulumTelemetryHub:
                 raw_name = command.get(str(PLUGIN_COMMAND))
             if not isinstance(raw_name, str):
                 return False
-            normalized = normalize_name(raw_name) if callable(normalize_name) else None
+            normalized = normalize_name_fn(raw_name)
             if normalized is None:
                 normalized = raw_name.strip() or None
             if normalized in known_names:

--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -1330,9 +1330,7 @@ class ReticulumTelemetryHub:
         all_names = getattr(manager, "_all_command_names", None) if manager is not None else None
         if not callable(normalize_name) or not callable(all_names):
             return False
-        normalize_name_fn = cast(Callable[[str], str | None], normalize_name)
-        known_names_fn = cast(Callable[[], list[str] | set[str] | tuple[str, ...]], all_names)
-        known_names = set(known_names_fn())
+        known_names = set(all_names())
 
         for command in commands:
             if not isinstance(command, dict):
@@ -1347,7 +1345,9 @@ class ReticulumTelemetryHub:
                 raw_name = command.get(str(PLUGIN_COMMAND))
             if not isinstance(raw_name, str):
                 return False
-            normalized = normalize_name_fn(raw_name)
+            if not callable(normalize_name):
+                return False
+            normalized = normalize_name(raw_name)
             if normalized is None:
                 normalized = raw_name.strip() or None
             if normalized in known_names:

--- a/reticulum_telemetry_hub/reticulum_server/command_manager.py
+++ b/reticulum_telemetry_hub/reticulum_server/command_manager.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 import json
 from pathlib import Path
 import re
@@ -103,6 +103,7 @@ class CommandManager:
         *,
         config_manager: HubConfigurationManager | None = None,
         event_log: EventLog | None = None,
+        destination_removed_callback: Callable[[str], None] | None = None,
     ):
         self.connections = connections
         self.tel_controller = tel_controller
@@ -110,6 +111,7 @@ class CommandManager:
         self.api = api
         self.config_manager = config_manager
         self.event_log = event_log
+        self._destination_removed_callback = destination_removed_callback
         self.pending_field_requests: Dict[str, Dict[str, Dict[str, Any]]] = {}
         self._command_aliases_cache: Dict[str, str] = {}
         self._start_time = time.time()
@@ -606,6 +608,9 @@ class CommandManager:
         dest = self._create_dest(message.source.identity)
         self.connections.pop(dest.identity.hash, None)
         identity_hex = self._identity_hex(dest.identity)
+        callback = self._destination_removed_callback
+        if callback is not None:
+            callback(identity_hex)
         self.api.leave(identity_hex)
         RNS.log(f"Connection removed: {message.source}")
         display_name, label = self._resolve_identity_label(identity_hex)

--- a/reticulum_telemetry_hub/reticulum_server/outbound_queue.py
+++ b/reticulum_telemetry_hub/reticulum_server/outbound_queue.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import heapq
 import threading
 import time
+from collections import defaultdict
 from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError
@@ -21,6 +23,9 @@ import RNS
 from reticulum_telemetry_hub.reticulum_server.appearance import apply_icon_appearance
 from reticulum_telemetry_hub.reticulum_server.propagation_selection import (
     PropagationNodeCandidate,
+)
+from reticulum_telemetry_hub.reticulum_server.runtime_metrics_store import (
+    RuntimeMetricsStore,
 )
 
 
@@ -78,12 +83,14 @@ class _PendingReceipt(NamedTuple):
     payload: OutboundPayload
     attempt_id: int
     deadline: float
+    registered_at: float
 
 
 class _PendingDispatch(NamedTuple):
     payload: OutboundPayload
     attempt_id: int
     future: Future[None]
+    timed_out_at: float
 
 
 class OutboundMessageQueue:
@@ -117,6 +124,7 @@ class OutboundMessageQueue:
         payload_dropped_callback: (
             Callable[[OutboundPayload, str], None] | None
         ) = None,
+        runtime_metrics: RuntimeMetricsStore | None = None,
     ) -> None:
         """
         Initialize a bounded outbound queue.
@@ -145,11 +153,13 @@ class OutboundMessageQueue:
                 Optional callback invoked when a delivery attempt begins.
             payload_dropped_callback (Callable[[OutboundPayload, str], None] | None):
                 Optional callback invoked when queue backpressure drops a payload.
+            runtime_metrics (RuntimeMetricsStore | None): Optional runtime metrics sink.
         """
 
         self._lxm_router = lxm_router
         self._sender = sender
-        self._queue: Queue[OutboundPayload] = Queue(maxsize=max(queue_size, 1))
+        self._max_queue_size = max(int(queue_size), 1)
+        self._queue: Queue[OutboundPayload] = Queue(maxsize=self._max_queue_size)
         self._worker_count = max(worker_count, 1)
         self._send_executor = ThreadPoolExecutor(
             max_workers=self._worker_count,
@@ -166,6 +176,11 @@ class OutboundMessageQueue:
         self._stop_event = threading.Event()
         self._workers: list[threading.Thread] = []
         self._receipt_monitor: threading.Thread | None = None
+        self._delayed_scheduler: threading.Thread | None = None
+        self._delayed_heap: list[tuple[float, int, OutboundPayload]] = []
+        self._delayed_lock = threading.Lock()
+        self._delayed_event = threading.Event()
+        self._delayed_seq = 0
         self._inflight = 0
         self._inflight_lock = threading.Lock()
         self._active_dispatches = 0
@@ -177,7 +192,9 @@ class OutboundMessageQueue:
         self._pending_dispatches: dict[tuple[int, int], _PendingDispatch] = {}
         self._pending_dispatches_lock = threading.Lock()
         self._pending_receipts: dict[tuple[int, int], _PendingReceipt] = {}
+        self._pending_receipt_deadlines: list[tuple[float, tuple[int, int]]] = []
         self._pending_receipts_lock = threading.Lock()
+        self._receipt_wakeup = threading.Event()
         self._delivery_receipt_callback = delivery_receipt_callback
         self._delivery_failure_callback = delivery_failure_callback
         self._propagation_selector = propagation_selector
@@ -185,6 +202,16 @@ class OutboundMessageQueue:
         self._propagation_fallback_callback = propagation_fallback_callback
         self._attempt_started_callback = attempt_started_callback
         self._payload_dropped_callback = payload_dropped_callback
+        self._runtime_metrics = runtime_metrics
+        self._max_queue_depth = 0
+        self._enqueued_total = 0
+        self._dropped_total = 0
+        self._retry_total = 0
+        self._timeout_total = 0
+        self._receipt_timeout_total = 0
+        self._propagation_fallback_total = 0
+        self._dropped_by_reason: dict[str, int] = defaultdict(int)
+        self._stats_lock = threading.Lock()
 
     def start(self) -> None:
         """Start background worker threads if they are not already running."""
@@ -193,6 +220,8 @@ class OutboundMessageQueue:
             return
 
         self._stop_event.clear()
+        self._delayed_event.clear()
+        self._receipt_wakeup.clear()
         for index in range(self._worker_count):
             worker = threading.Thread(
                 target=self._worker_loop,
@@ -201,6 +230,13 @@ class OutboundMessageQueue:
             )
             worker.start()
             self._workers.append(worker)
+        if self._delayed_scheduler is None:
+            self._delayed_scheduler = threading.Thread(
+                target=self._delayed_scheduler_loop,
+                name="lxmf-outbound-delayed",
+                daemon=True,
+            )
+            self._delayed_scheduler.start()
         if self._receipt_monitor is None:
             self._receipt_monitor = threading.Thread(
                 target=self._receipt_monitor_loop,
@@ -216,9 +252,14 @@ class OutboundMessageQueue:
             return
 
         self._stop_event.set()
+        self._delayed_event.set()
+        self._receipt_wakeup.set()
         for worker in self._workers:
             worker.join(timeout=0.5)
         self._workers.clear()
+        if self._delayed_scheduler is not None:
+            self._delayed_scheduler.join(timeout=0.5)
+            self._delayed_scheduler = None
         if self._receipt_monitor is not None:
             self._receipt_monitor.join(timeout=0.5)
             self._receipt_monitor = None
@@ -236,20 +277,7 @@ class OutboundMessageQueue:
         topic_id: str | None = None,
         route_type: str = "broadcast",
     ) -> bool:
-        """
-        Enqueue a message for delivery.
-
-        Args:
-            connection (RNS.Destination): Destination to deliver the message to.
-            message_text (str): Plaintext message body to deliver.
-            destination_hash (bytes | None): Raw destination hash for diagnostics.
-            destination_hex (str | None): Hex-encoded destination hash for logging.
-            fields (dict | None): Optional LXMF message fields.
-            chat_message_id (str | None): Optional persisted chat message identifier.
-
-        Returns:
-            bool: ``True`` when the message was queued successfully.
-        """
+        """Enqueue a message for delivery."""
 
         payload = OutboundPayload(
             connection=connection,
@@ -271,15 +299,7 @@ class OutboundMessageQueue:
         return [self._enqueue_payload(payload) for payload in payloads]
 
     def wait_for_flush(self, timeout: float = 1.0) -> bool:
-        """
-        Wait until the queue and inflight sends complete.
-
-        Args:
-            timeout (float): Seconds to wait before giving up.
-
-        Returns:
-            bool: ``True`` when the queue drained before the timeout elapsed.
-        """
+        """Wait until the queue and inflight sends complete."""
 
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
@@ -293,8 +313,11 @@ class OutboundMessageQueue:
                 pending_dispatches = len(self._pending_dispatches)
             with self._pending_receipts_lock:
                 pending_receipts = len(self._pending_receipts)
+            with self._delayed_lock:
+                delayed = len(self._delayed_heap)
             if (
                 self._queue.empty()
+                and delayed == 0
                 and inflight == 0
                 and active_dispatches == 0
                 and in_progress_futures == 0
@@ -305,7 +328,7 @@ class OutboundMessageQueue:
             time.sleep(0.01)
         return False
 
-    def stats(self) -> dict[str, int]:
+    def stats(self) -> dict[str, int | float]:
         """Return queue counters for routing and backpressure metrics."""
 
         with self._inflight_lock:
@@ -318,10 +341,36 @@ class OutboundMessageQueue:
             timed_out_sends = self._timed_out_sends
         with self._pending_dispatches_lock:
             pending_dispatches = len(self._pending_dispatches)
+            oldest_pending_dispatch_age_ms = 0.0
+            now = time.monotonic()
+            if self._pending_dispatches:
+                oldest_pending_dispatch_age_ms = max(
+                    (now - dispatch.timed_out_at) * 1000
+                    for dispatch in self._pending_dispatches.values()
+                )
         with self._pending_receipts_lock:
             pending_receipts = len(self._pending_receipts)
-        return {
-            "queue_depth": self._queue.qsize(),
+            oldest_pending_receipt_age_ms = 0.0
+            if self._pending_receipts:
+                oldest_pending_receipt_age_ms = max(
+                    (now - receipt.registered_at) * 1000
+                    for receipt in self._pending_receipts.values()
+                )
+        with self._delayed_lock:
+            delayed_depth = len(self._delayed_heap)
+        queue_depth = self._queue.qsize()
+        with self._stats_lock:
+            enqueued_total = self._enqueued_total
+            dropped_total = self._dropped_total
+            retry_total = self._retry_total
+            timeout_total = self._timeout_total
+            receipt_timeout_total = self._receipt_timeout_total
+            propagation_fallback_total = self._propagation_fallback_total
+            max_queue_depth = self._max_queue_depth
+
+        stats: dict[str, int | float] = {
+            "queue_depth": queue_depth,
+            "delayed_depth": delayed_depth,
             "inflight": inflight,
             "active_dispatches": active_dispatches,
             "in_progress_futures": in_progress_futures,
@@ -329,16 +378,106 @@ class OutboundMessageQueue:
             "pending_receipts": pending_receipts,
             "timed_out_sends": timed_out_sends,
             "worker_count": self._worker_count,
+            "max_queue_depth": max_queue_depth,
+            "enqueued_total": enqueued_total,
+            "dropped_total": dropped_total,
+            "retry_total": retry_total,
+            "timeout_total": timeout_total,
+            "receipt_timeout_total": receipt_timeout_total,
+            "propagation_fallback_total": propagation_fallback_total,
+            "oldest_pending_dispatch_age_ms": round(oldest_pending_dispatch_age_ms, 3),
+            "oldest_pending_receipt_age_ms": round(oldest_pending_receipt_age_ms, 3),
         }
+        self._publish_stats(stats)
+        return stats
+
+    def _publish_stats(self, stats: dict[str, int | float]) -> None:
+        """Mirror runtime queue gauges into the shared metrics store."""
+
+        metrics = self._runtime_metrics
+        if metrics is None:
+            return
+        metrics.set_gauge("queue_depth", float(stats["queue_depth"]))
+        metrics.set_gauge("queue_max_depth", float(stats["max_queue_depth"]))
+        metrics.set_gauge("queue_delayed_depth", float(stats["delayed_depth"]))
+        metrics.set_gauge("queue_pending_dispatches", float(stats["pending_dispatches"]))
+        metrics.set_gauge("queue_pending_receipts", float(stats["pending_receipts"]))
+        metrics.set_gauge(
+            "queue_oldest_pending_dispatch_age_ms",
+            float(stats["oldest_pending_dispatch_age_ms"]),
+        )
+        metrics.set_gauge(
+            "queue_oldest_pending_receipt_age_ms",
+            float(stats["oldest_pending_receipt_age_ms"]),
+        )
+
+    def _record_counter(self, key: str, value: int = 1) -> None:
+        metrics = self._runtime_metrics
+        if metrics is None:
+            return
+        metrics.increment(key, value)
+
+    def _record_timer(self, key: str, value_ms: float) -> None:
+        metrics = self._runtime_metrics
+        if metrics is None:
+            return
+        metrics.observe_ms(key, value_ms)
 
     def _enqueue_payload(self, payload: OutboundPayload) -> bool:
+        payload.enqueued_at = time.monotonic()
+        if payload.next_attempt_at > payload.enqueued_at:
+            delayed_depth = 0
+            saturated = False
+            with self._delayed_lock:
+                total_depth = self._queue.qsize() + len(self._delayed_heap)
+                if total_depth >= self._max_queue_size:
+                    saturated = True
+                else:
+                    self._delayed_seq += 1
+                    seq = self._delayed_seq
+                    heapq.heappush(self._delayed_heap, (payload.next_attempt_at, seq, payload))
+                    delayed_depth = len(self._delayed_heap)
+            if saturated:
+                self._notify_payload_dropped(payload, "queue_saturated")
+                self._record_drop("queue_saturated")
+                RNS.log(
+                    (
+                        "Outbound queue is saturated; dropping delayed payload"
+                        f" destined for {payload.destination_hex or 'unknown destination'}"
+                    ),
+                    getattr(RNS, "LOG_WARNING", 2),
+                )
+                return False
+            self._delayed_event.set()
+            if self._runtime_metrics is not None:
+                self._runtime_metrics.set_gauge("queue_delayed_depth", float(delayed_depth))
+            return True
+        return self._enqueue_ready_payload(payload)
+
+    def _enqueue_ready_payload(self, payload: OutboundPayload) -> bool:
+        with self._delayed_lock:
+            total_depth = self._queue.qsize() + len(self._delayed_heap)
+            ready_has_capacity = self._queue.qsize() < self._max_queue_size
+        if total_depth >= self._max_queue_size and ready_has_capacity:
+            self._notify_payload_dropped(payload, "queue_saturated")
+            self._record_drop("queue_saturated")
+            RNS.log(
+                (
+                    "Outbound queue is saturated; dropping payload destined for"
+                    f" {payload.destination_hex or 'unknown destination'}"
+                ),
+                getattr(RNS, "LOG_WARNING", 2),
+            )
+            return False
         try:
             self._queue.put_nowait(payload)
+            self._record_queue_enqueued()
             return True
         except Full:
-            dropped = self._drop_oldest()
+            dropped = self._drop_oldest_ready()
             if dropped is not None:
                 self._notify_payload_dropped(dropped, "queue_backpressure_drop_oldest")
+                self._record_drop("queue_backpressure_drop_oldest")
                 RNS.log(
                     (
                         "Outbound queue is full; dropped oldest payload destined for"
@@ -348,9 +487,11 @@ class OutboundMessageQueue:
                 )
             try:
                 self._queue.put_nowait(payload)
+                self._record_queue_enqueued()
                 return True
             except Full:
                 self._notify_payload_dropped(payload, "queue_saturated")
+                self._record_drop("queue_saturated")
                 RNS.log(
                     (
                         "Outbound queue is saturated; dropping payload destined for"
@@ -360,7 +501,24 @@ class OutboundMessageQueue:
                 )
                 return False
 
-    def _drop_oldest(self) -> OutboundPayload | None:
+    def _record_queue_enqueued(self) -> None:
+        depth = self._queue.qsize()
+        with self._stats_lock:
+            self._enqueued_total += 1
+            self._max_queue_depth = max(self._max_queue_depth, depth)
+        self._record_counter("outbound_enqueued_total")
+        if self._runtime_metrics is not None:
+            self._runtime_metrics.set_gauge("queue_depth", float(depth))
+            self._runtime_metrics.set_gauge("queue_max_depth", float(self._max_queue_depth))
+
+    def _record_drop(self, reason: str) -> None:
+        with self._stats_lock:
+            self._dropped_total += 1
+            self._dropped_by_reason[reason] += 1
+        self._record_counter("outbound_dropped_total")
+        self._record_counter(f"outbound_dropped_{reason}")
+
+    def _drop_oldest_ready(self) -> OutboundPayload | None:
         try:
             oldest = self._queue.get_nowait()
             self._queue.task_done()
@@ -368,19 +526,30 @@ class OutboundMessageQueue:
         except Empty:
             return None
 
+    def _delayed_scheduler_loop(self) -> None:
+        """Promote delayed payloads when their retry deadline is due."""
+
+        while not self._stop_event.is_set():
+            due_payloads: list[OutboundPayload] = []
+            wait_seconds = 0.5
+            now = time.monotonic()
+            with self._delayed_lock:
+                while self._delayed_heap and self._delayed_heap[0][0] <= now:
+                    _, _, payload = heapq.heappop(self._delayed_heap)
+                    due_payloads.append(payload)
+                if self._delayed_heap:
+                    wait_seconds = max(min(self._delayed_heap[0][0] - now, 0.5), 0.01)
+            for payload in due_payloads:
+                if not self._enqueue_ready_payload(payload):
+                    self._finalize_terminal_failure(payload)
+            self._delayed_event.wait(wait_seconds)
+            self._delayed_event.clear()
+
     def _worker_loop(self) -> None:
         while not self._stop_event.is_set() or not self._queue.empty():
             try:
                 payload = self._queue.get(timeout=0.1)
             except Empty:
-                continue
-
-            now = time.monotonic()
-            if payload.next_attempt_at > now:
-                delay = min(payload.next_attempt_at - now, 0.1)
-                time.sleep(delay)
-                self._enqueue_payload(payload)
-                self._queue.task_done()
                 continue
 
             try:
@@ -394,7 +563,12 @@ class OutboundMessageQueue:
 
         try:
             self._notify_attempt_started(payload)
+            started_at = time.monotonic()
             failure_reason = self._send_with_timeout(payload)
+            self._record_timer(
+                "outbound_dispatch_latency_ms",
+                (time.monotonic() - started_at) * 1000,
+            )
             if failure_reason is not None:
                 self._handle_delivery_attempt_failure(payload, reason=failure_reason)
         finally:
@@ -440,10 +614,13 @@ class OutboundMessageQueue:
 
         if self._delivery_receipt_timeout is None:
             return
-        deadline = time.monotonic() + self._delivery_receipt_timeout
+        now = time.monotonic()
+        deadline = now + self._delivery_receipt_timeout
         key = (id(payload), attempt_id)
         with self._pending_receipts_lock:
-            self._pending_receipts[key] = _PendingReceipt(payload, attempt_id, deadline)
+            self._pending_receipts[key] = _PendingReceipt(payload, attempt_id, deadline, now)
+            heapq.heappush(self._pending_receipt_deadlines, (deadline, key))
+        self._receipt_wakeup.set()
 
     def _pop_pending_receipt(
         self,
@@ -454,39 +631,37 @@ class OutboundMessageQueue:
 
         key = (id(payload), attempt_id)
         with self._pending_receipts_lock:
-            return self._pending_receipts.pop(key, None)
+            pending = self._pending_receipts.pop(key, None)
+        if pending is not None:
+            self._receipt_wakeup.set()
+        return pending
 
     def _receipt_monitor_loop(self) -> None:
-        """Advance timed-out sends and fail missing delivery receipts."""
+        """Handle receipt deadline expirations without fixed dictionary scans."""
 
         while not self._stop_event.is_set():
-            self._drain_pending_dispatches()
             now = time.monotonic()
             expired: list[_PendingReceipt] = []
+            wait_seconds = 0.5
             with self._pending_receipts_lock:
-                for key, pending in list(self._pending_receipts.items()):
-                    if pending.deadline <= now:
-                        expired.append(self._pending_receipts.pop(key))
+                while self._pending_receipt_deadlines:
+                    deadline, key = self._pending_receipt_deadlines[0]
+                    if deadline > now:
+                        wait_seconds = max(min(deadline - now, 0.5), 0.01)
+                        break
+                    heapq.heappop(self._pending_receipt_deadlines)
+                    pending = self._pending_receipts.get(key)
+                    if pending is None:
+                        continue
+                    if abs(pending.deadline - deadline) > 1e-9:
+                        continue
+                    expired.append(self._pending_receipts.pop(key))
+                if not self._pending_receipt_deadlines:
+                    wait_seconds = 0.5
             for pending in expired:
                 self._handle_receipt_timeout(pending.payload, pending.attempt_id)
-            self._stop_event.wait(0.05)
-
-        while True:
-            if not self._drain_pending_dispatches():
-                break
-
-    def _drain_pending_dispatches(self) -> bool:
-        """Handle completed dispatch futures tracked after send timeouts."""
-
-        pending: list[_PendingDispatch] = []
-        with self._pending_dispatches_lock:
-            for key, dispatch in list(self._pending_dispatches.items()):
-                if dispatch.future.done():
-                    pending.append(self._pending_dispatches.pop(key))
-        for dispatch in pending:
-            self._finalize_dispatch(dispatch.payload, dispatch.attempt_id, dispatch.future)
-        with self._pending_dispatches_lock:
-            return bool(self._pending_dispatches)
+            self._receipt_wakeup.wait(wait_seconds)
+            self._receipt_wakeup.clear()
 
     def _handle_receipt_timeout(
         self,
@@ -497,6 +672,9 @@ class OutboundMessageQueue:
 
         if not self._claim_attempt(payload, attempt_id):
             return
+        with self._stats_lock:
+            self._receipt_timeout_total += 1
+        self._record_counter("outbound_receipt_timeout_total")
         RNS.log(
             (
                 "Timed out waiting for LXMF delivery acknowledgement from"
@@ -530,6 +708,7 @@ class OutboundMessageQueue:
 
     def _send_with_timeout(self, payload: OutboundPayload) -> str | None:
         """Dispatch a payload and return a failure reason when dispatch fails."""
+
         attempt_id = self._begin_attempt(payload)
 
         def _mark_receipt(
@@ -575,9 +754,14 @@ class OutboundMessageQueue:
         except TimeoutError:
             with self._timed_out_sends_lock:
                 self._timed_out_sends += 1
+            with self._stats_lock:
+                self._timeout_total += 1
+            self._record_counter("outbound_timeout_total")
             key = (id(payload), attempt_id)
+            pending = _PendingDispatch(payload, attempt_id, future, time.monotonic())
             with self._pending_dispatches_lock:
-                self._pending_dispatches[key] = _PendingDispatch(payload, attempt_id, future)
+                self._pending_dispatches[key] = pending
+            future.add_done_callback(lambda _future, k=key: self._on_pending_dispatch_done(k))
             RNS.log(
                 (
                     "Timed out delivering outbound message to"
@@ -591,6 +775,15 @@ class OutboundMessageQueue:
             return self._finalize_dispatch(payload, attempt_id, future)
 
         return self._finalize_dispatch(payload, attempt_id, future)
+
+    def _on_pending_dispatch_done(self, key: tuple[int, int]) -> None:
+        """Finalize a dispatch that previously timed out waiting on the caller thread."""
+
+        with self._pending_dispatches_lock:
+            pending = self._pending_dispatches.pop(key, None)
+        if pending is None:
+            return
+        self._finalize_dispatch(pending.payload, pending.attempt_id, pending.future)
 
     def _finalize_dispatch(
         self,
@@ -800,6 +993,9 @@ class OutboundMessageQueue:
             if result is False:
                 raise RuntimeError("local propagation storage rejected payload")
             message.state = LXMF.LXMessage.SENT
+            with self._stats_lock:
+                self._propagation_fallback_total += 1
+            self._record_counter("outbound_propagation_fallback_total")
             self._notify_propagation_fallback(payload)
             self._emit_delivery_receipt_callback(message, payload)
         except Exception as exc:
@@ -838,8 +1034,13 @@ class OutboundMessageQueue:
             payload.next_attempt_at = (
                 time.monotonic() + self._backoff_seconds * payload.attempts
             )
+            if not self._enqueue_payload(payload):
+                self._finalize_terminal_failure(payload, callback_message=callback_message)
+                return
+            with self._stats_lock:
+                self._retry_total += 1
+            self._record_counter("outbound_retry_total")
             self._notify_retry_scheduled(payload)
-            self._enqueue_payload(payload)
             return
 
         candidate = self._select_propagation_candidate()
@@ -860,8 +1061,16 @@ class OutboundMessageQueue:
                 payload.propagation_node_hex = candidate.destination_hex
                 payload.local_propagation_fallback = False
                 payload.next_attempt_at = time.monotonic()
+                if not self._enqueue_payload(payload):
+                    self._finalize_terminal_failure(
+                        payload,
+                        callback_message=callback_message,
+                    )
+                    return
+                with self._stats_lock:
+                    self._propagation_fallback_total += 1
+                self._record_counter("outbound_propagation_fallback_total")
                 self._notify_propagation_fallback(payload)
-                self._enqueue_payload(payload)
                 return
 
         if getattr(self._lxm_router, "propagation_node", False):

--- a/reticulum_telemetry_hub/reticulum_server/runtime_metrics_store.py
+++ b/reticulum_telemetry_hub/reticulum_server/runtime_metrics_store.py
@@ -1,0 +1,95 @@
+"""Thread-safe runtime metrics collection for hub diagnostics."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections import deque
+from dataclasses import dataclass
+from dataclasses import field
+import threading
+import time
+from typing import Deque
+
+
+@dataclass
+class _TimerSeries:
+    """Rolling timer series used to summarize latency observations."""
+
+    values: Deque[float] = field(default_factory=lambda: deque(maxlen=512))
+
+    def observe(self, value_ms: float) -> None:
+        self.values.append(max(float(value_ms), 0.0))
+
+    def snapshot(self) -> dict[str, float]:
+        if not self.values:
+            return {
+                "count": 0,
+                "avg_ms": 0.0,
+                "p50_ms": 0.0,
+                "p95_ms": 0.0,
+                "max_ms": 0.0,
+            }
+        ordered = sorted(self.values)
+        count = len(ordered)
+        p50_index = min(int(round((count - 1) * 0.50)), count - 1)
+        p95_index = min(int(round((count - 1) * 0.95)), count - 1)
+        return {
+            "count": float(count),
+            "avg_ms": round(sum(ordered) / count, 3),
+            "p50_ms": round(ordered[p50_index], 3),
+            "p95_ms": round(ordered[p95_index], 3),
+            "max_ms": round(ordered[-1], 3),
+        }
+
+
+class RuntimeMetricsStore:
+    """In-process counter/gauge/timer registry for runtime diagnostics."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._counters: dict[str, int] = defaultdict(int)
+        self._gauges: dict[str, float] = {}
+        self._timers: dict[str, _TimerSeries] = defaultdict(_TimerSeries)
+        self._updated_at = time.time()
+
+    def increment(self, key: str, value: int = 1) -> None:
+        """Increment an integer counter."""
+
+        if not key:
+            return
+        with self._lock:
+            self._counters[key] += int(value)
+            self._updated_at = time.time()
+
+    def set_gauge(self, key: str, value: float) -> None:
+        """Set a floating-point gauge value."""
+
+        if not key:
+            return
+        with self._lock:
+            self._gauges[key] = float(value)
+            self._updated_at = time.time()
+
+    def observe_ms(self, key: str, value_ms: float) -> None:
+        """Record a duration in milliseconds."""
+
+        if not key:
+            return
+        with self._lock:
+            self._timers[key].observe(value_ms)
+            self._updated_at = time.time()
+
+    def snapshot(self) -> dict[str, object]:
+        """Return a serializable runtime metrics snapshot."""
+
+        with self._lock:
+            counters = dict(self._counters)
+            gauges = dict(self._gauges)
+            timers = {name: series.snapshot() for name, series in self._timers.items()}
+            updated_at = self._updated_at
+        return {
+            "updated_at_unix": round(updated_at, 3),
+            "counters": counters,
+            "gauges": gauges,
+            "timers": timers,
+        }

--- a/tests/northbound/test_routes_rest_extended.py
+++ b/tests/northbound/test_routes_rest_extended.py
@@ -119,6 +119,11 @@ def test_core_routes_endpoints(tmp_path: Path) -> None:
 
     status_response = client.get("/Status", headers=headers)
     assert status_response.status_code == 200
+    diagnostics_response = client.get("/diagnostics/runtime", headers=headers)
+    assert diagnostics_response.status_code == 200
+    assert isinstance(diagnostics_response.json(), dict)
+    diagnostics_alias_response = client.get("/Diagnostics/Runtime", headers=headers)
+    assert diagnostics_alias_response.status_code == 200
 
     event_log.add_event("test_event", "Event recorded")
     events_response = client.get("/Events", headers=headers)

--- a/tests/northbound/test_services.py
+++ b/tests/northbound/test_services.py
@@ -49,6 +49,29 @@ def test_status_snapshot_includes_counts(tmp_path: Path) -> None:
 
     assert snapshot["topics"] == 1
     assert snapshot["clients"] == 0
+    assert "runtime" in snapshot
+
+
+def test_status_snapshot_includes_runtime_provider_payload(tmp_path: Path) -> None:
+    """Ensure runtime diagnostics are surfaced in status snapshots."""
+
+    api = _build_api(tmp_path)
+    event_log = EventLog()
+    telemetry = TelemetryController(db_path=tmp_path / "telemetry.db", api=api)
+    runtime_snapshot = {"counters": {"outbound_enqueued_total": 5}}
+    services = NorthboundServices(
+        api=api,
+        telemetry=telemetry,
+        event_log=event_log,
+        started_at=datetime.now(timezone.utc),
+        runtime_metrics_provider=lambda: runtime_snapshot,
+    )
+
+    snapshot = services.status_snapshot()
+    diagnostics = services.runtime_diagnostics()
+
+    assert snapshot["runtime"] == runtime_snapshot
+    assert diagnostics == runtime_snapshot
 
 
 def test_dump_routing_defaults_to_clients(tmp_path: Path) -> None:

--- a/tests/northbound/test_websocket_handlers.py
+++ b/tests/northbound/test_websocket_handlers.py
@@ -299,3 +299,64 @@ def test_handle_message_socket_subscribe_send_and_errors(monkeypatch) -> None:
         assert "error" in response_types
 
     asyncio.run(_exercise())
+
+
+def test_handle_message_socket_send_supports_keyword_only_sender(monkeypatch) -> None:
+    """Ensure message.send supports keyword-only sender signatures."""
+
+    async def _exercise() -> None:
+        websocket = _FakeWebSocket(
+            [
+                {
+                    "type": "message.send",
+                    "data": {
+                        "content": "hello",
+                        "topic_id": "chat",
+                        "destination": "abcd",
+                    },
+                }
+            ]
+        )
+        broadcaster = _FakeMessageBroadcaster()
+        sent_payloads: list[dict[str, str | None]] = []
+
+        async def _fake_ping_loop(*_args, **_kwargs):
+            await asyncio.sleep(999)
+
+        monkeypatch.setattr(
+            "reticulum_telemetry_hub.northbound.websocket.authenticate_websocket",
+            lambda *args, **kwargs: asyncio.sleep(0, result=True),
+        )
+        monkeypatch.setattr(
+            "reticulum_telemetry_hub.northbound.websocket.ping_loop",
+            _fake_ping_loop,
+        )
+
+        def _message_sender(
+            content: str,
+            *,
+            topic_id: str | None = None,
+            destination: str | None = None,
+        ) -> None:
+            sent_payloads.append(
+                {
+                    "content": content,
+                    "topic_id": topic_id,
+                    "destination": destination,
+                }
+            )
+
+        await handle_message_socket(
+            websocket,
+            auth=_FakeAuth(True),
+            message_broadcaster=broadcaster,
+            message_sender=_message_sender,
+        )
+
+        assert sent_payloads == [
+            {"content": "hello", "topic_id": "chat", "destination": "abcd"}
+        ]
+        response_types = [item["type"] for item in websocket.sent]
+        assert "message.sent" in response_types
+
+    asyncio.run(_exercise())

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -46,6 +46,51 @@ def make_command_manager(api):
     return manager, server_dest
 
 
+def test_handle_leave_invokes_destination_removed_callback():
+    if RNS.Reticulum.get_instance() is None:
+        RNS.Reticulum()
+
+    class DummyAPI:
+        def __init__(self) -> None:
+            self.left: list[str] = []
+
+        def leave(self, identity: str) -> bool:
+            self.left.append(identity)
+            return True
+
+    server_dest = RNS.Destination(
+        RNS.Identity(),
+        RNS.Destination.IN,
+        RNS.Destination.SINGLE,
+        "lxmf",
+        "delivery",
+    )
+    source_dest = RNS.Destination(
+        RNS.Identity(),
+        RNS.Destination.OUT,
+        RNS.Destination.SINGLE,
+        "lxmf",
+        "delivery",
+    )
+    removed: list[str] = []
+    manager = CommandManager(
+        {source_dest.identity.hash: source_dest},
+        type("DummyTelemetry", (), {"handle_command": lambda self, command, message, dest: None})(),
+        server_dest,
+        DummyAPI(),
+        destination_removed_callback=lambda identity: removed.append(identity),
+    )
+    message = LXMF.LXMessage(server_dest, source_dest, "leave")
+    message.pack()
+    message.signature_validated = True
+
+    reply = manager._handle_leave(message)
+
+    assert "Connection removed" in reply.content_as_string()
+    assert removed == [source_dest.identity.hash.hex().lower()]
+    assert manager.api.left == [source_dest.identity.hash.hex().lower()]
+
+
 def test_apply_lxmf_router_runtime_config_reads_allowed_and_ignored_sidecars(
     tmp_path,
 ):

--- a/tests/test_outbound_queue.py
+++ b/tests/test_outbound_queue.py
@@ -63,6 +63,101 @@ def test_outbound_queue_applies_backpressure():
     assert delivered == [recipient_two.identity.hash]
 
 
+def test_outbound_queue_rejects_delayed_enqueues_when_saturated():
+    sender = _make_destination(RNS.Destination.IN)
+    recipient = _make_destination()
+    dropped: list[tuple[str | None, str]] = []
+
+    class SilentRouter:
+        def handle_outbound(self, message):
+            _ = message
+
+    queue = OutboundMessageQueue(
+        SilentRouter(),
+        sender,
+        queue_size=1,
+        worker_count=1,
+        send_timeout=0.1,
+        backoff_seconds=0.01,
+        max_attempts=1,
+        payload_dropped_callback=lambda payload, reason: dropped.append(
+            (payload.destination_hex, reason)
+        ),
+    )
+
+    delayed_first = OutboundPayload(
+        connection=recipient,
+        message_text="first-delayed",
+        destination_hash=recipient.identity.hash,
+        destination_hex=recipient.identity.hash.hex(),
+        sender=sender,
+    )
+    delayed_first.next_attempt_at = time.monotonic() + 5.0
+    delayed_second = OutboundPayload(
+        connection=recipient,
+        message_text="second-delayed",
+        destination_hash=recipient.identity.hash,
+        destination_hex=recipient.identity.hash.hex(),
+        sender=sender,
+    )
+    delayed_second.next_attempt_at = time.monotonic() + 5.0
+
+    outcomes = queue.queue_messages([delayed_first, delayed_second])
+    stats = queue.stats()
+
+    assert outcomes == [True, False]
+    assert dropped == [(recipient.identity.hash.hex(), "queue_saturated")]
+    assert stats["delayed_depth"] == 1
+    assert stats["dropped_total"] == 1
+
+
+def test_outbound_queue_rejects_ready_enqueue_when_delayed_buffer_is_full():
+    sender = _make_destination(RNS.Destination.IN)
+    recipient = _make_destination()
+    dropped: list[tuple[str | None, str]] = []
+
+    class SilentRouter:
+        def handle_outbound(self, message):
+            _ = message
+
+    queue = OutboundMessageQueue(
+        SilentRouter(),
+        sender,
+        queue_size=1,
+        worker_count=1,
+        send_timeout=0.1,
+        backoff_seconds=0.01,
+        max_attempts=1,
+        payload_dropped_callback=lambda payload, reason: dropped.append(
+            (payload.destination_hex, reason)
+        ),
+    )
+
+    delayed = OutboundPayload(
+        connection=recipient,
+        message_text="delayed",
+        destination_hash=recipient.identity.hash,
+        destination_hex=recipient.identity.hash.hex(),
+        sender=sender,
+    )
+    delayed.next_attempt_at = time.monotonic() + 5.0
+    ready = OutboundPayload(
+        connection=recipient,
+        message_text="ready",
+        destination_hash=recipient.identity.hash,
+        destination_hex=recipient.identity.hash.hex(),
+        sender=sender,
+    )
+
+    outcomes = queue.queue_messages([delayed, ready])
+    stats = queue.stats()
+
+    assert outcomes == [True, False]
+    assert dropped == [(recipient.identity.hash.hex(), "queue_saturated")]
+    assert stats["delayed_depth"] == 1
+    assert stats["queue_depth"] == 0
+
+
 def test_outbound_queue_retries_after_failure():
     sender = _make_destination(RNS.Destination.IN)
     recipient = _make_destination()

--- a/tests/test_reticulum_server_daemon.py
+++ b/tests/test_reticulum_server_daemon.py
@@ -1304,6 +1304,17 @@ def test_mission_registry_event_fanout_is_capability_aware(tmp_path):
         return True
 
     hub.send_message = _capture_send  # type: ignore[assignment]
+    hub.send_many = (  # type: ignore[assignment]
+        lambda message, destinations, **kwargs: all(
+            _capture_send(
+                message,
+                destination=destination,
+                fields=kwargs.get("fields"),
+                sender=kwargs.get("sender"),
+            )
+            for destination in destinations
+        )
+    )
 
     try:
         hub.api.record_identity_announce(
@@ -1431,6 +1442,17 @@ def test_rem_registry_commands_and_connected_eam_fanout(tmp_path):
             return self.source
 
     hub.send_message = _capture_send  # type: ignore[assignment]
+    hub.send_many = (  # type: ignore[assignment]
+        lambda message, destinations, **kwargs: all(
+            _capture_send(
+                message,
+                destination=destination,
+                fields=kwargs.get("fields"),
+                sender=kwargs.get("sender"),
+            )
+            for destination in destinations
+        )
+    )
 
     try:
         hub.api.record_identity_announce(
@@ -1557,6 +1579,17 @@ def test_mission_change_fanout_de_duplicates_by_change_uid(tmp_path):
         return True
 
     hub.send_message = _capture_send  # type: ignore[assignment]
+    hub.send_many = (  # type: ignore[assignment]
+        lambda message, destinations, **kwargs: all(
+            _capture_send(
+                message,
+                destination=destination,
+                fields=kwargs.get("fields"),
+                sender=kwargs.get("sender"),
+            )
+            for destination in destinations
+        )
+    )
     try:
         assert hub.mission_domain_service is not None
         domain = hub.mission_domain_service


### PR DESCRIPTION
## Summary
- add runtime metrics store and expose runtime diagnostics in northbound status/API
- refactor outbound queue for delayed scheduling, deadline-driven receipt handling, and explicit saturation outcomes
- optimize fanout paths with bulk send support and destination caching
- harden websocket delivery/error handling and move blocking message send off the event loop
- replace hot-path TAK syncio.run usage with a dedicated async runner
- fix queue-capacity enforcement across ready+delayed buffers and evict destination cache entries on leave

## Tests
- python -m pytest --no-cov tests/northbound/test_websocket_handlers.py tests/test_outbound_queue.py tests/test_command_manager.py::test_handle_leave_invokes_destination_removed_callback -q
- python -m pytest --no-cov tests/test_reticulum_server_daemon.py -q
- python -m pytest --no-cov tests/test_command_manager.py -q
- python -m ruff check reticulum_telemetry_hub/reticulum_server/outbound_queue.py tests/test_outbound_queue.py

## Notes
- full python -m pytest -q was started twice but exceeded local command timeout windows in this session.