### PR TITLE
Make WS system status fan-out configurable, cache status snapshots, and use DB-backed count queries

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -1,4 +1,5 @@
 # TASKS
+- 2026-04-19: DONE. Make northbound system websocket status fan-out configurable (`event_only` default with periodic/event-plus-periodic options), cache periodic status snapshots, and switch status counts to DB-backed count queries.
 - 2026-04-19: DONE. Replace single-identity announce map lookups with indexed queries, add bulk display-name resolution, and add telemetry listing query-count regression coverage.
 - 2026-04-19: DONE. Resolve __main__.py merge-conflict-style separator so conflict-marker scans no longer flag the module header.
 - 2026-04-19: DONE. Apply review follow-ups by switching __main__ to public service APIs and centralizing outbound default constants in shared delivery_defaults.py.

--- a/reticulum_telemetry_hub/api/service.py
+++ b/reticulum_telemetry_hub/api/service.py
@@ -209,6 +209,11 @@ class ReticulumTelemetryHubAPI:  # pylint: disable=too-many-public-methods
             for client in self._storage.list_clients()
         ]
 
+    def count_clients(self) -> int:
+        """Return the number of clients that have joined the hub."""
+
+        return self._storage.count_clients()
+
     def has_client(self, identity: str) -> bool:
         """Return ``True`` when the client is registered with the hub.
 
@@ -612,10 +617,20 @@ class ReticulumTelemetryHubAPI:  # pylint: disable=too-many-public-methods
 
         return self._storage.list_file_records(category=self._file_category)
 
+    def count_files(self) -> int:
+        """Return the number of stored file attachments."""
+
+        return self._storage.count_file_records(category=self._file_category)
+
     def list_images(self) -> List[FileAttachment]:
         """Return stored image records."""
 
         return self._storage.list_file_records(category=self._image_category)
+
+    def count_images(self) -> int:
+        """Return the number of stored image attachments."""
+
+        return self._storage.count_file_records(category=self._image_category)
 
     def retrieve_file(self, record_id: int) -> FileAttachment:
         """Fetch stored file metadata by ID."""
@@ -764,6 +779,11 @@ class ReticulumTelemetryHubAPI:  # pylint: disable=too-many-public-methods
             List[Topic]: Current topic catalog from storage.
         """
         return self._storage.list_topics()
+
+    def count_topics(self) -> int:
+        """Return the number of topics known to the hub."""
+
+        return self._storage.count_topics()
 
     def retrieve_topic(self, topic_id: str) -> Topic:
         """Fetch a topic by its identifier.
@@ -921,6 +941,11 @@ class ReticulumTelemetryHubAPI:  # pylint: disable=too-many-public-methods
             List[Subscriber]: Subscribers currently stored in the hub.
         """
         return self._storage.list_subscribers()
+
+    def count_subscribers(self) -> int:
+        """Return the number of subscribers currently stored in the hub."""
+
+        return self._storage.count_subscribers()
 
     def list_subscribers_for_topic(self, topic_id: str) -> List[Subscriber]:
         """Return subscribers for a specific topic.

--- a/reticulum_telemetry_hub/api/storage.py
+++ b/reticulum_telemetry_hub/api/storage.py
@@ -120,6 +120,13 @@ class HubStorage(HubStorageBase):
                 for r in records
             ]
 
+    def count_topics(self) -> int:
+        """Return the total number of topics."""
+
+        with self._session_scope() as session:
+            total = session.query(sa_count(TopicRecord.id)).scalar()
+            return int(total or 0)
+
     def get_topic(self, topic_id: str) -> Optional[Topic]:
         """Fetch a topic by identifier.
 
@@ -228,6 +235,13 @@ class HubStorage(HubStorageBase):
         with self._session_scope() as session:
             records = session.query(SubscriberRecord).all()
             return [self._subscriber_from_record(r) for r in records]
+
+    def count_subscribers(self) -> int:
+        """Return the total number of subscribers."""
+
+        with self._session_scope() as session:
+            total = session.query(sa_count(SubscriberRecord.id)).scalar()
+            return int(total or 0)
 
     def list_subscribers_for_topic(self, topic_id: str) -> List[Subscriber]:
         """Return subscribers stored for a topic identifier."""
@@ -345,6 +359,13 @@ class HubStorage(HubStorageBase):
                 for record in records
             ]
 
+    def count_clients(self) -> int:
+        """Return the total number of clients."""
+
+        with self._session_scope() as session:
+            total = session.query(sa_count(ClientRecord.identity)).scalar()
+            return int(total or 0)
+
     def get_client(self, identity: str) -> Client | None:
         """Return a client by identity when it exists.
 
@@ -387,6 +408,16 @@ class HubStorage(HubStorageBase):
                 query = query.filter(FileRecord.category == category)
             records = query.all()
             return [self._file_from_record(record) for record in records]
+
+    def count_file_records(self, category: str | None = None) -> int:
+        """Return the number of stored file records for an optional category."""
+
+        with self._session_scope() as session:
+            query = session.query(sa_count(FileRecord.id))
+            if category:
+                query = query.filter(FileRecord.category == category)
+            total = query.scalar()
+            return int(total or 0)
 
     def get_file_record(self, record_id: int) -> FileAttachment | None:
         """Return a stored file by its database identifier."""

--- a/reticulum_telemetry_hub/config/default_config.ini
+++ b/reticulum_telemetry_hub/config/default_config.ini
@@ -30,6 +30,13 @@ reticulum_config_path = ~/.reticulum/config
 # automatically from its packaged LXMF template.
 lxmf_router_config_path =
 telemetry_filename = telemetry.ini
+# System websocket status fan-out strategy:
+# - event_only (default): send status only on initial subscribe/request.
+# - periodic: send status on interval only, never piggybacked on events.
+# - event_plus_periodic: send both periodic status and event-triggered status.
+ws_status_fanout_mode = event_only
+# Periodic status refresh cadence in seconds (2-5s recommended).
+ws_status_refresh_interval_seconds = 3.0
 # Max bytes accepted by POST /Chat/Attachment. Defaults to 8 MiB.
 chat_attachment_max_bytes = 8388608
 # Legacy/compat override keys accepted in [hub]:

--- a/reticulum_telemetry_hub/config/manager.py
+++ b/reticulum_telemetry_hub/config/manager.py
@@ -22,6 +22,8 @@ from .models import (
     TakConnectionConfig,
 )
 
+_WS_STATUS_FANOUT_MODES = {"event_only", "periodic", "event_plus_periodic"}
+
 
 def _expand_user_path(value: Path | str) -> Path:
     """Expand user paths honoring HOME overrides on Windows."""
@@ -419,6 +421,15 @@ class HubConfigurationManager:  # pylint: disable=too-many-instance-attributes
             hub_section.get("event_retention_days"),
             defaults.event_retention_days,
         )
+        ws_status_fanout_mode = self._normalize_status_fanout_mode(
+            hub_section.get("ws_status_fanout_mode"),
+            default=defaults.ws_status_fanout_mode,
+        )
+        ws_status_refresh_interval_seconds = self._coerce_min_float(
+            hub_section.get("ws_status_refresh_interval_seconds"),
+            default=defaults.ws_status_refresh_interval_seconds,
+            minimum=2.0,
+        )
         chat_attachment_max_bytes = self._coerce_optional_int_min(
             hub_section.get("chat_attachment_max_bytes"),
             minimum=1,
@@ -561,6 +572,8 @@ class HubConfigurationManager:  # pylint: disable=too-many-instance-attributes
             ),
             telemetry_filename=telemetry_filename,
             event_retention_days=event_retention_days,
+            ws_status_fanout_mode=ws_status_fanout_mode,
+            ws_status_refresh_interval_seconds=ws_status_refresh_interval_seconds,
             chat_attachment_max_bytes=chat_attachment_max_bytes,
             file_storage_path=file_storage_path,
             image_storage_path=image_storage_path,
@@ -951,6 +964,17 @@ class HubConfigurationManager:  # pylint: disable=too-many-instance-attributes
             return float(value)
         except ValueError:
             return default
+
+    @staticmethod
+    def _normalize_status_fanout_mode(value: str | None, *, default: str) -> str:
+        """Return a supported status fan-out mode."""
+
+        if value is None:
+            return default
+        normalized = str(value).strip().lower()
+        if normalized in _WS_STATUS_FANOUT_MODES:
+            return normalized
+        return default
 
     @staticmethod
     def _normalize_propagation_start_mode(value: str | None) -> str:

--- a/reticulum_telemetry_hub/config/models.py
+++ b/reticulum_telemetry_hub/config/models.py
@@ -182,6 +182,8 @@ class HubRuntimeConfig:  # pylint: disable=too-many-instance-attributes
     telemetry_filename: str = "telemetry.ini"
     event_retention_days: int = 90
     chat_attachment_max_bytes: int = 8 * 1024 * 1024
+    ws_status_fanout_mode: str = "event_only"
+    ws_status_refresh_interval_seconds: float = 3.0
     file_storage_path: Path | None = None
     image_storage_path: Path | None = None
 

--- a/reticulum_telemetry_hub/northbound/app.py
+++ b/reticulum_telemetry_hub/northbound/app.py
@@ -55,6 +55,8 @@ from .services import NorthboundServices
 from .websocket import EventBroadcaster
 from .websocket import MessageBroadcaster
 from .websocket import TelemetryBroadcaster
+from .websocket import DEFAULT_WS_STATUS_FANOUT_MODE
+from .websocket import DEFAULT_WS_STATUS_REFRESH_INTERVAL_SECONDS
 
 
 def _resolve_openapi_spec() -> Optional[Path]:
@@ -306,6 +308,22 @@ def create_app(
         telemetry_broadcaster=telemetry_broadcaster,
         message_broadcaster=message_broadcaster,
         runtime_metrics=runtime_metrics,
+        status_fanout_mode=(
+            getattr(config_manager.runtime_config, "ws_status_fanout_mode", DEFAULT_WS_STATUS_FANOUT_MODE)
+            if config_manager is not None
+            else DEFAULT_WS_STATUS_FANOUT_MODE
+        ),
+        status_refresh_interval_seconds=(
+            float(
+                getattr(
+                    config_manager.runtime_config,
+                    "ws_status_refresh_interval_seconds",
+                    DEFAULT_WS_STATUS_REFRESH_INTERVAL_SECONDS,
+                )
+            )
+            if config_manager is not None
+            else DEFAULT_WS_STATUS_REFRESH_INTERVAL_SECONDS
+        ),
     )
     if control is not None:
         register_control_routes(

--- a/reticulum_telemetry_hub/northbound/routes_ws.py
+++ b/reticulum_telemetry_hub/northbound/routes_ws.py
@@ -25,6 +25,8 @@ def register_ws_routes(
     telemetry_broadcaster: TelemetryBroadcaster,
     message_broadcaster: MessageBroadcaster,
     runtime_metrics: object | None = None,
+    status_fanout_mode: str = "event_only",
+    status_refresh_interval_seconds: float = 3.0,
 ) -> None:
     """Register WebSocket routes on the FastAPI app.
 
@@ -36,6 +38,8 @@ def register_ws_routes(
         telemetry_broadcaster (TelemetryBroadcaster): Telemetry broadcaster.
         message_broadcaster (MessageBroadcaster): Message broadcaster.
         runtime_metrics (object | None): Optional runtime metrics sink.
+        status_fanout_mode (str): System websocket status fan-out mode.
+        status_refresh_interval_seconds (float): Status refresh cadence.
 
     Returns:
         None: Routes are registered on the application.
@@ -65,8 +69,12 @@ def register_ws_routes(
             websocket,
             auth=auth,
             event_broadcaster=event_broadcaster,
-            status_provider=services.status_snapshot,
+            status_provider=lambda: services.status_snapshot_cached(
+                max_age_seconds=status_refresh_interval_seconds
+            ),
             event_list_provider=_event_list_provider,
+            status_fanout_mode=status_fanout_mode,
+            status_refresh_interval_seconds=status_refresh_interval_seconds,
         )
 
     @app.websocket("/telemetry/stream")

--- a/reticulum_telemetry_hub/northbound/services.py
+++ b/reticulum_telemetry_hub/northbound/services.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import field
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
@@ -115,6 +116,8 @@ class NorthboundServices:
     zone_service: ZoneService | None = None
     origin_rch: str = ""
     runtime_metrics_provider: Optional[Callable[[], Dict[str, object]]] = None
+    _status_cache_snapshot: Dict[str, object] | None = field(default=None, init=False)
+    _status_cache_generated_at: float = field(default=0.0, init=False)
 
     def help_text(self) -> str:
         """Return the Help command text.
@@ -156,11 +159,11 @@ class NorthboundServices:
         runtime = self.runtime_diagnostics()
         return {
             "uptime_seconds": int(uptime.total_seconds()),
-            "clients": len(self.api.list_clients()),
-            "topics": len(self.api.list_topics()),
-            "subscribers": len(self.api.list_subscribers()),
-            "files": len(self.api.list_files()),
-            "images": len(self.api.list_images()),
+            "clients": self.api.count_clients(),
+            "topics": self.api.count_topics(),
+            "subscribers": self.api.count_subscribers(),
+            "files": self.api.count_files(),
+            "images": self.api.count_images(),
             "chat": {
                 "sent": chat_stats.get("sent", 0),
                 "failed": chat_stats.get("failed", 0),
@@ -169,6 +172,20 @@ class NorthboundServices:
             "telemetry": self.telemetry.telemetry_stats(),
             "runtime": runtime,
         }
+
+    def status_snapshot_cached(self, *, max_age_seconds: float) -> Dict[str, object]:
+        """Return a cached status snapshot refreshed at most every ``max_age_seconds``."""
+
+        now = datetime.now(timezone.utc).timestamp()
+        should_refresh = (
+            self._status_cache_snapshot is None
+            or max_age_seconds <= 0
+            or (now - self._status_cache_generated_at) >= max_age_seconds
+        )
+        if should_refresh:
+            self._status_cache_snapshot = self.status_snapshot()
+            self._status_cache_generated_at = now
+        return dict(self._status_cache_snapshot)
 
     def runtime_diagnostics(self) -> Dict[str, object]:
         """Return the detailed runtime metrics snapshot when available."""

--- a/reticulum_telemetry_hub/northbound/websocket.py
+++ b/reticulum_telemetry_hub/northbound/websocket.py
@@ -35,6 +35,9 @@ from .auth import ApiAuth
 DEFAULT_WS_PING_INTERVAL_SECONDS = 30.0
 DEFAULT_WS_INACTIVITY_TIMEOUT_SECONDS = 90.0
 DEFAULT_WS_DELIVERY_QUEUE_SIZE = 64
+DEFAULT_WS_STATUS_REFRESH_INTERVAL_SECONDS = 3.0
+DEFAULT_WS_STATUS_FANOUT_MODE = "event_only"
+_WS_STATUS_FANOUT_MODES = {"event_only", "periodic", "event_plus_periodic"}
 WS_INACTIVITY_CLOSE_CODE = 4004
 LOGGER = logging.getLogger(__name__)
 
@@ -789,7 +792,12 @@ def _auth_failure_detail(auth: ApiAuth, client_host: Optional[str]) -> str:
     return "Unauthorized"
 
 
-def _get_subscribe_flags(data: Dict[str, Any]) -> tuple[bool, bool, int]:
+def _get_subscribe_flags(
+    data: Dict[str, Any],
+    *,
+    default_include_status: bool,
+    default_include_events: bool,
+) -> tuple[bool, bool, int]:
     """Return subscription flags for system events.
 
     Args:
@@ -799,12 +807,23 @@ def _get_subscribe_flags(data: Dict[str, Any]) -> tuple[bool, bool, int]:
         tuple[bool, bool, int]: include_status, include_events, events_limit.
     """
 
-    include_status = bool(data.get("include_status", True))
-    include_events = bool(data.get("include_events", True))
+    include_status = data.get("include_status")
+    include_events = data.get("include_events")
+    include_status_flag = default_include_status if include_status is None else bool(include_status)
+    include_events_flag = default_include_events if include_events is None else bool(include_events)
     events_limit = data.get("events_limit")
     if not isinstance(events_limit, int) or events_limit <= 0:
         events_limit = 50
-    return include_status, include_events, events_limit
+    return include_status_flag, include_events_flag, events_limit
+
+
+def _normalize_status_fanout_mode(mode: str) -> str:
+    """Return a supported status fan-out mode."""
+
+    normalized = str(mode).strip().lower()
+    if normalized in _WS_STATUS_FANOUT_MODES:
+        return normalized
+    return DEFAULT_WS_STATUS_FANOUT_MODE
 
 
 def _get_telemetry_subscription(data: Dict[str, Any]) -> tuple[int, Optional[str], bool]:
@@ -1026,6 +1045,8 @@ async def handle_system_socket(
     event_broadcaster: EventBroadcaster,
     status_provider: Callable[[], Dict[str, object]],
     event_list_provider: Callable[[int], list[Dict[str, object]]],
+    status_refresh_interval_seconds: float = DEFAULT_WS_STATUS_REFRESH_INTERVAL_SECONDS,
+    status_fanout_mode: str = DEFAULT_WS_STATUS_FANOUT_MODE,
     ping_interval_seconds: float = DEFAULT_WS_PING_INTERVAL_SECONDS,
     inactivity_timeout_seconds: float = DEFAULT_WS_INACTIVITY_TIMEOUT_SECONDS,
 ) -> None:
@@ -1037,6 +1058,9 @@ async def handle_system_socket(
         event_broadcaster (EventBroadcaster): Event broadcaster.
         status_provider (Callable[[], Dict[str, object]]): Status snapshot provider.
         event_list_provider (Callable[[int], list[Dict[str, object]]]): Event list provider.
+        status_refresh_interval_seconds (float): Periodic status refresh cadence.
+        status_fanout_mode (str): Status fan-out mode. Supported values:
+            ``event_only``, ``periodic``, ``event_plus_periodic``.
         ping_interval_seconds (float): Interval between keepalive ping payloads.
         inactivity_timeout_seconds (float): Maximum idle time allowed before the
             socket is closed.
@@ -1046,10 +1070,13 @@ async def handle_system_socket(
     if not await authenticate_websocket(websocket, auth=auth):
         return
 
-    include_status = True
+    include_status = False
     include_events = True
     events_limit = 50
     last_activity_at = time.monotonic()
+    fanout_mode = _normalize_status_fanout_mode(status_fanout_mode)
+    include_status = fanout_mode != "event_only"
+    status_interval = max(float(status_refresh_interval_seconds), 2.0)
 
     async def _send_event(entry: Dict[str, object]) -> None:
         """Send event updates to the WebSocket client.
@@ -1063,13 +1090,24 @@ async def handle_system_socket(
 
         if include_events:
             await websocket.send_json(build_ws_message("system.event", entry))
-        if include_status:
+        if include_status and fanout_mode == "event_plus_periodic":
             await websocket.send_json(build_ws_message("system.status", status_provider()))
+
+    async def _periodic_status_loop() -> None:
+        """Send periodic status updates when enabled."""
+
+        if fanout_mode not in {"periodic", "event_plus_periodic"}:
+            return
+        while True:
+            await asyncio.sleep(status_interval)
+            if include_status:
+                await websocket.send_json(build_ws_message("system.status", status_provider()))
 
     unsubscribe = event_broadcaster.subscribe(_send_event)
     ping_task = asyncio.create_task(
         ping_loop(websocket, interval_seconds=ping_interval_seconds)
     )
+    status_task = asyncio.create_task(_periodic_status_loop())
 
     try:
         if include_status:
@@ -1098,7 +1136,11 @@ async def handle_system_socket(
             msg_type = _get_message_type(message)
             if msg_type == "system.subscribe":
                 data = _get_message_data(message)
-                include_status, include_events, events_limit = _get_subscribe_flags(data)
+                include_status, include_events, events_limit = _get_subscribe_flags(
+                    data,
+                    default_include_status=(fanout_mode != "event_only"),
+                    default_include_events=True,
+                )
                 if include_status:
                     await websocket.send_json(build_ws_message("system.status", status_provider()))
             elif msg_type == "pong":
@@ -1113,6 +1155,7 @@ async def handle_system_socket(
     finally:
         unsubscribe()
         await _cancel_task(ping_task)
+        await _cancel_task(status_task)
 
 
 async def handle_telemetry_socket(

--- a/tests/northbound/test_websocket_handlers.py
+++ b/tests/northbound/test_websocket_handlers.py
@@ -174,6 +174,73 @@ def test_handle_system_socket_handles_subscribe_and_bad_request(monkeypatch) -> 
     asyncio.run(_exercise())
 
 
+def test_handle_system_socket_defaults_to_event_only_mode(monkeypatch) -> None:
+    """Ensure default system subscriptions do not emit status payloads."""
+
+    async def _exercise() -> None:
+        websocket = _FakeWebSocket([{"type": "unsupported"}])
+        broadcaster = _FakeEventBroadcaster()
+
+        async def _fake_ping_loop(*_args, **_kwargs):
+            await asyncio.sleep(999)
+
+        monkeypatch.setattr(
+            "reticulum_telemetry_hub.northbound.websocket.authenticate_websocket",
+            lambda *args, **kwargs: asyncio.sleep(0, result=True),
+        )
+        monkeypatch.setattr(
+            "reticulum_telemetry_hub.northbound.websocket.ping_loop",
+            _fake_ping_loop,
+        )
+
+        await handle_system_socket(
+            websocket,
+            auth=_FakeAuth(True),
+            event_broadcaster=broadcaster,
+            status_provider=lambda: {"ok": True},
+            event_list_provider=lambda limit: [{"n": limit}],
+        )
+
+        sent_types = [item["type"] for item in websocket.sent]
+        assert "system.event" in sent_types
+        assert "system.status" not in sent_types
+
+    asyncio.run(_exercise())
+
+
+def test_handle_system_socket_invalid_mode_falls_back_to_event_only(monkeypatch) -> None:
+    """Ensure unsupported status fan-out modes behave as event-only."""
+
+    async def _exercise() -> None:
+        websocket = _FakeWebSocket([{"type": "unsupported"}])
+        broadcaster = _FakeEventBroadcaster()
+
+        async def _fake_ping_loop(*_args, **_kwargs):
+            await asyncio.sleep(999)
+
+        monkeypatch.setattr(
+            "reticulum_telemetry_hub.northbound.websocket.authenticate_websocket",
+            lambda *args, **kwargs: asyncio.sleep(0, result=True),
+        )
+        monkeypatch.setattr(
+            "reticulum_telemetry_hub.northbound.websocket.ping_loop",
+            _fake_ping_loop,
+        )
+
+        await handle_system_socket(
+            websocket,
+            auth=_FakeAuth(True),
+            event_broadcaster=broadcaster,
+            status_provider=lambda: {"ok": True},
+            event_list_provider=lambda _limit: [],
+            status_fanout_mode="bogus_mode",
+        )
+
+        assert all(item["type"] != "system.status" for item in websocket.sent)
+
+    asyncio.run(_exercise())
+
+
 def test_handle_telemetry_socket_subscribe_variants(monkeypatch) -> None:
     """Exercise telemetry subscription validation and follow wiring."""
 

--- a/tests/northbound/test_websocket_helpers.py
+++ b/tests/northbound/test_websocket_helpers.py
@@ -50,9 +50,13 @@ def test_parse_ws_message_requires_object() -> None:
 def test_get_subscribe_flags_defaults() -> None:
     """Ensure subscription flags default sensibly."""
 
-    include_status, include_events, events_limit = _get_subscribe_flags({})
+    include_status, include_events, events_limit = _get_subscribe_flags(
+        {},
+        default_include_status=False,
+        default_include_events=True,
+    )
 
-    assert include_status is True
+    assert include_status is False
     assert include_events is True
     assert events_limit == 50
 


### PR DESCRIPTION
### Motivation
- Allow finer control of northbound system WebSocket status fan-out (event-only vs periodic vs both) and tune periodic cadence.
- Reduce load and improve accuracy by switching status counts from list-lengths to database count queries.
- Avoid expensive repeated status snapshot generation by caching periodic status snapshots per runtime.

### Description
- Added `ws_status_fanout_mode` and `ws_status_refresh_interval_seconds` defaults to `default_config.ini` and exposed them on `HubRuntimeConfig` with validation in `config.manager` via `_normalize_status_fanout_mode`.
- Implemented `count_*` APIs on `ReticulumTelemetryHubAPI` and corresponding `count_*` storage methods that issue SQL count queries (`sa_count`) for topics, subscribers, clients, files, and images in `api/service.py` and `api/storage.py`.
- Introduced cached status snapshots and a `status_snapshot_cached` accessor on `NorthboundServices` to limit snapshot regeneration, and switched `status_snapshot` to use the new DB-backed counts.
- Plumbed fan-out mode and refresh interval through `northbound.app` -> `register_ws_routes` -> `handle_system_socket`, added fan-out logic and a periodic status loop in `northbound.websocket`, normalized subscribe flag defaults, and added helpers/defaults for modes.
- Added/updated unit tests to assert default `event_only` behavior and fallback on invalid modes, and adjusted helper tests to reflect the new default include-status semantics.

### Testing
- Ran the updated unit tests in `tests/northbound` including `test_websocket_handlers.py` and `test_websocket_helpers.py`, and all assertions passed.
- Executed the repository test suite locally with `pytest` and the run completed successfully (no test failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f567f578832589ca7a01bc42593d)