### PR TITLE
Fix CI failures after delivery/routing service extraction

### DIFF
--- a/reticulum_telemetry_hub/reticulum_server/__main__.py
+++ b/reticulum_telemetry_hub/reticulum_server/__main__.py
@@ -1328,8 +1328,13 @@ class ReticulumTelemetryHub:
         manager = getattr(self, "command_manager", None)
         if not isinstance(manager, CommandManager):
             return False
-        normalize_name_fn = cast(Callable[[str], str | None], normalize_name)
-        known_names = set(all_names())
+        normalize_name_fn = cast(
+            Callable[[str | None], str | None],
+            manager._normalize_command_name,  # pylint: disable=protected-access
+        )
+        known_names = set(
+            manager._all_command_names()  # pylint: disable=protected-access
+        )
 
         for command in commands:
             if not isinstance(command, dict):

--- a/reticulum_telemetry_hub/reticulum_server/delivery_service.py
+++ b/reticulum_telemetry_hub/reticulum_server/delivery_service.py
@@ -89,7 +89,7 @@ class DeliveryService:
     def ensure_outbound_queue(self) -> OutboundMessageQueue | None:
         """Initialize and start the outbound worker queue."""
 
-        if self._hub.my_lxmf_dest is None:
+        if getattr(self._hub, "my_lxmf_dest", None) is None:
             return None
 
         if not hasattr(self._hub, "_outbound_queue"):

--- a/reticulum_telemetry_hub/reticulum_server/message_router.py
+++ b/reticulum_telemetry_hub/reticulum_server/message_router.py
@@ -245,7 +245,8 @@ class MessageRouter:
                 topic_id=normalized_topic_id,
                 destination=normalized_destination,
             )
-        enqueued = self.send_message(
+        send_message_fn = getattr(self._hub, "send_message", self.send_message)
+        enqueued = send_message_fn(
             outbound_message,
             topic=normalized_topic_id,
             destination=normalized_destination,


### PR DESCRIPTION
### Motivation
- The outbound delivery/routing refactor introduced runtime and lint regressions causing CI failures: undefined command helper references, dispatch bypassing test stubs, and AttributeError for partially-initialized hub instances.

### Description
- Replaced stale references in `ReticulumTelemetryHub._should_ignore_passive_command_payload()` with the `CommandManager` APIs by calling `manager._normalize_command_name` and `manager._all_command_names()` to restore correct command-name normalization and listing.
- Restored dispatch compatibility in `MessageRouter.dispatch_northbound_message()` by preferring an instance `hub.send_message` (when present) before falling back to the router's `send_message` implementation so tests that monkeypatch `hub.send_message` behave correctly.
- Hardened `DeliveryService.ensure_outbound_queue()` to avoid `AttributeError` on partially-initialized hub objects by using `getattr(self._hub, "my_lxmf_dest", None)`.
- Changes touch `reticulum_telemetry_hub/reticulum_server/__main__.py`, `.../message_router.py`, and `.../delivery_service.py` to address the issues.

### Testing
- Ran linter with `ruff check .` which passed successfully.
- Ran the full test suite with `pytest -q`, and all tests passed (`750 passed`) with total coverage meeting the required threshold (coverage >= 90%, final 90.14%).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d024f1988325b46dc11f5cd4a908)