### PR TITLE
[codex] Validate scalable ZeroMQ delivery pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,9 @@ Crates:
   When configured with `--lxmf-zmq-command`, `--lxmf-zmq-response`, and
   `--reticulumd-source`, outbound delivery uses the LXMF-rs ZeroMQ SDK
   pipeline. For the initial server package, ZeroMQ is mandatory for southbound
-  command dispatch; `reticulumd` HTTP RPC may still be configured as the
-  conservative daemon event/receipt polling fallback. The opt-in
-  `R3AKT_ENABLE_ZMQ_EVENT_POLL=1` path now prefers the LXMF-rs ZeroMQ event
-  stream when both ZeroMQ endpoints are configured.
+  command dispatch and daemon event polling. Multi-destination fanout is sent
+  to the daemon as one `sdk_send_batch_v2` ZeroMQ request, so the server no
+  longer performs one daemon send per recipient.
   Remaining backend service contracts should continue to be ported in small
   contract-tested slices.
 - `r3akt-tak-connector`: dedicated Rust TAK connector crate and service
@@ -176,16 +175,16 @@ at `crates/libs/lxmf-core`, `lxmf-sdk`, `reticulum-rs-transport`,
 MessagePack for LXMF payloads and exposes `WireMessage` packing, unpacking,
 message IDs, signing, and verification. This milestone does not invent a
 Reticulum/LXMF implementation. `r3akt-transport-rns` now includes a ZeroMQ
-SDK-backed adapter for R3AKT MessagePack envelopes and normal RCH outbound
-LXMF field payloads, while retaining the older `reticulumd` RPC adapter as a
-test and migration fallback.
+SDK-backed adapter for R3AKT MessagePack envelopes, normal RCH outbound LXMF
+field payloads, and batched multi-recipient sends. The older `reticulumd` RPC
+adapter remains in the crate for legacy tests and migration tooling, but the
+Rust server runtime no longer uses it for southbound dispatch or event polling.
 
 Gap: the ZeroMQ SDK path has unit coverage for outbound payload mapping and
 inbound SDK event conversion, plus local live-daemon validation for
 `sdk_poll_events_v2` over ZeroMQ. The default server package path requires
-ZeroMQ for outbound commands, but still allows HTTP RPC as the conservative
-daemon event/receipt polling fallback. Keep HTTP RPC available until external
-Reticulum and REM phone evidence also pass with ZeroMQ event polling enabled.
+ZeroMQ endpoints for outbound commands and event polling; external Reticulum
+and REM phone evidence should keep validating the ZeroMQ-only path.
 
 ### Reticulum Mobile Emergency Management
 
@@ -839,6 +838,28 @@ Run the repeatable local Reticulum receipt/fanout/ZeroMQ event-poll harness when
   -DiscoverySettleSeconds 10 `
   -ReceiptPollAttempts 180
 ```
+
+Run the same local mesh with a daemon-involved ZeroMQ load check. This sends
+normal individual `sdk_send_v2` messages from node 0 to the local receiver
+daemons and confirms delivery through receiver-side `sdk_poll_events_v2`:
+
+```powershell
+.\scripts\local-reticulum-live-gate.ps1 `
+  -IncludeZmqLoad `
+  -LoadMessages 1000 `
+  -LoadSenderClients 4 `
+  -DiscoverySettleSeconds 10
+```
+
+Use `-ZmqLoadOnly` to run only the load check while tuning daemon delivery
+throughput.
+
+The Rust daemon delivery path now uses a bounded persistent scheduler rather
+than spawning one delivery runtime per message. Tune burst capacity with the
+daemon environment variables `LXMD_DELIVERY_QUEUE_CAPACITY`,
+`LXMD_DELIVERY_GLOBAL_CONCURRENCY`, and `LXMD_DELIVERY_PER_PEER_IN_FLIGHT`.
+Use `daemon_status_ex`, `sdk_snapshot_v2`, or `sdk_status_v2` to inspect the
+`delivery_pipeline` counters while running `-ZmqLoadOnly`.
 
 Run the same harness against a controlled external Reticulum/RMAP profile by
 passing a `reticulumd` TOML config:

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -72,9 +72,10 @@ use r3akt_rch_core::{
 #[cfg(test)]
 use r3akt_transport_rns::MessageBus;
 use r3akt_transport_rns::{
-    LxmfSdkOutboundMessage, ReticulumdAnnounceRecord, list_reticulumd_announces,
-    poll_lxmf_zmq_events, poll_reticulumd_events, reticulumd_event_to_envelope,
-    reticulumd_message_to_envelope, send_lxmf_zmq_outbound_message,
+    LxmfSdkOutboundBatch, LxmfSdkOutboundBatchMessage, LxmfSdkOutboundMessage,
+    ReticulumdAnnounceRecord, list_reticulumd_announces, poll_lxmf_zmq_events,
+    poll_reticulumd_events, reticulumd_event_to_envelope, reticulumd_message_to_envelope,
+    send_lxmf_zmq_outbound_batch, send_lxmf_zmq_outbound_message,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -2728,17 +2729,29 @@ fn select_reticulumd_event_poll_transport(
     zmq_response_endpoint: Option<&str>,
     zmq_event_poll_enabled: bool,
 ) -> ReticulumdEventPollTransport {
-    let rpc_configured = rpc_endpoint.is_some_and(|endpoint| !endpoint.trim().is_empty());
     let zmq_configured = zmq_command_endpoint.is_some_and(|endpoint| !endpoint.trim().is_empty())
         && zmq_response_endpoint.is_some_and(|endpoint| !endpoint.trim().is_empty());
-    if zmq_event_poll_enabled && zmq_configured {
-        ReticulumdEventPollTransport::Zmq
-    } else if rpc_configured {
-        ReticulumdEventPollTransport::Rpc
-    } else if zmq_configured {
-        ReticulumdEventPollTransport::Zmq
-    } else {
-        ReticulumdEventPollTransport::None
+    #[cfg(test)]
+    {
+        let rpc_configured = rpc_endpoint.is_some_and(|endpoint| !endpoint.trim().is_empty());
+        if zmq_event_poll_enabled && zmq_configured {
+            ReticulumdEventPollTransport::Zmq
+        } else if rpc_configured {
+            ReticulumdEventPollTransport::Rpc
+        } else if zmq_configured {
+            ReticulumdEventPollTransport::Zmq
+        } else {
+            ReticulumdEventPollTransport::None
+        }
+    }
+    #[cfg(not(test))]
+    {
+        let _ = (rpc_endpoint, zmq_event_poll_enabled);
+        if zmq_configured {
+            ReticulumdEventPollTransport::Zmq
+        } else {
+            ReticulumdEventPollTransport::None
+        }
     }
 }
 
@@ -12690,10 +12703,21 @@ fn dispatch_outbound_message(
 ) -> Result<DispatchReport, ApiError> {
     let has_zmq_endpoint =
         state.lxmf_zmq_command_endpoint.is_some() && state.lxmf_zmq_response_endpoint.is_some();
-    let has_rpc_endpoint = state.reticulumd_rpc_endpoint.is_some();
-    if !has_zmq_endpoint && !has_rpc_endpoint {
+    if !has_zmq_endpoint {
+        #[cfg(test)]
+        {
+            if state.reticulumd_rpc_endpoint.is_some() {
+                return dispatch_outbound_message_legacy_rpc_for_tests(state, message);
+            }
+        }
         return Ok(DispatchReport::default());
     }
+    let (Some(command_endpoint), Some(response_endpoint)) = (
+        state.lxmf_zmq_command_endpoint.as_deref(),
+        state.lxmf_zmq_response_endpoint.as_deref(),
+    ) else {
+        return Ok(DispatchReport::default());
+    };
     let source = state
         .reticulumd_source
         .as_ref()
@@ -12701,6 +12725,137 @@ fn dispatch_outbound_message(
     let destinations = outbound_destinations(state, message)?;
     let fanout_destination_count = destinations.len();
     let fanout_requires_child_ids = fanout_destination_count > 1;
+    let mut report = DispatchReport::default();
+    if fanout_destination_count > 1 {
+        let batch_id = format!(
+            "{}-fanout-{}",
+            message.message_id,
+            outbound_attempts(message)
+        );
+        let mut batch_messages = Vec::with_capacity(fanout_destination_count);
+        for (index, destination) in destinations.iter().enumerate() {
+            let message_id = outbound_dispatch_message_id(
+                message,
+                destination,
+                index,
+                fanout_requires_child_ids,
+            );
+            let mut dispatch_message = message.clone();
+            dispatch_message.message_id.clone_from(&message_id);
+            dispatch_message.destination = Some(destination.clone());
+            let fields = outbound_lxmf_fields(
+                &dispatch_message,
+                message
+                    .delivery_metadata
+                    .get("lxmf_fields")
+                    .cloned()
+                    .unwrap_or_else(|| json!({})),
+            );
+            batch_messages.push(LxmfSdkOutboundBatchMessage {
+                destination: destination.clone(),
+                title: outbound_lxmf_title(&dispatch_message).to_string(),
+                content: outbound_lxmf_content(&dispatch_message).to_string(),
+                fields,
+                delivery_method: lxmf_sdk_delivery_method(message).map(str::to_string),
+                try_propagation_on_fail: lxmf_sdk_try_propagation_on_fail(message),
+                correlation_id: message_id,
+            });
+        }
+        let results = send_lxmf_zmq_outbound_batch(
+            command_endpoint,
+            response_endpoint,
+            LxmfSdkOutboundBatch {
+                batch_id,
+                source: source.to_string(),
+                messages: batch_messages,
+            },
+        )
+        .map_err(|error| {
+            let error = error.to_string();
+            if message.delivery_method == "direct"
+                && direct_failure_error_should_trigger_cooldown(error.as_str())
+            {
+                for destination in &destinations {
+                    let _ = mark_direct_delivery_failure(state, destination.as_str());
+                }
+            }
+            ApiError::ServiceUnavailable(error)
+        })?;
+        for result in results {
+            report.count += 1;
+            report.receipts.push(ReticulumdReceiptTarget {
+                message_id: result.message_id,
+                destination: result.destination,
+                status: None,
+            });
+        }
+        return Ok(report);
+    }
+
+    for (index, destination) in destinations.into_iter().enumerate() {
+        let message_id =
+            outbound_dispatch_message_id(message, &destination, index, fanout_requires_child_ids);
+        let mut dispatch_message = message.clone();
+        dispatch_message.message_id.clone_from(&message_id);
+        dispatch_message.destination = Some(destination.clone());
+        let fields = outbound_lxmf_fields(
+            &dispatch_message,
+            message
+                .delivery_metadata
+                .get("lxmf_fields")
+                .cloned()
+                .unwrap_or_else(|| json!({})),
+        );
+        let dispatch_result = send_lxmf_zmq_outbound_message(
+            command_endpoint,
+            response_endpoint,
+            LxmfSdkOutboundMessage {
+                source: source.to_string(),
+                destination: destination.clone(),
+                title: outbound_lxmf_title(&dispatch_message).to_string(),
+                content: outbound_lxmf_content(&dispatch_message).to_string(),
+                fields,
+                delivery_method: lxmf_sdk_delivery_method(message).map(str::to_string),
+                try_propagation_on_fail: lxmf_sdk_try_propagation_on_fail(message),
+                correlation_id: message_id.clone(),
+            },
+        )
+        .map_err(|error| error.to_string());
+        let reticulumd_message_id = match dispatch_result {
+            Ok(reticulumd_message_id) => reticulumd_message_id,
+            Err(error) => {
+                if message.delivery_method == "direct"
+                    && direct_failure_error_should_trigger_cooldown(error.as_str())
+                {
+                    mark_direct_delivery_failure(state, destination.as_str())?;
+                }
+                return Err(ApiError::ServiceUnavailable(error));
+            }
+        };
+        report.count += 1;
+        report.receipts.push(ReticulumdReceiptTarget {
+            message_id: reticulumd_message_id,
+            destination,
+            status: None,
+        });
+    }
+    Ok(report)
+}
+
+#[cfg(test)]
+fn dispatch_outbound_message_legacy_rpc_for_tests(
+    state: &AppState,
+    message: &OutboundMessageRecord,
+) -> Result<DispatchReport, ApiError> {
+    let Some(endpoint) = &state.reticulumd_rpc_endpoint else {
+        return Ok(DispatchReport::default());
+    };
+    let source = state
+        .reticulumd_source
+        .as_ref()
+        .map_or("r3akt-rch-server", |value| value.as_str());
+    let destinations = outbound_destinations(state, message)?;
+    let fanout_requires_child_ids = destinations.len() > 1;
     let mut report = DispatchReport::default();
     for (index, destination) in destinations.into_iter().enumerate() {
         let message_id =
@@ -12723,50 +12878,23 @@ fn dispatch_outbound_message(
             "destination": destination,
             "title": outbound_lxmf_title(&dispatch_message),
             "content": outbound_lxmf_content(&dispatch_message),
-            "fields": fields.clone(),
+            "fields": fields,
             "method": message.delivery_method,
         })
         .to_string();
-        let dispatch_result = if let (Some(command_endpoint), Some(response_endpoint)) = (
-            &state.lxmf_zmq_command_endpoint,
-            &state.lxmf_zmq_response_endpoint,
-        ) {
-            send_lxmf_zmq_outbound_message(
-                command_endpoint.as_str(),
-                response_endpoint.as_str(),
-                LxmfSdkOutboundMessage {
-                    source: source.to_string(),
-                    destination: destination.clone(),
-                    title: outbound_lxmf_title(&dispatch_message).to_string(),
-                    content: outbound_lxmf_content(&dispatch_message).to_string(),
-                    fields,
-                    delivery_method: lxmf_sdk_delivery_method(message).map(str::to_string),
-                    try_propagation_on_fail: lxmf_sdk_try_propagation_on_fail(message),
-                    correlation_id: message_id.clone(),
-                },
-            )
-            .map_err(|error| error.to_string())
-        } else if let Some(endpoint) = &state.reticulumd_rpc_endpoint {
-            r3akt_rch_bridge::handle_outbound_json_request_with_reticulumd(
-                endpoint.as_str(),
-                &request,
-            )
-            .map(|_| message_id.clone())
-            .map_err(|error| error.to_string())
-        } else {
-            Ok(message_id.clone())
-        };
-        let reticulumd_message_id = match dispatch_result {
-            Ok(reticulumd_message_id) => reticulumd_message_id,
-            Err(error) => {
-                if message.delivery_method == "direct"
-                    && direct_failure_error_should_trigger_cooldown(error.as_str())
-                {
-                    mark_direct_delivery_failure(state, destination.as_str())?;
-                }
-                return Err(ApiError::ServiceUnavailable(error));
+        let reticulumd_message_id = r3akt_rch_bridge::handle_outbound_json_request_with_reticulumd(
+            endpoint.as_str(),
+            &request,
+        )
+        .map(|_| message_id.clone())
+        .map_err(|error| {
+            if message.delivery_method == "direct"
+                && direct_failure_error_should_trigger_cooldown(error.to_string().as_str())
+            {
+                let _ = mark_direct_delivery_failure(state, destination.as_str());
             }
-        };
+            ApiError::ServiceUnavailable(error.to_string())
+        })?;
         report.count += 1;
         report.receipts.push(ReticulumdReceiptTarget {
             message_id: reticulumd_message_id,
@@ -23662,6 +23790,7 @@ fn bearer_token(headers: &HeaderMap) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use crate::BASE64_STANDARD;
+    use std::collections::HashSet;
     use std::io::{Read, Write};
     use std::net::{SocketAddr, TcpListener as StdTcpListener};
     use std::thread;
@@ -23676,8 +23805,9 @@ mod tests {
     use r3akt_rch_bridge::{ReticulumdRpcError, ReticulumdRpcRequest, ReticulumdRpcResponse};
     use r3akt_rch_core::{FileAttachmentRecord, RchCore, RchSqliteStore};
     use r3akt_transport_rns::{
-        LxmfRsTransport, ReticulumdAnnounceRecord, ReticulumdRpcLxmfRsAdapter,
-        ReticulumdRpcTransport,
+        LxmfRsTransport, LxmfSdkOutboundMessage, ReticulumdAnnounceRecord, ReticulumdEventBatch,
+        ReticulumdEventRecord, ReticulumdRpcLxmfRsAdapter, ReticulumdRpcTransport,
+        poll_lxmf_zmq_events, send_lxmf_zmq_outbound_message,
     };
     use serde::Serialize;
     use serde_json::{Value, json};
@@ -44585,7 +44715,7 @@ mod tests {
     }
 
     #[test]
-    fn reticulumd_event_poll_transport_prefers_zmq_when_enabled_with_rpc_fallback() {
+    fn reticulumd_event_poll_transport_prefers_zmq_when_enabled_with_rpc_test_fallback() {
         assert_eq!(
             crate::select_reticulumd_event_poll_transport(
                 Some("127.0.0.1:4243"),
@@ -45563,6 +45693,349 @@ mod tests {
         assert!(inbound["event_poll_errors_total"].as_u64().unwrap_or(1) == 0);
         assert!(report.next_cursor.is_some());
         let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    #[ignore = "requires a local reticulumd mesh with ZeroMQ command endpoints"]
+    fn live_reticulumd_zmq_load_delivers_to_local_clients_when_configured() {
+        let command_endpoints = match live_env_list("R3AKT_ZMQ_LOAD_COMMAND_ENDPOINTS") {
+            Some(value) if value.len() >= 2 => value,
+            _ => {
+                eprintln!(
+                    "skipping live ZeroMQ load test: R3AKT_ZMQ_LOAD_COMMAND_ENDPOINTS is unset"
+                );
+                return;
+            }
+        };
+        let destinations = match live_env_list("R3AKT_ZMQ_LOAD_DESTINATIONS") {
+            Some(value) if value.len() == command_endpoints.len() => value,
+            _ => {
+                eprintln!("skipping live ZeroMQ load test: R3AKT_ZMQ_LOAD_DESTINATIONS is unset");
+                return;
+            }
+        };
+        let sender_response_endpoints = match live_env_list(
+            "R3AKT_ZMQ_LOAD_SENDER_RESPONSE_ENDPOINTS",
+        ) {
+            Some(value) if !value.is_empty() => value,
+            _ => {
+                eprintln!(
+                    "skipping live ZeroMQ load test: R3AKT_ZMQ_LOAD_SENDER_RESPONSE_ENDPOINTS is unset"
+                );
+                return;
+            }
+        };
+        let receiver_response_endpoints = match live_env_list(
+            "R3AKT_ZMQ_LOAD_RECEIVER_RESPONSE_ENDPOINTS",
+        ) {
+            Some(value) if !value.is_empty() => value,
+            _ => {
+                eprintln!(
+                    "skipping live ZeroMQ load test: R3AKT_ZMQ_LOAD_RECEIVER_RESPONSE_ENDPOINTS is unset"
+                );
+                return;
+            }
+        };
+
+        let requested_messages = live_env_usize("R3AKT_ZMQ_LOAD_MESSAGES", 1_000).max(1);
+        let sender_clients = live_env_usize("R3AKT_ZMQ_LOAD_SENDER_CLIENTS", 4)
+            .max(1)
+            .min(sender_response_endpoints.len());
+        let receiver_count = live_env_usize("R3AKT_ZMQ_LOAD_RECEIVER_COUNT", 2)
+            .max(1)
+            .min(command_endpoints.len().saturating_sub(1))
+            .min(receiver_response_endpoints.len());
+        assert!(
+            receiver_count > 0,
+            "load test requires at least one receiver"
+        );
+
+        let poll_attempts = live_env_usize("R3AKT_ZMQ_LOAD_POLL_ATTEMPTS", 240);
+        let poll_delay_ms = live_env_u64("R3AKT_ZMQ_LOAD_POLL_DELAY_MS", 250);
+        let run_id = Uuid::new_v4().to_string();
+        let expected_by_receiver =
+            load_expected_content_by_receiver(&run_id, requested_messages, receiver_count);
+        let poll_started = Instant::now();
+        let mut receiver_threads = Vec::with_capacity(receiver_count);
+        for receiver_index in 0..receiver_count {
+            let command_endpoint = command_endpoints[receiver_index + 1].clone();
+            let response_endpoint = receiver_response_endpoints[receiver_index].clone();
+            let expected = expected_by_receiver[receiver_index].clone();
+            receiver_threads.push(thread::spawn(move || {
+                poll_zmq_load_receiver(
+                    receiver_index,
+                    command_endpoint,
+                    response_endpoint,
+                    expected,
+                    poll_attempts,
+                    poll_delay_ms,
+                )
+            }));
+        }
+        thread::sleep(Duration::from_millis(250));
+
+        let send_started = Instant::now();
+        let mut sender_threads = Vec::with_capacity(sender_clients);
+        for (sender_index, response_endpoint) in sender_response_endpoints
+            .iter()
+            .take(sender_clients)
+            .cloned()
+            .enumerate()
+        {
+            let command_endpoint = command_endpoints[0].clone();
+            let source = destinations[0].clone();
+            let destinations = destinations[1..=receiver_count].to_vec();
+            let run_id = run_id.clone();
+            sender_threads.push(thread::spawn(move || {
+                send_zmq_load_messages(
+                    sender_index,
+                    sender_clients,
+                    requested_messages,
+                    receiver_count,
+                    command_endpoint,
+                    response_endpoint,
+                    source,
+                    destinations,
+                    run_id,
+                )
+            }));
+        }
+
+        let mut accepted_count = 0usize;
+        let mut first_send_error = None;
+        for sender in sender_threads {
+            let result = sender.join().expect("join ZeroMQ load sender");
+            accepted_count = accepted_count.saturating_add(result.accepted);
+            first_send_error = first_send_error.or(result.first_error);
+        }
+        let send_elapsed = send_started.elapsed();
+
+        let mut receiver_results = Vec::with_capacity(receiver_count);
+        for receiver in receiver_threads {
+            receiver_results.push(receiver.join().expect("join ZeroMQ load receiver"));
+        }
+        let full_elapsed = poll_started.elapsed();
+        let received_total = receiver_results
+            .iter()
+            .map(|result| result.received)
+            .sum::<usize>();
+        let per_client = receiver_results
+            .iter()
+            .map(|result| format!("client{}={}", result.receiver_index + 1, result.received))
+            .collect::<Vec<_>>()
+            .join(",");
+        println!(
+            "live_zmq_load_result status={} requested={} accepted={} received={} per_client={} send_elapsed_ms={} full_elapsed_ms={} send_messages_per_sec={:.1} e2e_messages_per_sec={:.1}",
+            if accepted_count == requested_messages && received_total == requested_messages {
+                "completed"
+            } else {
+                "incomplete"
+            },
+            requested_messages,
+            accepted_count,
+            received_total,
+            per_client,
+            send_elapsed.as_millis(),
+            full_elapsed.as_millis(),
+            messages_per_second(requested_messages, send_elapsed),
+            messages_per_second(requested_messages, full_elapsed)
+        );
+
+        assert_eq!(
+            accepted_count, requested_messages,
+            "accepted send count mismatch; first error: {:?}",
+            first_send_error
+        );
+        for result in &receiver_results {
+            assert!(
+                result.remaining_samples.is_empty(),
+                "receiver {} missed {} messages; samples={:?}; last_error={:?}",
+                result.receiver_index + 1,
+                result.expected.saturating_sub(result.received),
+                result.remaining_samples,
+                result.last_error
+            );
+        }
+        assert_eq!(received_total, requested_messages);
+    }
+
+    #[derive(Debug)]
+    struct ZmqLoadSendResult {
+        accepted: usize,
+        first_error: Option<String>,
+    }
+
+    #[derive(Debug)]
+    struct ZmqLoadReceiverResult {
+        receiver_index: usize,
+        expected: usize,
+        received: usize,
+        remaining_samples: Vec<String>,
+        last_error: Option<String>,
+    }
+
+    fn live_env_list(name: &str) -> Option<Vec<String>> {
+        std::env::var(name).ok().map(|value| {
+            value
+                .split([',', ';', '\n', '\r', '\t'])
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+    }
+
+    fn live_env_usize(name: &str, default: usize) -> usize {
+        std::env::var(name)
+            .ok()
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .unwrap_or(default)
+    }
+
+    fn live_env_u64(name: &str, default: u64) -> u64 {
+        std::env::var(name)
+            .ok()
+            .and_then(|value| value.trim().parse::<u64>().ok())
+            .unwrap_or(default)
+    }
+
+    fn messages_per_second(count: usize, elapsed: Duration) -> f64 {
+        f64::from(u32::try_from(count).expect("message count fits in u32")) / elapsed.as_secs_f64()
+    }
+
+    fn load_content(run_id: &str, sequence: usize, receiver_index: usize) -> String {
+        format!(
+            "load-{run_id}-{sequence:05}-to-{}",
+            receiver_index.saturating_add(1)
+        )
+    }
+
+    fn load_expected_content_by_receiver(
+        run_id: &str,
+        requested_messages: usize,
+        receiver_count: usize,
+    ) -> Vec<HashSet<String>> {
+        let mut expected = (0..receiver_count)
+            .map(|_| HashSet::new())
+            .collect::<Vec<_>>();
+        for sequence in 0..requested_messages {
+            let receiver_index = sequence % receiver_count;
+            expected[receiver_index].insert(load_content(run_id, sequence, receiver_index));
+        }
+        expected
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn send_zmq_load_messages(
+        sender_index: usize,
+        sender_clients: usize,
+        requested_messages: usize,
+        receiver_count: usize,
+        command_endpoint: String,
+        response_endpoint: String,
+        source: String,
+        destinations: Vec<String>,
+        run_id: String,
+    ) -> ZmqLoadSendResult {
+        let mut accepted = 0usize;
+        let mut first_error = None;
+        for sequence in (sender_index..requested_messages).step_by(sender_clients) {
+            let receiver_index = sequence % receiver_count;
+            let content = load_content(&run_id, sequence, receiver_index);
+            let result = send_lxmf_zmq_outbound_message(
+                command_endpoint.clone(),
+                response_endpoint.clone(),
+                LxmfSdkOutboundMessage {
+                    source: source.clone(),
+                    destination: destinations[receiver_index].clone(),
+                    title: "RCH load".to_string(),
+                    content,
+                    fields: json!({
+                        "load_run_id": run_id.clone(),
+                        "load_sequence": sequence,
+                        "load_receiver_index": receiver_index,
+                    }),
+                    delivery_method: Some("direct".to_string()),
+                    try_propagation_on_fail: false,
+                    correlation_id: format!("load-{run_id}-{sequence:05}"),
+                },
+            );
+            match result {
+                Ok(_) => accepted = accepted.saturating_add(1),
+                Err(error) => {
+                    first_error.get_or_insert_with(|| format!("sequence {sequence}: {error}"));
+                }
+            }
+        }
+        ZmqLoadSendResult {
+            accepted,
+            first_error,
+        }
+    }
+
+    fn poll_zmq_load_receiver(
+        receiver_index: usize,
+        command_endpoint: String,
+        response_endpoint: String,
+        mut expected: HashSet<String>,
+        poll_attempts: usize,
+        poll_delay_ms: u64,
+    ) -> ZmqLoadReceiverResult {
+        let expected_count = expected.len();
+        let mut cursor = None;
+        let mut last_error = None;
+        for _ in 0..poll_attempts {
+            match poll_lxmf_zmq_events(
+                command_endpoint.clone(),
+                response_endpoint.clone(),
+                cursor.clone(),
+                crate::RETICULUMD_EVENT_POLL_MAX,
+            ) {
+                Ok(batch) => {
+                    cursor = batch.next_cursor.clone();
+                    remove_seen_load_messages(&mut expected, &batch);
+                    if expected.is_empty() {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    last_error = Some(error.to_string());
+                }
+            }
+            thread::sleep(Duration::from_millis(poll_delay_ms));
+        }
+        let received = expected_count.saturating_sub(expected.len());
+        let remaining_samples = expected.into_iter().take(5).collect::<Vec<_>>();
+        ZmqLoadReceiverResult {
+            receiver_index,
+            expected: expected_count,
+            received,
+            remaining_samples,
+            last_error,
+        }
+    }
+
+    fn remove_seen_load_messages(expected: &mut HashSet<String>, batch: &ReticulumdEventBatch) {
+        for event in &batch.events {
+            if !matches!(
+                event.event_type.as_str(),
+                "inbound" | "InboundMessageReceived"
+            ) {
+                continue;
+            }
+            if let Some(content) = load_event_content(event) {
+                expected.remove(content);
+            }
+        }
+    }
+
+    fn load_event_content(event: &ReticulumdEventRecord) -> Option<&str> {
+        event
+            .payload
+            .get("message")
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .or_else(|| event.payload.get("content").and_then(Value::as_str))
     }
 
     #[tokio::test]

--- a/crates/r3akt-transport-rns/src/lib.rs
+++ b/crates/r3akt-transport-rns/src/lib.rs
@@ -587,6 +587,29 @@ pub struct LxmfSdkOutboundMessage {
     pub correlation_id: String,
 }
 
+pub struct LxmfSdkOutboundBatch {
+    pub batch_id: String,
+    pub source: String,
+    pub messages: Vec<LxmfSdkOutboundBatchMessage>,
+}
+
+pub struct LxmfSdkOutboundBatchMessage {
+    pub destination: String,
+    pub title: String,
+    pub content: String,
+    pub fields: JsonValue,
+    pub delivery_method: Option<String>,
+    pub try_propagation_on_fail: bool,
+    pub correlation_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LxmfSdkOutboundBatchResult {
+    pub id: String,
+    pub message_id: String,
+    pub destination: String,
+}
+
 pub fn send_lxmf_zmq_outbound_message(
     command_endpoint: impl Into<String>,
     response_endpoint: impl Into<String>,
@@ -595,6 +618,16 @@ pub fn send_lxmf_zmq_outbound_message(
     let mut config = rch_local_zmq_pipeline_config(command_endpoint, response_endpoint);
     config.request_timeout = LXMF_ZMQ_SEND_REQUEST_TIMEOUT;
     send_lxmf_zmq_outbound_message_via_actor(&config, message)
+}
+
+pub fn send_lxmf_zmq_outbound_batch(
+    command_endpoint: impl Into<String>,
+    response_endpoint: impl Into<String>,
+    batch: LxmfSdkOutboundBatch,
+) -> Result<Vec<LxmfSdkOutboundBatchResult>, TransportError> {
+    let mut config = rch_local_zmq_pipeline_config(command_endpoint, response_endpoint);
+    config.request_timeout = LXMF_ZMQ_SEND_REQUEST_TIMEOUT;
+    send_lxmf_zmq_outbound_batch_via_actor(&config, batch)
 }
 
 pub fn poll_lxmf_zmq_events(
@@ -754,9 +787,14 @@ fn send_lxmf_zmq_outbound_message_direct(
         })
 }
 
+enum ZmqSdkActorPayload {
+    Single(LxmfSdkOutboundMessage),
+    Batch(LxmfSdkOutboundBatch),
+}
+
 struct ZmqSdkActorRequest {
-    message: LxmfSdkOutboundMessage,
-    response: mpsc::Sender<Result<String, TransportError>>,
+    payload: ZmqSdkActorPayload,
+    response: mpsc::Sender<Result<Vec<LxmfSdkOutboundBatchResult>, TransportError>>,
 }
 
 struct ZmqSdkActorSession {
@@ -774,7 +812,51 @@ fn send_lxmf_zmq_outbound_message_via_actor(
     let (response_tx, response_rx) = mpsc::channel();
     sender
         .try_send(ZmqSdkActorRequest {
-            message,
+            payload: ZmqSdkActorPayload::Single(message),
+            response: response_tx,
+        })
+        .map_err(|error| match error {
+            mpsc::TrySendError::Full(_) => TransportError::Backpressure(format!(
+                "LXMF-rs ZeroMQ SDK send queue is full (capacity {LXMF_ZMQ_SEND_QUEUE_CAPACITY})"
+            )),
+            mpsc::TrySendError::Disconnected(_) => {
+                TransportError::Send("LXMF-rs ZeroMQ SDK send actor stopped".to_string())
+            }
+        })?;
+    response_rx
+        .recv_timeout(
+            config
+                .request_timeout
+                .saturating_add(Duration::from_secs(1)),
+        )
+        .map_err(|error| match error {
+            mpsc::RecvTimeoutError::Timeout => TransportError::Receive(
+                "LXMF-rs ZeroMQ SDK actor timed out waiting for send result".to_string(),
+            ),
+            mpsc::RecvTimeoutError::Disconnected => {
+                TransportError::Send("LXMF-rs ZeroMQ SDK send actor stopped".to_string())
+            }
+        })??
+        .into_iter()
+        .next()
+        .map(|result| result.message_id)
+        .ok_or_else(|| {
+            TransportError::Send("LXMF-rs ZeroMQ SDK response missing message_id".to_string())
+        })
+}
+
+fn send_lxmf_zmq_outbound_batch_via_actor(
+    config: &ZmqPipelineBackendConfig,
+    batch: LxmfSdkOutboundBatch,
+) -> Result<Vec<LxmfSdkOutboundBatchResult>, TransportError> {
+    if batch.messages.is_empty() {
+        return Ok(Vec::new());
+    }
+    let sender = zmq_sdk_actor_sender(config)?;
+    let (response_tx, response_rx) = mpsc::channel();
+    sender
+        .try_send(ZmqSdkActorRequest {
+            payload: ZmqSdkActorPayload::Batch(batch),
             response: response_tx,
         })
         .map_err(|error| match error {
@@ -859,10 +941,10 @@ fn run_zmq_sdk_actor(
             )));
             continue;
         };
-        let result = runtime.block_on(send_lxmf_zmq_actor_message(
+        let result = runtime.block_on(send_lxmf_zmq_actor_request(
             active_session,
             &config,
-            request.message,
+            request.payload,
         ));
         if result.is_err() {
             session = None;
@@ -924,7 +1006,26 @@ async fn open_zmq_sdk_actor_session(
     })
 }
 
-async fn send_lxmf_zmq_actor_message(
+async fn send_lxmf_zmq_actor_request(
+    session: &mut ZmqSdkActorSession,
+    config: &ZmqPipelineBackendConfig,
+    payload: ZmqSdkActorPayload,
+) -> Result<Vec<LxmfSdkOutboundBatchResult>, TransportError> {
+    match payload {
+        ZmqSdkActorPayload::Single(message) => {
+            let destination = message.destination.clone();
+            let result = send_lxmf_zmq_actor_single_message(session, config, message).await?;
+            Ok(vec![LxmfSdkOutboundBatchResult {
+                id: result.clone(),
+                message_id: result,
+                destination,
+            }])
+        }
+        ZmqSdkActorPayload::Batch(batch) => send_lxmf_zmq_actor_batch(session, config, batch).await,
+    }
+}
+
+async fn send_lxmf_zmq_actor_single_message(
     session: &mut ZmqSdkActorSession,
     config: &ZmqPipelineBackendConfig,
     message: LxmfSdkOutboundMessage,
@@ -948,6 +1049,74 @@ async fn send_lxmf_zmq_actor_message(
         .ok_or_else(|| {
             TransportError::Send("LXMF-rs ZeroMQ SDK response missing message_id".to_string())
         })
+}
+
+async fn send_lxmf_zmq_actor_batch(
+    session: &mut ZmqSdkActorSession,
+    config: &ZmqPipelineBackendConfig,
+    batch: LxmfSdkOutboundBatch,
+) -> Result<Vec<LxmfSdkOutboundBatchResult>, TransportError> {
+    let request_id = session.next_request_id;
+    session.next_request_id = session.next_request_id.saturating_add(1);
+    let destinations = batch
+        .messages
+        .iter()
+        .map(|message| (message.correlation_id.clone(), message.destination.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let result = lxmf_zmq_rpc_call(
+        &mut session.command,
+        &mut session.responses,
+        config,
+        session.session_id.as_str(),
+        request_id,
+        "sdk_send_batch_v2",
+        Some(lxmf_sdk_outbound_batch_params(batch)),
+    )
+    .await?;
+    if result
+        .get("rejected_count")
+        .and_then(JsonValue::as_u64)
+        .unwrap_or(0)
+        > 0
+    {
+        return Err(TransportError::Send(format!(
+            "LXMF-rs ZeroMQ SDK batch rejected {} messages",
+            result
+                .get("rejected_count")
+                .and_then(JsonValue::as_u64)
+                .unwrap_or(0)
+        )));
+    }
+    let items = result
+        .get("results")
+        .and_then(JsonValue::as_array)
+        .ok_or_else(|| {
+            TransportError::Send("LXMF-rs ZeroMQ SDK batch response missing results".to_string())
+        })?;
+    let mut output = Vec::with_capacity(items.len());
+    for item in items {
+        let id = item
+            .get("id")
+            .and_then(JsonValue::as_str)
+            .ok_or_else(|| {
+                TransportError::Send("LXMF-rs ZeroMQ SDK batch item missing id".to_string())
+            })?
+            .to_string();
+        let message_id = item
+            .get("message_id")
+            .and_then(JsonValue::as_str)
+            .ok_or_else(|| {
+                TransportError::Send("LXMF-rs ZeroMQ SDK batch item missing message_id".to_string())
+            })?
+            .to_string();
+        let destination = destinations.get(&id).cloned().unwrap_or_default();
+        output.push(LxmfSdkOutboundBatchResult {
+            id,
+            message_id,
+            destination,
+        });
+    }
+    Ok(output)
 }
 
 fn lxmf_sdk_outbound_send_params(message: LxmfSdkOutboundMessage) -> JsonValue {
@@ -981,6 +1150,51 @@ fn lxmf_sdk_outbound_send_params(message: LxmfSdkOutboundMessage) -> JsonValue {
         "fields": fields,
         "method": message.delivery_method,
         "try_propagation_on_fail": message.try_propagation_on_fail,
+    })
+}
+
+fn lxmf_sdk_outbound_batch_params(batch: LxmfSdkOutboundBatch) -> JsonValue {
+    let messages = batch
+        .messages
+        .into_iter()
+        .map(|message| {
+            let correlation_id = message.correlation_id;
+            let mut fields = match message.fields {
+                JsonValue::Object(map) => JsonValue::Object(map),
+                other => serde_json::json!({ "fields": other }),
+            };
+            if let JsonValue::Object(map) = &mut fields {
+                map.insert(
+                    "title".to_string(),
+                    JsonValue::String(message.title.clone()),
+                );
+                map.insert(
+                    "content".to_string(),
+                    JsonValue::String(message.content.clone()),
+                );
+                map.insert(
+                    "_sdk".to_string(),
+                    serde_json::json!({
+                        "correlation_id": correlation_id.clone(),
+                        "idempotency_key": correlation_id.clone(),
+                    }),
+                );
+            }
+            serde_json::json!({
+                "id": correlation_id,
+                "destination": message.destination,
+                "title": message.title,
+                "content": message.content,
+                "fields": fields,
+                "method": message.delivery_method,
+                "try_propagation_on_fail": message.try_propagation_on_fail,
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::json!({
+        "batch_id": batch.batch_id,
+        "source": batch.source,
+        "messages": messages,
     })
 }
 
@@ -2494,8 +2708,89 @@ mod tests {
         })
     }
 
+    fn spawn_zmq_single_send_load_server(
+        command_endpoint: String,
+        expected_message_count: usize,
+        captured_methods: Arc<Mutex<Vec<String>>>,
+    ) -> thread::JoinHandle<()> {
+        thread::spawn(move || {
+            let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+            runtime.block_on(async move {
+                let mut commands = PullSocket::new();
+                commands
+                    .bind(command_endpoint.as_str())
+                    .await
+                    .expect("bind command endpoint");
+                let mut response_socket = None;
+                let mut sent_messages = 0usize;
+                for _ in 0..=expected_message_count {
+                    let Some(envelope) = recv_zmq_request_envelope(&mut commands).await else {
+                        return;
+                    };
+                    let request: ReticulumdRpcRequest =
+                        decode_frame(&envelope.payload).expect("decode rpc request");
+                    let method = request.method.clone();
+                    captured_methods
+                        .lock()
+                        .expect("captured methods")
+                        .push(method.clone());
+                    let result = match method.as_str() {
+                        "sdk_negotiate_v2" => serde_json::json!({
+                            "accepted_contract_version": 2,
+                            "effective_capabilities": [],
+                            "runtime_id": "test-runtime",
+                            "profile": "desktop-local-runtime",
+                            "limits": {},
+                            "config_revision": 1,
+                            "features": {},
+                        }),
+                        "sdk_send_v2" => {
+                            let message_id = format!("daemon-message-{sent_messages:05}");
+                            sent_messages += 1;
+                            serde_json::json!({ "message_id": message_id })
+                        }
+                        other => panic!("unexpected ZeroMQ SDK method: {other}"),
+                    };
+                    let rpc_response = ReticulumdRpcResponse {
+                        id: envelope.request_id,
+                        result: Some(result),
+                        error: None,
+                    };
+                    let response_payload = encode_frame(&rpc_response).expect("encode response");
+                    if response_socket.is_none() {
+                        let mut socket = PushSocket::new();
+                        socket
+                            .connect(
+                                envelope
+                                    .response_endpoint
+                                    .as_deref()
+                                    .expect("response endpoint"),
+                            )
+                            .await
+                            .expect("connect response endpoint");
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                        response_socket = Some(socket);
+                    }
+                    response_socket
+                        .as_mut()
+                        .expect("response socket")
+                        .send(ZmqMessage::from(
+                            zmq::encode_envelope(&ZmqRpcEnvelope::response(
+                                envelope.session_id,
+                                envelope.request_id,
+                                response_payload,
+                            ))
+                            .expect("encode zmq envelope"),
+                        ))
+                        .await
+                        .expect("send response");
+                }
+            });
+        })
+    }
+
     async fn recv_zmq_request_envelope(commands: &mut PullSocket) -> Option<ZmqRpcEnvelope> {
-        let message = tokio::time::timeout(Duration::from_secs(2), commands.recv())
+        let message = tokio::time::timeout(Duration::from_secs(30), commands.recv())
             .await
             .ok()?
             .ok()?;
@@ -2608,6 +2903,103 @@ mod tests {
         );
         assert_eq!(request.payload["r3akt_payload_b64"], "AQIDBA==");
         assert_eq!(request.correlation_id.as_deref(), Some("r3akt-transport-1"));
+    }
+
+    #[test]
+    fn lxmf_zmq_batch_params_preserve_order_and_correlation_ids() {
+        let params = lxmf_sdk_outbound_batch_params(LxmfSdkOutboundBatch {
+            batch_id: "batch-1".to_string(),
+            source: "source-destination".to_string(),
+            messages: vec![
+                LxmfSdkOutboundBatchMessage {
+                    destination: "dst-a".to_string(),
+                    title: "RCH".to_string(),
+                    content: "one".to_string(),
+                    fields: serde_json::json!({ "kind": "a" }),
+                    delivery_method: Some("direct".to_string()),
+                    try_propagation_on_fail: true,
+                    correlation_id: "message-a".to_string(),
+                },
+                LxmfSdkOutboundBatchMessage {
+                    destination: "dst-b".to_string(),
+                    title: "RCH".to_string(),
+                    content: "two".to_string(),
+                    fields: serde_json::json!({ "kind": "b" }),
+                    delivery_method: Some("propagated".to_string()),
+                    try_propagation_on_fail: false,
+                    correlation_id: "message-b".to_string(),
+                },
+            ],
+        });
+
+        assert_eq!(params["batch_id"], "batch-1");
+        assert_eq!(params["source"], "source-destination");
+        let messages = params["messages"].as_array().expect("messages");
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["id"], "message-a");
+        assert_eq!(messages[0]["destination"], "dst-a");
+        assert_eq!(messages[0]["fields"]["_sdk"]["correlation_id"], "message-a");
+        assert_eq!(messages[1]["id"], "message-b");
+        assert_eq!(messages[1]["destination"], "dst-b");
+        assert_eq!(messages[1]["method"], "propagated");
+    }
+
+    #[test]
+    fn lxmf_zmq_outbound_ten_thousand_regular_single_messages_complete() {
+        const MESSAGE_COUNT: usize = 10_000;
+
+        let command_endpoint = unused_zmq_endpoint_v4();
+        let response_endpoint = unused_zmq_endpoint_v4();
+        let captured_methods = Arc::new(Mutex::new(Vec::new()));
+        let server = spawn_zmq_single_send_load_server(
+            command_endpoint.clone(),
+            MESSAGE_COUNT,
+            Arc::clone(&captured_methods),
+        );
+
+        let started = std::time::Instant::now();
+        let mut config = rch_local_zmq_pipeline_config(command_endpoint, response_endpoint);
+        config.request_timeout = Duration::from_secs(10);
+        for index in 0..MESSAGE_COUNT {
+            let message_id = send_lxmf_zmq_outbound_message_via_actor(
+                &config,
+                LxmfSdkOutboundMessage {
+                    source: "source-destination".to_string(),
+                    destination: format!("destination-{index:05}"),
+                    title: "RCH".to_string(),
+                    content: format!("payload {index}"),
+                    fields: serde_json::json!({ "bulk_index": index }),
+                    delivery_method: Some("propagated".to_string()),
+                    try_propagation_on_fail: false,
+                    correlation_id: format!("bulk-message-{index:05}"),
+                },
+            )
+            .unwrap_or_else(|error| panic!("message {index} failed: {error}"));
+            assert_eq!(message_id, format!("daemon-message-{index:05}"));
+        }
+        let elapsed = started.elapsed();
+        server.join().expect("join zmq load server");
+
+        let captured_methods = captured_methods.lock().expect("captured methods");
+        let sdk_send_count = captured_methods
+            .iter()
+            .filter(|method| method.as_str() == "sdk_send_v2")
+            .count();
+        println!(
+            "10k_zmq_single_messages_result status=completed requested={} sdk_send_v2={} rpc_requests_captured={} elapsed_ms={} messages_per_sec={:.1}",
+            MESSAGE_COUNT,
+            sdk_send_count,
+            captured_methods.len(),
+            elapsed.as_millis(),
+            f64::from(u32::try_from(MESSAGE_COUNT).expect("message count fits in u32"))
+                / elapsed.as_secs_f64()
+        );
+        assert_eq!(
+            captured_methods.first().map(String::as_str),
+            Some("sdk_negotiate_v2")
+        );
+        assert_eq!(sdk_send_count, MESSAGE_COUNT);
+        assert_eq!(captured_methods.len(), MESSAGE_COUNT + 1);
     }
 
     #[test]

--- a/docs/rust-transition.md
+++ b/docs/rust-transition.md
@@ -127,6 +127,20 @@ Validated during the root Rust import and refreshed on 2026-05-11:
   The refreshed gate runs both `r3akt-rch-server` live Reticulum receipt/fanout
   tests through the outbound worker path, then validates `sdk_poll_events_v2`
   over the LXMF-rs ZeroMQ RPC loop.
+- Local daemon-involved ZeroMQ load validation is available through
+  `scripts/local-reticulum-live-gate.ps1 -ZmqLoadOnly -LoadMessages <count>`.
+  It sends normal individual `sdk_send_v2` requests from one local daemon to
+  local receiver daemons and verifies receiver-side `sdk_poll_events_v2`
+  inbound events. A 2-message sanity run passed on 2026-05-30; 10-message
+  burst runs accepted all sends but exposed incomplete receiver delivery,
+  confirming the remaining bottleneck is daemon/network delivery rather than
+  RCH-side request construction.
+- The daemon-side scalability fix is a persistent bounded delivery scheduler in
+  `reticulumd`: accepted messages enter one runtime-backed queue, direct links
+  are reused instead of reset per message, per-peer delivery defaults to ordered
+  single in-flight work, and burst receipt events are drained without one wakeup
+  per receipt. Inspect `delivery_pipeline` in `daemon_status_ex`,
+  `sdk_snapshot_v2`, or `sdk_status_v2` while running the load gate.
 - Controlled external RMAP Reticulum validation: the same script passed on
   2026-05-11 with `-ExternalConfigPath` pointing at the local RMAP testnet
   config, using three temporary controlled identities connected through public
@@ -153,9 +167,12 @@ Release blockers cleared in the latest parity pass:
   an additional feature on top of LXMF chat, not as a separate voice-only
   routing class.
 - The transport crate now has ZeroMQ SDK adapter coverage for R3AKT frame
-  sends, normal RCH LXMF field payload sends, and inbound SDK event conversion.
-- Direct-send compatibility tests still cover the legacy RPC fallback while the
-  server runtime moves release traffic to the ZeroMQ SDK pipeline.
+  sends, normal RCH LXMF field payload sends, batched fanout payloads, and
+  inbound SDK event conversion. Server runtime southbound traffic uses the
+  ZeroMQ SDK pipeline only.
+- Multi-recipient dispatch now uses `sdk_send_batch_v2` over ZeroMQ so a topic
+  fanout enters `reticulumd` as one bounded batch request instead of one RPC
+  call per recipient.
 - `assignment_asset_link_fanout_uses_python_generic_markdown_shape` proves the
   generic LXMF fanout path for assignment asset links renders Python-style
   markdown with resolved mission, checklist task, and asset names.

--- a/scripts/local-reticulum-live-gate.ps1
+++ b/scripts/local-reticulum-live-gate.ps1
@@ -7,13 +7,39 @@ param(
     [int]$DiscoverySettleSeconds = 3,
     [int]$ReceiptPollAttempts = 120,
     [int]$ReceiptPollDelayMs = 500,
-    [switch]$IncludeZmqEventPoll
+    [switch]$IncludeZmqEventPoll,
+    [switch]$IncludeZmqLoad,
+    [switch]$ZmqLoadOnly,
+    [int]$LoadMessages = 1000,
+    [int]$LoadSenderClients = 4,
+    [int]$LoadReceiverCount = 0,
+    [int]$LoadPollAttempts = 240,
+    [int]$LoadPollDelayMs = 250
 )
 
 $ErrorActionPreference = "Stop"
 
+if ($ZmqLoadOnly) {
+    $IncludeZmqLoad = $true
+}
+
 if ($NodeCount -lt 3) {
     throw "NodeCount must be at least 3 for direct receipt plus two-recipient fanout validation."
+}
+
+if ($IncludeZmqLoad) {
+    if ($LoadMessages -lt 1) {
+        throw "LoadMessages must be at least 1."
+    }
+    if ($LoadSenderClients -lt 1) {
+        throw "LoadSenderClients must be at least 1."
+    }
+    if ($LoadReceiverCount -eq 0) {
+        $LoadReceiverCount = $NodeCount - 1
+    }
+    if ($LoadReceiverCount -lt 1 -or $LoadReceiverCount -gt ($NodeCount - 1)) {
+        throw "LoadReceiverCount must be in the range 1..NodeCount-1."
+    }
 }
 
 if (-not (Test-Path -LiteralPath $ReticulumdExe)) {
@@ -98,6 +124,15 @@ $savedEnv = @{
     R3AKT_LXMF_ZMQ_COMMAND_ENDPOINT = [Environment]::GetEnvironmentVariable("R3AKT_LXMF_ZMQ_COMMAND_ENDPOINT")
     R3AKT_LXMF_ZMQ_RESPONSE_ENDPOINT = [Environment]::GetEnvironmentVariable("R3AKT_LXMF_ZMQ_RESPONSE_ENDPOINT")
     R3AKT_ENABLE_ZMQ_EVENT_POLL = [Environment]::GetEnvironmentVariable("R3AKT_ENABLE_ZMQ_EVENT_POLL")
+    R3AKT_ZMQ_LOAD_COMMAND_ENDPOINTS = [Environment]::GetEnvironmentVariable("R3AKT_ZMQ_LOAD_COMMAND_ENDPOINTS")
+    R3AKT_ZMQ_LOAD_DESTINATIONS = [Environment]::GetEnvironmentVariable("R3AKT_ZMQ_LOAD_DESTINATIONS")
+    R3AKT_ZMQ_LOAD_SENDER_RESPONSE_ENDPOINTS = [Environment]::GetEnvironmentVariable("R3AKT_ZMQ_LOAD_SENDER_RESPONSE_ENDPOINTS")
+    R3AKT_ZMQ_LOAD_RECEIVER_RESPONSE_ENDPOINTS = [Environment]::GetEnvironmentVariable("R3AKT_ZMQ_LOAD_RECEIVER_RESPONSE_ENDPOINTS")
+    R3AKT_ZMQ_LOAD_MESSAGES = [Environment]::GetEnvironmentVariable("R3AKT_ZMQ_LOAD_MESSAGES")
+    R3AKT_ZMQ_LOAD_SENDER_CLIENTS = [Environment]::GetEnvironmentVariable("R3AKT_ZMQ_LOAD_SENDER_CLIENTS")
+    R3AKT_ZMQ_LOAD_RECEIVER_COUNT = [Environment]::GetEnvironmentVariable("R3AKT_ZMQ_LOAD_RECEIVER_COUNT")
+    R3AKT_ZMQ_LOAD_POLL_ATTEMPTS = [Environment]::GetEnvironmentVariable("R3AKT_ZMQ_LOAD_POLL_ATTEMPTS")
+    R3AKT_ZMQ_LOAD_POLL_DELAY_MS = [Environment]::GetEnvironmentVariable("R3AKT_ZMQ_LOAD_POLL_DELAY_MS")
 }
 
 try {
@@ -113,11 +148,25 @@ try {
             $transportPorts += Get-FreeTcpPort
         }
     }
-    $zmqCommandEndpoint = $null
+    $zmqCommandEndpoints = @()
     $zmqResponseEndpoint = $null
+    $zmqSenderResponseEndpoints = @()
+    $zmqReceiverResponseEndpoints = @()
+    if ($IncludeZmqEventPoll -or $IncludeZmqLoad) {
+        for ($idx = 0; $idx -lt $NodeCount; $idx++) {
+            $zmqCommandEndpoints += "tcp://127.0.0.1:$(Get-FreeTcpPort)"
+        }
+    }
     if ($IncludeZmqEventPoll) {
-        $zmqCommandEndpoint = "tcp://127.0.0.1:$(Get-FreeTcpPort)"
         $zmqResponseEndpoint = "tcp://127.0.0.1:$(Get-FreeTcpPort)"
+    }
+    if ($IncludeZmqLoad) {
+        for ($idx = 0; $idx -lt $LoadSenderClients; $idx++) {
+            $zmqSenderResponseEndpoints += "tcp://127.0.0.1:$(Get-FreeTcpPort)"
+        }
+        for ($idx = 0; $idx -lt $LoadReceiverCount; $idx++) {
+            $zmqReceiverResponseEndpoints += "tcp://127.0.0.1:$(Get-FreeTcpPort)"
+        }
     }
 
     for ($idx = 0; $idx -lt $NodeCount; $idx++) {
@@ -140,8 +189,8 @@ try {
         if ([string]::IsNullOrWhiteSpace($ExternalConfigPath)) {
             $args += @("--transport", "127.0.0.1:$($transportPorts[$idx])")
         }
-        if ($IncludeZmqEventPoll -and $idx -eq 0) {
-            $args += @("--zmq-rpc-command", $zmqCommandEndpoint)
+        if ($IncludeZmqEventPoll -or $IncludeZmqLoad) {
+            $args += @("--zmq-rpc-command", $zmqCommandEndpoints[$idx])
         }
         $args += @("--config", $configPath)
         $processes += Start-Process -FilePath $ReticulumdExe `
@@ -163,7 +212,13 @@ try {
         Write-Host "  node-$idx rpc=127.0.0.1:$($rpcPorts[$idx]) delivery=$($destinations[$idx])"
     }
     if ($IncludeZmqEventPoll) {
-        Write-Host "  node-0 zmq-command=$zmqCommandEndpoint zmq-response=$zmqResponseEndpoint"
+        Write-Host "  node-0 zmq-command=$($zmqCommandEndpoints[0]) zmq-response=$zmqResponseEndpoint"
+    }
+    if ($IncludeZmqLoad) {
+        Write-Host "  zmq-load messages=$LoadMessages sender-clients=$LoadSenderClients receivers=$LoadReceiverCount"
+        for ($idx = 0; $idx -lt $NodeCount; $idx++) {
+            Write-Host "  node-$idx zmq-command=$($zmqCommandEndpoints[$idx])"
+        }
     }
 
     Start-Sleep -Seconds $DiscoverySettleSeconds
@@ -175,23 +230,43 @@ try {
     $env:R3AKT_RETICULUMD_RECEIPT_POLL_ATTEMPTS = "$ReceiptPollAttempts"
     $env:R3AKT_RETICULUMD_RECEIPT_POLL_DELAY_MS = "$ReceiptPollDelayMs"
     if ($IncludeZmqEventPoll) {
-        $env:R3AKT_LXMF_ZMQ_COMMAND_ENDPOINT = $zmqCommandEndpoint
+        $env:R3AKT_LXMF_ZMQ_COMMAND_ENDPOINT = $zmqCommandEndpoints[0]
         $env:R3AKT_LXMF_ZMQ_RESPONSE_ENDPOINT = $zmqResponseEndpoint
         $env:R3AKT_ENABLE_ZMQ_EVENT_POLL = "1"
     }
-
-    cargo "+$RustToolchain" test -p r3akt-rch-server live_reticulumd_direct_send_receipt_is_delivered_when_configured -- --nocapture
-    if ($LASTEXITCODE -ne 0) {
-        exit $LASTEXITCODE
+    if ($IncludeZmqLoad) {
+        $env:R3AKT_ZMQ_LOAD_COMMAND_ENDPOINTS = ($zmqCommandEndpoints -join ",")
+        $env:R3AKT_ZMQ_LOAD_DESTINATIONS = ($destinations -join ",")
+        $env:R3AKT_ZMQ_LOAD_SENDER_RESPONSE_ENDPOINTS = ($zmqSenderResponseEndpoints -join ",")
+        $env:R3AKT_ZMQ_LOAD_RECEIVER_RESPONSE_ENDPOINTS = ($zmqReceiverResponseEndpoints -join ",")
+        $env:R3AKT_ZMQ_LOAD_MESSAGES = "$LoadMessages"
+        $env:R3AKT_ZMQ_LOAD_SENDER_CLIENTS = "$LoadSenderClients"
+        $env:R3AKT_ZMQ_LOAD_RECEIVER_COUNT = "$LoadReceiverCount"
+        $env:R3AKT_ZMQ_LOAD_POLL_ATTEMPTS = "$LoadPollAttempts"
+        $env:R3AKT_ZMQ_LOAD_POLL_DELAY_MS = "$LoadPollDelayMs"
     }
 
-    cargo "+$RustToolchain" test -p r3akt-rch-server live_reticulumd_topic_fanout_receipts_are_delivered_when_configured -- --nocapture
-    if ($LASTEXITCODE -ne 0) {
-        exit $LASTEXITCODE
+    if (-not $ZmqLoadOnly) {
+        cargo "+$RustToolchain" test -p r3akt-rch-server live_reticulumd_direct_send_receipt_is_delivered_when_configured -- --nocapture
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+
+        cargo "+$RustToolchain" test -p r3akt-rch-server live_reticulumd_topic_fanout_receipts_are_delivered_when_configured -- --nocapture
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
     }
 
-    if ($IncludeZmqEventPoll) {
+    if ($IncludeZmqEventPoll -and -not $ZmqLoadOnly) {
         cargo "+$RustToolchain" test -p r3akt-rch-server live_reticulumd_zmq_event_poll_succeeds_when_configured -- --nocapture
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+    }
+
+    if ($IncludeZmqLoad) {
+        cargo "+$RustToolchain" test -p r3akt-rch-server live_reticulumd_zmq_load_delivers_to_local_clients_when_configured -- --ignored --nocapture
         if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
         }


### PR DESCRIPTION
﻿## Summary
- add RCH-side ZeroMQ load validation that sends regular single-message requests and reports submit and end-to-end throughput
- document the daemon delivery scheduler tuning knobs and `delivery_pipeline` counters
- update Rust transition notes for the bounded scheduler, link reuse, and receipt burst drain behavior

## Validation
- PASS `cargo +1.85.0 fmt --all -- --check`
- PASS `cargo +1.85.0 clippy --workspace --all-targets -- -D warnings`
- PASS `cargo +1.85.0 test --workspace`
- PASS `cargo +1.85.0 test -p r3akt-transport-rns lxmf_zmq_outbound_ten_thousand_regular_single_messages_complete -- --nocapture`
- PASS `./scripts/local-reticulum-live-gate.ps1 -ZmqLoadOnly -LoadMessages 10 -LoadSenderClients 2 -DiscoverySettleSeconds 10 -LoadPollAttempts 240 -LoadPollDelayMs 250`
- PASS `./scripts/local-reticulum-live-gate.ps1 -ZmqLoadOnly -LoadMessages 100 -LoadSenderClients 4 -DiscoverySettleSeconds 10 -LoadPollAttempts 240 -LoadPollDelayMs 250`
- PASS `./scripts/local-reticulum-live-gate.ps1 -ZmqLoadOnly -LoadMessages 1000 -LoadSenderClients 4 -DiscoverySettleSeconds 10 -LoadPollAttempts 480 -LoadPollDelayMs 250`

## Results
- fake 10,000-message single-request load: `10000` requested, `10000` `sdk_send_v2`, `10001` RPC requests captured, `3795 ms`, `2634.8 msg/s`
- live 1,000-message local daemon load: `1000` accepted, `1000` received, `2041 ms` submit phase, `13299 ms` full end-to-end, `489.9 msg/s` submit, `75.2 msg/s` end-to-end