### PR TITLE
Batch identity display-name resolution and indexed announce lookups; add index and telemetry query-count test

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -1,4 +1,5 @@
 # TASKS
+- 2026-04-19: DONE. Replace single-identity announce map lookups with indexed queries, add bulk display-name resolution, and add telemetry listing query-count regression coverage.
 - 2026-04-19: DONE. Resolve __main__.py merge-conflict-style separator so conflict-marker scans no longer flag the module header.
 - 2026-04-19: DONE. Apply review follow-ups by switching __main__ to public service APIs and centralizing outbound default constants in shared delivery_defaults.py.
 - 2026-04-19: DONE. Rework the reticulum_server extraction to remove duplicated __main__ logic and delegate outbound routing/delivery/listener flows cleanly to service modules while keeping architecture guards.

--- a/reticulum_telemetry_hub/api/service.py
+++ b/reticulum_telemetry_hub/api/service.py
@@ -260,6 +260,16 @@ class ReticulumTelemetryHubAPI:  # pylint: disable=too-many-public-methods
             return None
         return record.display_name
 
+    def resolve_identity_display_names_bulk(
+        self,
+        identities: list[str],
+    ) -> dict[str, str | None]:
+        """Return display names for a batch of identity hashes."""
+
+        if not identities:
+            return {}
+        return self._storage.resolve_identity_display_names_bulk(identities)
+
     def list_identity_capabilities(self, identity: str) -> List[str]:
         """Return active capabilities for an identity."""
 

--- a/reticulum_telemetry_hub/api/storage.py
+++ b/reticulum_telemetry_hub/api/storage.py
@@ -358,7 +358,7 @@ class HubStorage(HubStorageBase):
             record = session.get(ClientRecord, identity)
             if not record:
                 return None
-            announce = self._identity_announce_map(session).get(identity.lower())
+            announce = self._identity_announce_for_identity(session, identity)
             return self._client_from_record(record, announce)
 
     def create_file_record(self, attachment: FileAttachment) -> FileAttachment:
@@ -487,7 +487,57 @@ class HubStorage(HubStorageBase):
         """Return announce metadata for an identity when present."""
 
         with self._session_scope() as session:
-            return self._identity_announce_map(session).get(identity.lower())
+            return self._identity_announce_for_identity(session, identity)
+
+    def resolve_identity_display_names_bulk(
+        self,
+        identities: list[str],
+    ) -> dict[str, str | None]:
+        """Resolve display names for many identities with one database roundtrip."""
+
+        normalized_identities = [
+            str(identity).strip().lower()
+            for identity in identities
+            if str(identity).strip()
+        ]
+        if not normalized_identities:
+            return {}
+        requested = set(normalized_identities)
+        canonical_announces: dict[str, IdentityAnnounceRecord] = {}
+        keys_by_canonical: dict[str, set[str]] = {}
+        with self._session_scope() as session:
+            records = (
+                session.query(IdentityAnnounceRecord)
+                .filter(
+                    or_(
+                        IdentityAnnounceRecord.destination_hash.in_(requested),
+                        IdentityAnnounceRecord.announced_identity_hash.in_(requested),
+                    )
+                )
+                .all()
+            )
+            for record in records:
+                destination_hash = str(record.destination_hash or "").strip().lower()
+                announced_identity_hash = str(record.announced_identity_hash or "").strip().lower()
+                canonical_key = announced_identity_hash or destination_hash
+                if not canonical_key:
+                    continue
+                canonical_announces[canonical_key] = self._merge_identity_announce_records(
+                    canonical_announces.get(canonical_key),
+                    record,
+                )
+                keys = keys_by_canonical.setdefault(canonical_key, set())
+                if destination_hash in requested:
+                    keys.add(destination_hash)
+                if announced_identity_hash in requested:
+                    keys.add(announced_identity_hash)
+        resolved_display_names: dict[str, str | None] = {}
+        for canonical_key, keys in keys_by_canonical.items():
+            display_name = canonical_announces.get(canonical_key).display_name
+            for key in keys:
+                resolved_display_names[key] = display_name
+
+        return {identity: resolved_display_names.get(identity) for identity in normalized_identities}
 
     def list_identity_announces(self) -> List[IdentityAnnounceRecord]:
         """Return all announce metadata records."""
@@ -1112,6 +1162,10 @@ class HubStorage(HubStorageBase):
             (
                 "CREATE INDEX IF NOT EXISTS ix_chat_messages_source_created_at "
                 "ON chat_messages(source, created_at DESC);"
+            ),
+            (
+                "CREATE INDEX IF NOT EXISTS ix_identity_announces_announced_identity_hash "
+                "ON identity_announces(announced_identity_hash);"
             ),
         )
         try:

--- a/reticulum_telemetry_hub/api/storage_base.py
+++ b/reticulum_telemetry_hub/api/storage_base.py
@@ -7,6 +7,7 @@ import logging
 import time
 from typing import Any
 
+from sqlalchemy import case
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
 
@@ -269,3 +270,30 @@ class HubStorageBase:
                 record,
             )
         return announce_map
+
+    @staticmethod
+    def _identity_announce_for_identity(
+        session,
+        identity: str,
+    ) -> IdentityAnnounceRecord | None:
+        """Return announce metadata for ``identity`` using indexed point lookups."""
+
+        normalized_identity = str(identity or "").strip().lower()
+        if not normalized_identity:
+            return None
+        direct = session.get(IdentityAnnounceRecord, normalized_identity)
+        if direct is not None:
+            return direct
+        return (
+            session.query(IdentityAnnounceRecord)
+            .filter(IdentityAnnounceRecord.announced_identity_hash == normalized_identity)
+            .order_by(
+                case(
+                    (IdentityAnnounceRecord.source_interface == "identity", 0),
+                    (IdentityAnnounceRecord.display_name.is_not(None), 1),
+                    else_=2,
+                ),
+                IdentityAnnounceRecord.last_seen.desc(),
+            )
+            .first()
+        )

--- a/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
+++ b/reticulum_telemetry_hub/lxmf_telemetry/telemetry_controller.py
@@ -392,14 +392,24 @@ class TelemetryController:
                 start_time=timebase_dt,
                 peer_destinations=allowed_destinations,
             )
+            display_name_by_peer: dict[str, str | None] = {}
+            peer_destinations = [telemeter.peer_dest for telemeter in telemeters if telemeter.peer_dest]
+            if self._api is not None and hasattr(
+                self._api, "resolve_identity_display_names_bulk"
+            ):
+                try:
+                    resolver = getattr(self._api, "resolve_identity_display_names_bulk")
+                    display_name_by_peer = resolver(peer_destinations) or {}
+                except Exception:  # pragma: no cover - defensive
+                    display_name_by_peer = {}
 
             entries: list[dict[str, object]] = []
             for telemeter in telemeters:
                 timestamp = int(telemeter.time.timestamp()) if telemeter.time else 0
                 payload = self._serialize_telemeter(telemeter)
                 readable_payload = self._humanize_telemetry(payload)
-                display_name = None
-                if self._api is not None and hasattr(
+                display_name = display_name_by_peer.get(telemeter.peer_dest)
+                if display_name is None and self._api is not None and hasattr(
                     self._api, "resolve_identity_display_name"
                 ):
                     try:

--- a/tests/northbound/test_telemetry_entries.py
+++ b/tests/northbound/test_telemetry_entries.py
@@ -5,6 +5,7 @@ from datetime import timezone
 from pathlib import Path
 
 import pytest
+from sqlalchemy import event
 
 from reticulum_telemetry_hub.api.models import Subscriber
 from reticulum_telemetry_hub.api.models import Topic
@@ -117,3 +118,41 @@ def test_list_telemetry_entries_unknown_topic(tmp_path) -> None:
 
     with pytest.raises(KeyError):
         controller.list_telemetry_entries(since=0, topic_id="missing")
+
+
+def test_list_telemetry_entries_bulk_resolves_display_names_in_single_query(tmp_path) -> None:
+    """Ensure telemetry listing performs one bulk display-name lookup query."""
+
+    api = _build_api(tmp_path)
+    controller = TelemetryController(db_path=tmp_path / "telemetry.db", api=api)
+    now = datetime.now(timezone.utc)
+    timestamp = int(now.timestamp())
+    payload = {
+        SID_TIME: timestamp,
+        SID_LOCATION: build_location_payload(timestamp),
+    }
+    api.record_identity_announce("peer-1", display_name="Alpha")
+    api.record_identity_announce("peer-2", display_name="Bravo")
+    controller.save_telemetry(payload, "peer-1", timestamp=now)
+    controller.save_telemetry(payload, "peer-2", timestamp=now)
+
+    query_count = 0
+
+    def _before_cursor_execute(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
+        nonlocal query_count
+        normalized_statement = str(statement).lower()
+        if "identity_announces" in normalized_statement and "select" in normalized_statement:
+            query_count += 1
+
+    event.listen(api._storage._engine, "before_cursor_execute", _before_cursor_execute)  # pylint: disable=protected-access
+    try:
+        entries = controller.list_telemetry_entries(since=timestamp - 10)
+    finally:
+        event.remove(
+            api._storage._engine,  # pylint: disable=protected-access
+            "before_cursor_execute",
+            _before_cursor_execute,
+        )
+
+    assert len(entries) == 2
+    assert query_count == 1

--- a/tests/test_rth_api.py
+++ b/tests/test_rth_api.py
@@ -427,6 +427,22 @@ def test_identity_announce_ignores_missing_name(tmp_path):
     assert api.resolve_identity_display_name("deadbeef") == "Sideband-Alice"
 
 
+def test_resolve_identity_display_names_bulk(tmp_path):
+    """Ensure bulk identity display-name resolution returns merged announce view."""
+
+    api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
+    api.record_identity_announce("deadbeef-destination", announced_identity_hash="deadbeef")
+    api.record_identity_announce("deadbeef", display_name="Sideband-Alice")
+
+    resolved = api.resolve_identity_display_names_bulk(
+        ["deadbeef", "deadbeef-destination", "missing"]
+    )
+
+    assert resolved["deadbeef"] == "Sideband-Alice"
+    assert resolved["deadbeef-destination"] == "Sideband-Alice"
+    assert resolved["missing"] is None
+
+
 def test_identity_announce_concurrent_upserts_do_not_duplicate_records(tmp_path):
     api = ReticulumTelemetryHubAPI(config_manager=make_config_manager(tmp_path))
     errors: list[Exception] = []


### PR DESCRIPTION
### Motivation
- Replace repeated single-row announce map scans with indexed point lookups to improve lookup performance and eliminate extra DB roundtrips when resolving identities.
- Support bulk display-name resolution to allow callers to resolve many identities in a single query for telemetry and listing use-cases.
- Add a regression test to ensure telemetry listing uses a single display-name query to prevent query-count regressions.

### Description
- Added `HubStorageBase._identity_announce_for_identity` to perform indexed lookups and a prioritized ordered query when an exact key is not found, and switched callers (`get_client`, `get_identity_announce`) to use it.
- Added `HubStorage.resolve_identity_display_names_bulk` to normalize identities, query `identity_announces` once for both `destination_hash` and `announced_identity_hash`, merge records by canonical key, and return a mapping of requested identities to display names.
- Exposed `ReticulumTelemetryHubAPI.resolve_identity_display_names_bulk` to the service API for bulk resolution and added a bulk-aware path in `TelemetryController.list_telemetry_entries` that calls the bulk resolver and falls back to single lookups defensively.
- Created an index on `identity_announces(announced_identity_hash)` in `_ensure_indexes` to support the new indexed queries.
- Added tests: `tests/northbound/test_telemetry_entries.py::test_list_telemetry_entries_bulk_resolves_display_names_in_single_query` to assert one DB query for display-name resolution during telemetry listing, and `tests/test_rth_api.py::test_resolve_identity_display_names_bulk` to validate merged announce view for bulk resolution.

### Testing
- Ran `tests/northbound/test_telemetry_entries.py::test_list_telemetry_entries_bulk_resolves_display_names_in_single_query` which verified telemetry listing performs a single `identity_announces` SELECT and the test passed.
- Ran `tests/test_rth_api.py::test_resolve_identity_display_names_bulk` which verified bulk resolution returns merged announce display-names and the test passed.
- Existing identity announce/status tests that exercise `get_identity_announce` and `resolve_identity_display_name` were also exercised and continued to pass during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d8b7b6008325b8519ec1defb29b7)