### PR TITLE
Make telemetry websocket snapshots non-blocking with timing metrics

### DIFF
--- a/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import contextmanager
 from datetime import datetime
 import json
@@ -418,6 +419,30 @@ class TelemetryController:
                     }
                 )
             return entries
+
+    async def list_telemetry_entries_async(
+        self, *, since: int, topic_id: str | None = None
+    ) -> list[dict[str, object]]:
+        """Return telemetry entries without blocking the event loop.
+
+        This method is intended for async callers (for example websocket
+        handlers) and offloads synchronous SQLAlchemy access to a thread.
+
+        Args:
+            since (int): Unix timestamp (seconds) for the earliest telemetry
+                records to include.
+            topic_id (str | None): Optional topic identifier for filtering.
+
+        Returns:
+            list[dict[str, object]]: Telemetry entries formatted for async
+                northbound consumers.
+        """
+
+        return await asyncio.to_thread(
+            self.list_telemetry_entries,
+            since=since,
+            topic_id=topic_id,
+        )
 
     def register_listener(
         self,

--- a/reticulum_telemetry_hub/northbound/app.py
+++ b/reticulum_telemetry_hub/northbound/app.py
@@ -305,6 +305,7 @@ def create_app(
         event_broadcaster=event_broadcaster,
         telemetry_broadcaster=telemetry_broadcaster,
         message_broadcaster=message_broadcaster,
+        runtime_metrics=runtime_metrics,
     )
     if control is not None:
         register_control_routes(

--- a/reticulum_telemetry_hub/northbound/routes_ws.py
+++ b/reticulum_telemetry_hub/northbound/routes_ws.py
@@ -75,7 +75,7 @@ def register_ws_routes(
             websocket (WebSocket): WebSocket connection.
         """
 
-        def _telemetry_snapshot(since: int, topic_id: str | None) -> list[dict]:
+        async def _telemetry_snapshot(since: int, topic_id: str | None) -> list[dict]:
             """Return telemetry snapshots for WebSocket clients.
 
             Args:
@@ -86,7 +86,10 @@ def register_ws_routes(
                 list[dict]: Telemetry entries.
             """
 
-            return services.telemetry_entries(since=since, topic_id=topic_id)
+            return await services.telemetry.list_telemetry_entries_async(
+                since=since,
+                topic_id=topic_id,
+            )
 
         await handle_telemetry_socket(
             websocket,

--- a/reticulum_telemetry_hub/northbound/routes_ws.py
+++ b/reticulum_telemetry_hub/northbound/routes_ws.py
@@ -24,6 +24,7 @@ def register_ws_routes(
     event_broadcaster: EventBroadcaster,
     telemetry_broadcaster: TelemetryBroadcaster,
     message_broadcaster: MessageBroadcaster,
+    runtime_metrics: object | None = None,
 ) -> None:
     """Register WebSocket routes on the FastAPI app.
 
@@ -34,6 +35,7 @@ def register_ws_routes(
         event_broadcaster (EventBroadcaster): Event broadcaster.
         telemetry_broadcaster (TelemetryBroadcaster): Telemetry broadcaster.
         message_broadcaster (MessageBroadcaster): Message broadcaster.
+        runtime_metrics (object | None): Optional runtime metrics sink.
 
     Returns:
         None: Routes are registered on the application.
@@ -96,6 +98,7 @@ def register_ws_routes(
             auth=auth,
             telemetry_broadcaster=telemetry_broadcaster,
             telemetry_snapshot=_telemetry_snapshot,
+            runtime_metrics=runtime_metrics,
         )
 
     @app.websocket("/messages/stream")

--- a/reticulum_telemetry_hub/northbound/websocket.py
+++ b/reticulum_telemetry_hub/northbound/websocket.py
@@ -18,6 +18,7 @@ from typing import Awaitable
 from typing import Callable
 from typing import Dict
 from typing import Optional
+from typing import TypeAlias
 
 from fastapi import WebSocketDisconnect
 from fastapi import WebSocket
@@ -56,6 +57,24 @@ def _metrics_set_gauge(metrics: object | None, key: str, value: float) -> None:
     setter = getattr(metrics, "set_gauge", None)
     if callable(setter):
         setter(key, value)
+
+
+def _metrics_observe_ms(metrics: object | None, key: str, value_ms: float) -> None:
+    """Record a runtime timer metric (in milliseconds) when supported."""
+
+    if metrics is None:
+        return
+    observer = getattr(metrics, "observe_ms", None)
+    if callable(observer):
+        observer(key, value_ms)
+
+
+# Contract: providers used by websocket handlers must be non-blocking
+# (async-native or internally offloaded with ``asyncio.to_thread``).
+TelemetrySnapshotProvider: TypeAlias = Callable[
+    [int, Optional[str]],
+    Awaitable[list[Dict[str, object]]],
+]
 
 
 @dataclass(eq=False)
@@ -986,6 +1005,20 @@ async def _cancel_task(task: asyncio.Task[Any] | None) -> None:
             return
 
 
+async def _send_json_timed(
+    websocket: WebSocket,
+    payload: Dict[str, Any],
+    *,
+    runtime_metrics: object | None = None,
+    metric_key: str,
+) -> None:
+    """Send websocket JSON while recording send latency."""
+
+    started = time.perf_counter()
+    await websocket.send_json(payload)
+    _metrics_observe_ms(runtime_metrics, metric_key, (time.perf_counter() - started) * 1000.0)
+
+
 async def handle_system_socket(
     websocket: WebSocket,
     *,
@@ -1087,7 +1120,8 @@ async def handle_telemetry_socket(
     *,
     auth: ApiAuth,
     telemetry_broadcaster: TelemetryBroadcaster,
-    telemetry_snapshot: Callable[[int, Optional[str]], list[Dict[str, object]]],
+    telemetry_snapshot: TelemetrySnapshotProvider,
+    runtime_metrics: object | None = None,
     ping_interval_seconds: float = DEFAULT_WS_PING_INTERVAL_SECONDS,
     inactivity_timeout_seconds: float = DEFAULT_WS_INACTIVITY_TIMEOUT_SECONDS,
 ) -> None:
@@ -1097,7 +1131,9 @@ async def handle_telemetry_socket(
         websocket (WebSocket): WebSocket connection.
         auth (ApiAuth): Auth validator.
         telemetry_broadcaster (TelemetryBroadcaster): Telemetry broadcaster.
-        telemetry_snapshot (Callable[[int, Optional[str]], list[Dict[str, object]]]): Snapshot provider.
+        telemetry_snapshot (TelemetrySnapshotProvider): Non-blocking snapshot
+            provider for initial history replies.
+        runtime_metrics (object | None): Optional runtime metrics sink.
         ping_interval_seconds (float): Interval between keepalive ping payloads.
         inactivity_timeout_seconds (float): Maximum idle time allowed before the
             socket is closed.
@@ -1139,9 +1175,18 @@ async def handle_telemetry_socket(
                 except ValueError as exc:
                     await websocket.send_json(build_error_message("bad_request", str(exc)))
                     continue
-                entries = telemetry_snapshot(since, topic_id)
-                await websocket.send_json(
-                    build_ws_message("telemetry.snapshot", {"entries": entries})
+                snapshot_started = time.perf_counter()
+                entries = await telemetry_snapshot(since, topic_id)
+                _metrics_observe_ms(
+                    runtime_metrics,
+                    "ws_telemetry_snapshot_generation_ms",
+                    (time.perf_counter() - snapshot_started) * 1000.0,
+                )
+                await _send_json_timed(
+                    websocket,
+                    build_ws_message("telemetry.snapshot", {"entries": entries}),
+                    runtime_metrics=runtime_metrics,
+                    metric_key="ws_telemetry_snapshot_send_latency_ms",
                 )
                 if follow:
                     if unsubscribe:
@@ -1157,8 +1202,11 @@ async def handle_telemetry_socket(
                                 None: Sends messages to the WebSocket client.
                             """
 
-                            await websocket.send_json(
-                                build_ws_message("telemetry.update", {"entry": entry})
+                            await _send_json_timed(
+                                websocket,
+                                build_ws_message("telemetry.update", {"entry": entry}),
+                                runtime_metrics=runtime_metrics,
+                                metric_key="ws_telemetry_update_send_latency_ms",
                             )
 
                         unsubscribe = telemetry_broadcaster.subscribe(

--- a/tests/northbound/test_websocket_handlers.py
+++ b/tests/northbound/test_websocket_handlers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from typing import Any
 
 from reticulum_telemetry_hub.northbound.websocket import authenticate_websocket
@@ -201,7 +202,10 @@ def test_handle_telemetry_socket_subscribe_variants(monkeypatch) -> None:
             websocket,
             auth=_FakeAuth(True),
             telemetry_broadcaster=broadcaster,
-            telemetry_snapshot=lambda since, topic_id: [{"since": since, "topic": topic_id}],
+            telemetry_snapshot=lambda since, topic_id: asyncio.sleep(
+                0,
+                result=[{"since": since, "topic": topic_id}],
+            ),
         )
 
         assert websocket.accepted is True
@@ -209,6 +213,70 @@ def test_handle_telemetry_socket_subscribe_variants(monkeypatch) -> None:
         assert any(item["type"] == "error" for item in websocket.sent)
         assert broadcaster.calls == [("t1",)]
         assert broadcaster.unsubscribed is True
+
+    asyncio.run(_exercise())
+
+
+def test_telemetry_subscriptions_do_not_block_other_socket_pong(monkeypatch) -> None:
+    """Ensure a slow telemetry snapshot does not stall pong handling elsewhere."""
+
+    async def _exercise() -> None:
+        slow_websocket = _FakeWebSocket(
+            [
+                {"type": "telemetry.subscribe", "data": {"since": 1, "follow": False}},
+                {"type": "unsupported"},
+            ]
+        )
+        fast_websocket = _FakeWebSocket(
+            [
+                {"type": "pong"},
+                {"type": "unsupported"},
+            ]
+        )
+        broadcaster = _FakeTelemetryBroadcaster()
+
+        async def _fake_ping_loop(*_args, **_kwargs):
+            await asyncio.sleep(999)
+
+        async def _slow_snapshot(_since: int, _topic_id: str | None) -> list[dict[str, object]]:
+            await asyncio.to_thread(time.sleep, 0.05)
+            return [{"peer_destination": "abc"}]
+
+        monkeypatch.setattr(
+            "reticulum_telemetry_hub.northbound.websocket.authenticate_websocket",
+            lambda *args, **kwargs: asyncio.sleep(0, result=True),
+        )
+        monkeypatch.setattr(
+            "reticulum_telemetry_hub.northbound.websocket.ping_loop",
+            _fake_ping_loop,
+        )
+
+        start = time.perf_counter()
+        slow_task = asyncio.create_task(
+            handle_telemetry_socket(
+                slow_websocket,
+                auth=_FakeAuth(True),
+                telemetry_broadcaster=broadcaster,
+                telemetry_snapshot=_slow_snapshot,
+            )
+        )
+        fast_task = asyncio.create_task(
+            handle_telemetry_socket(
+                fast_websocket,
+                auth=_FakeAuth(True),
+                telemetry_broadcaster=broadcaster,
+                telemetry_snapshot=lambda *_args, **_kwargs: asyncio.sleep(0, result=[]),
+            )
+        )
+        await fast_task
+        fast_elapsed = time.perf_counter() - start
+        await slow_task
+
+        assert fast_elapsed < 0.04
+        assert slow_websocket.accepted is True
+        assert fast_websocket.accepted is True
+        assert any(item["type"] == "telemetry.snapshot" for item in slow_websocket.sent)
+        assert all(item["type"] != "error" or item["data"]["code"] != "timeout" for item in fast_websocket.sent)
 
     asyncio.run(_exercise())
 

--- a/tests/northbound/test_websocket_handlers.py
+++ b/tests/northbound/test_websocket_handlers.py
@@ -234,12 +234,16 @@ def test_telemetry_subscriptions_do_not_block_other_socket_pong(monkeypatch) -> 
             ]
         )
         broadcaster = _FakeTelemetryBroadcaster()
+        snapshot_started = asyncio.Event()
+        snapshot_finished = asyncio.Event()
 
         async def _fake_ping_loop(*_args, **_kwargs):
             await asyncio.sleep(999)
 
         async def _slow_snapshot(_since: int, _topic_id: str | None) -> list[dict[str, object]]:
-            await asyncio.to_thread(time.sleep, 0.05)
+            snapshot_started.set()
+            await asyncio.to_thread(time.sleep, 0.2)
+            snapshot_finished.set()
             return [{"peer_destination": "abc"}]
 
         monkeypatch.setattr(
@@ -251,7 +255,6 @@ def test_telemetry_subscriptions_do_not_block_other_socket_pong(monkeypatch) -> 
             _fake_ping_loop,
         )
 
-        start = time.perf_counter()
         slow_task = asyncio.create_task(
             handle_telemetry_socket(
                 slow_websocket,
@@ -268,11 +271,11 @@ def test_telemetry_subscriptions_do_not_block_other_socket_pong(monkeypatch) -> 
                 telemetry_snapshot=lambda *_args, **_kwargs: asyncio.sleep(0, result=[]),
             )
         )
-        await fast_task
-        fast_elapsed = time.perf_counter() - start
+        await snapshot_started.wait()
+        await asyncio.wait_for(fast_task, timeout=0.05)
+        assert snapshot_finished.is_set() is False
         await slow_task
 
-        assert fast_elapsed < 0.04
         assert slow_websocket.accepted is True
         assert fast_websocket.accepted is True
         assert any(item["type"] == "telemetry.snapshot" for item in slow_websocket.sent)


### PR DESCRIPTION
### Motivation
- Telemetry snapshot generation uses synchronous SQLAlchemy paths and can block the event loop when served directly to WebSocket clients, risking stalled ping/pong handling and degraded responsiveness.
- WebSocket handlers need an explicit contract that snapshot providers are non-blocking so async code paths remain safe.
- Add lightweight timing instrumentation to observe snapshot generation and send latencies for operational visibility.

### Description
- Added `TelemetryController.list_telemetry_entries_async()` which offloads the existing synchronous `list_telemetry_entries()` to a background thread via `await asyncio.to_thread(...)`. (file: `lxmf_telemetry/telemetry_controller.py`)
- Changed the telemetry WS route wiring to use the new async snapshot provider (`services.telemetry.list_telemetry_entries_async(...)`). (file: `northbound/routes_ws.py`)
- Introduced a typed contract `TelemetrySnapshotProvider: TypeAlias = Callable[[int, Optional[str]], Awaitable[list[Dict[str, object]]]]` and a comment that providers must be non-blocking. (file: `northbound/websocket.py`)
- Added runtime metric helper `_metrics_observe_ms` and send-timed helper `_send_json_timed`, and instrumented `handle_telemetry_socket` to measure snapshot generation time and websocket send latency for snapshot and update messages; `handle_telemetry_socket` now awaits the async snapshot provider. (file: `northbound/websocket.py`)
- Added a regression test `test_telemetry_subscriptions_do_not_block_other_socket_pong` that runs concurrent telemetry websocket handlers and verifies a slow snapshot does not delay another socket's pong handling, and adjusted existing telemetry handler tests to use async-friendly snapshot providers. (file: `tests/northbound/test_websocket_handlers.py`)

### Testing
- Ran linting: `ruff check reticulum_telemetry_hub/northbound/websocket.py reticulum_telemetry_hub/northbound/routes_ws.py reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py tests/northbound/test_websocket_handlers.py` and it passed.
- Ran the websocket handler tests without coverage: `pytest tests/northbound/test_websocket_handlers.py -q --no-cov` and all tests passed (7 passed).
- Ran the same test file with the repo coverage settings: `pytest tests/northbound/test_websocket_handlers.py -q` which exercises the coverage machinery and failed due to the repository-wide `--cov-fail-under=90` threshold (coverage failure), not because of functional test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d8a2c28c8325936549fe4c4d258a)