### PR TITLE
Reconcile RCH LXMF phone relay delivery state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -134,9 +134,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -158,15 +158,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cbc"
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -417,12 +417,6 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -617,15 +611,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -649,25 +641,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown",
 ]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -695,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -746,9 +726,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -780,24 +760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,21 +786,14 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -874,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lxmf-reference"
@@ -927,9 +882,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mime"
@@ -949,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1015,9 +970,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1046,9 +1001,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -1120,16 +1075,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -1416,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1439,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reticulum-rs-core"
@@ -1471,7 +1416,6 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "log",
  "lxmf-reference",
  "rand_core 0.6.4",
  "rmp-serde",
@@ -1571,9 +1515,9 @@ checksum = "68f5acb362a0e75c2a963532fa7fabf13dff81626dc494df16488d30befcbea0"
 
 [[package]]
 name = "scc"
-version = "3.7.1"
+version = "3.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcd12b6caff5213cc3c03123cde8c3db5e413008a63b0c0ba35e6275825ea92"
+checksum = "5581cd5dd2cb79cbe9d8137071d67f62f0db926e83a07b4d14561c5b7d423776"
 dependencies = [
  "saa",
  "sdd",
@@ -1674,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1732,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1776,15 +1720,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1814,9 +1758,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1836,7 +1780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1915,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -1996,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
@@ -2017,7 +1961,6 @@ dependencies = [
  "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2070,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -2087,18 +2030,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -2128,23 +2065,14 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen 0.46.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2155,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2165,9 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2178,45 +2106,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -2241,94 +2135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,18 +2148,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2362,18 +2168,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,7 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
+ "log",
  "lxmf-reference",
  "rand_core 0.6.4",
  "rmp-serde",

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -3899,21 +3899,20 @@ fn relay_reticulumd_inbound_topic_message(
     let default_direct_relay = relay_destinations.is_empty() && is_direct_topic;
     let mut direct_active_relay = false;
     if is_direct_topic {
-        let active_destinations = active_generic_lxmf_relay_destinations(state, source.as_str())?;
-        if !active_destinations.is_empty() {
-            relay_destinations.retain(|destination| {
-                active_destinations
-                    .iter()
-                    .any(|active| active == destination)
-            });
+        let active_subscribers = active_direct_subscriber_relay_destinations(
+            state,
+            source.as_str(),
+            &relay_destinations,
+        )?;
+        if !active_subscribers.is_empty() {
+            relay_destinations = active_subscribers;
             direct_active_relay = true;
-        }
-        for destination in active_destinations {
-            if !relay_destinations
-                .iter()
-                .any(|existing| existing == &destination)
-            {
-                relay_destinations.push(destination);
+        } else {
+            let active_destinations =
+                active_generic_lxmf_relay_destinations(state, source.as_str())?;
+            if !active_destinations.is_empty() {
+                relay_destinations = active_destinations;
+                direct_active_relay = true;
             }
         }
     }
@@ -3977,6 +3976,30 @@ fn active_generic_lxmf_relay_destinations(
             let last_seen = unix_ms_from_iso8601(client.last_seen.as_str())?;
             (last_seen >= now - r3akt_rch_core::RECENT_RUNTIME_PRESENCE_WINDOW_MS)
                 .then_some(identity)
+        })
+        .collect::<Vec<_>>();
+    destinations.sort();
+    destinations.dedup();
+    Ok(destinations)
+}
+
+fn active_direct_subscriber_relay_destinations(
+    state: &AppState,
+    source: &str,
+    subscribers: &[String],
+) -> Result<Vec<String>, ApiError> {
+    let now = unix_now_ms();
+    let source = normalize_identity_key(source);
+    let announces = load_identity_announces_for_state(state)?;
+    let mut destinations = subscribers
+        .iter()
+        .filter_map(|destination| normalize_identity_key(destination))
+        .filter(|destination| source.as_deref() != Some(destination.as_str()))
+        .filter(|destination| {
+            announces.iter().any(|record| {
+                record.last_seen_ts_ms >= now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS
+                    && identity_announce_matches_destination(record, destination)
+            })
         })
         .collect::<Vec<_>>();
     destinations.sort();
@@ -26545,6 +26568,137 @@ mod tests {
         assert_eq!(
             relay.delivery_metadata["reticulumd_inbound_default_direct_relay"],
             false
+        );
+
+        std::fs::remove_file(db_path).expect("cleanup db");
+    }
+
+    #[tokio::test]
+    async fn reticulumd_inbound_direct_topic_prefers_fresh_announced_subscriber() {
+        let source = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let fresh_subscriber = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let stale_subscriber = "cccccccccccccccccccccccccccccccc";
+        let unrelated_active = "dddddddddddddddddddddddddddddddd";
+        let envelope = r3akt_protocol::ProtocolEnvelope::new(
+            r3akt_protocol::NodeId::new(source),
+            r3akt_protocol::Destination::Topic(r3akt_protocol::Topic::new("direct")),
+            r3akt_protocol::Topic::new("direct"),
+            r3akt_protocol::Payload::TopicMessage(r3akt_protocol::TopicMessage {
+                body: "phone to fresh subscriber".to_string(),
+                content_type: "text/plain".to_string(),
+                correlation_id: Some("direct-relay-fresh-sub-1".to_string()),
+                attachments: Vec::new(),
+            }),
+        );
+        let payload_b64 = BASE64_STANDARD.encode(envelope.encode_msgpack().expect("msgpack"));
+        let (endpoint, rpc_server) = fake_reticulumd_rpc_server_with_results(vec![
+            json!({
+                "messages": [{
+                    "id": "lxmf-inbound-direct-fresh-sub-1",
+                    "destination": "local-destination",
+                    "fields": {
+                        "r3akt_payload_b64": payload_b64
+                    }
+                }]
+            }),
+            json!({
+                "message_id": "direct-fresh-sub-accepted"
+            }),
+        ]);
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-reticulumd-inbound-direct-fresh-sub-{}.db",
+            Uuid::new_v4()
+        ));
+        let mut store = RchSqliteStore::open(&db_path).expect("sqlite");
+        let now = crate::unix_now_ms();
+        let mut snapshot = r3akt_rch_core::RchCore::new().snapshot();
+        snapshot.subscribers = vec![
+            r3akt_rch_core::SubscriberRecord {
+                node_id: stale_subscriber.to_string(),
+                topic_id: "direct".to_string(),
+                reject_tests: None,
+                metadata: json!({ "source": "old_phone_hil" }),
+                first_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 10_000,
+                last_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 10_000,
+            },
+            r3akt_rch_core::SubscriberRecord {
+                node_id: fresh_subscriber.to_string(),
+                topic_id: "direct".to_string(),
+                reject_tests: None,
+                metadata: json!({ "source": "sideband_hil" }),
+                first_seen_ts_ms: now,
+                last_seen_ts_ms: now,
+            },
+        ];
+        snapshot.identity_announces = vec![
+            r3akt_rch_core::IdentityAnnounceRecord {
+                destination_hash: stale_subscriber.to_string(),
+                announced_identity_hash: None,
+                display_name: Some("stale phone".to_string()),
+                source_interface: Some("reticulumd".to_string()),
+                announce_capabilities: Vec::new(),
+                client_type: "generic_lxmf".to_string(),
+                first_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 10_000,
+                last_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 10_000,
+            },
+            r3akt_rch_core::IdentityAnnounceRecord {
+                destination_hash: fresh_subscriber.to_string(),
+                announced_identity_hash: None,
+                display_name: Some("fresh phone".to_string()),
+                source_interface: Some("reticulumd".to_string()),
+                announce_capabilities: Vec::new(),
+                client_type: "generic_lxmf".to_string(),
+                first_seen_ts_ms: now,
+                last_seen_ts_ms: now,
+            },
+        ];
+        store.save_snapshot(&snapshot).expect("save snapshot");
+        drop(store);
+
+        let state = crate::AppState::from_sqlite_path(&db_path)
+            .expect("state")
+            .with_reticulumd_rpc(endpoint.clone(), "local-destination");
+        state.clients.write().expect("clients").insert(
+            unrelated_active.to_string(),
+            crate::ClientRecord::new(unrelated_active.to_string(), now),
+        );
+        let adapter = ReticulumdRpcLxmfRsAdapter::new(
+            "local-destination",
+            ReticulumdRpcTransport::new(endpoint),
+        );
+        let mut transport = LxmfRsTransport::new(adapter);
+
+        crate::process_reticulumd_inbound_worker_tick(
+            &state,
+            &mut transport,
+            Duration::from_millis(50),
+        )
+        .await
+        .expect("inbound tick")
+        .expect("envelope");
+
+        let requests = rpc_server.join().expect("rpc server");
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[1].method, "send_message_v2");
+        let params = requests[1].params.as_ref().expect("relay params");
+        assert_eq!(params["destination"], fresh_subscriber);
+        assert_ne!(params["destination"], stale_subscriber);
+        assert_ne!(params["destination"], unrelated_active);
+
+        let messages = state.messages.read().expect("messages");
+        let relay = messages
+            .iter()
+            .find(|message| {
+                message
+                    .delivery_metadata
+                    .get("reticulumd_inbound_direct_active_relay")
+                    .and_then(Value::as_bool)
+                    == Some(true)
+            })
+            .expect("active direct relay");
+        assert_eq!(
+            relay.delivery_metadata["target_destinations"],
+            json!([fresh_subscriber])
         );
 
         std::fs::remove_file(db_path).expect("cleanup db");

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -10781,6 +10781,7 @@ fn direct_status_failure_should_retry_propagated(
     }
     let status = receipt_status.trim().to_ascii_lowercase();
     reticulumd_status_is_retryable_link_failure(status.as_str())
+        || (status.starts_with("failed") && status.contains("peer not announced"))
 }
 
 fn rem_auto_status_failure_is_retryable(status: &str) -> bool {
@@ -50756,6 +50757,74 @@ mod tests {
         .expect("generic decision");
         assert_eq!(decision.method, "propagated");
         assert_eq!(decision.reason, "direct_cooldown");
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn reticulumd_direct_peer_not_announced_queues_generic_propagation_fallback() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-generic-status-peer-not-announced-{}.db",
+            Uuid::new_v4()
+        ));
+        let mut store = r3akt_rch_core::RchSqliteStore::open(&db_path).expect("sqlite");
+        let mut snapshot = r3akt_rch_core::RchCore::new().snapshot();
+        let now = crate::unix_now_ms();
+        let generic_destination = "7f08e12b3f25f23e62f3a15288303c95";
+        snapshot.messages = vec![r3akt_rch_core::MessageRecord {
+            message_id: "pending-generic-peer-not-announced".to_string(),
+            topic_id: Some("direct".to_string()),
+            destination: Some(generic_destination.to_string()),
+            sender: "northbound".to_string(),
+            content: "pending generic direct".to_string(),
+            delivery_mode: r3akt_rch_core::DeliveryMode::Fanout,
+            delivery_method: "direct".to_string(),
+            delivery_policy_reason: "fanout_route".to_string(),
+            delivery_state: "sent".to_string(),
+            delivery_metadata: json!({
+                "dispatch_status": "accepted",
+                "receipt_pending": true,
+            }),
+            created_ts_ms: now,
+            attachments: Vec::new(),
+        }];
+        store.save_snapshot(&snapshot).expect("save snapshot");
+
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        crate::mark_reticulumd_status_delivery_failure(
+            &state,
+            "pending-generic-peer-not-announced",
+            "failed: peer not announced",
+        )
+        .expect("mark failure");
+
+        let messages = state.messages.read().expect("messages");
+        let stored = messages
+            .iter()
+            .find(|message| message.message_id == "pending-generic-peer-not-announced")
+            .expect("stored message");
+        assert_eq!(stored.delivery_state, "queued");
+        assert_eq!(stored.delivery_method, "propagated");
+        assert_eq!(stored.delivery_policy_reason, "direct_failure_fallback");
+        assert_eq!(
+            stored.delivery_metadata["fallback_reason"],
+            "direct_status_failure"
+        );
+        assert_eq!(stored.delivery_metadata["retry_scheduled"], true);
+        drop(messages);
+
+        let decision = crate::outbound_delivery_decision(
+            &state,
+            r3akt_rch_core::DeliveryMode::Targeted,
+            Some(generic_destination),
+        )
+        .expect("generic decision");
+        assert_eq!(decision.method, "propagated");
+        assert!(
+            matches!(decision.reason.as_str(), "direct_cooldown" | "no_fresh_presence"),
+            "unexpected propagation reason: {}",
+            decision.reason
+        );
 
         let _ = std::fs::remove_file(db_path);
     }

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -10161,6 +10161,7 @@ fn poll_reticulumd_delivery_receipts(state: &AppState) -> Result<(), ApiError> {
             })
             .map(|message| {
                 (
+                    message.clone(),
                     message.message_id.clone(),
                     reticulumd_receipt_targets_for_message(message),
                 )
@@ -10172,7 +10173,7 @@ fn poll_reticulumd_delivery_receipts(state: &AppState) -> Result<(), ApiError> {
     }
 
     let mut client = ReticulumdRpcClient::new(endpoint.as_str());
-    for (message_id, targets) in pending_messages {
+    for (message, message_id, targets) in pending_messages {
         if targets.is_empty() {
             continue;
         }
@@ -10224,6 +10225,27 @@ fn poll_reticulumd_delivery_receipts(state: &AppState) -> Result<(), ApiError> {
                 .and_then(|target| target.status.as_deref())
                 .unwrap_or("sent");
             mark_reticulumd_status_sent(state, &message_id, receipt_status)?;
+        } else if statuses.len() == targets.len() {
+            if let Some(receipt_status) =
+                propagated_fanout_partial_success_status(&message, &statuses)
+            {
+                mark_reticulumd_status_sent(state, &message_id, receipt_status.as_str())?;
+            } else if let Some(failed) = statuses.iter().find_map(|target| {
+                target
+                    .status
+                    .as_deref()
+                    .filter(|status| terminal_reticulumd_failure_status(status))
+                    .map(ToString::to_string)
+                    .or_else(|| {
+                        target
+                            .sdk_snapshot
+                            .as_ref()
+                            .filter(|snapshot| sdk_status_failure_terminal(snapshot))
+                            .map(delivery_snapshot_receipt_status)
+                    })
+            }) {
+                mark_reticulumd_status_delivery_failure(state, &message_id, &failed)?;
+            }
         } else if let Some(failed) = statuses.iter().find_map(|target| {
             target
                 .status
@@ -10489,6 +10511,52 @@ fn sdk_status_failure_terminal(snapshot: &LxmfDeliverySnapshot) -> bool {
         )
 }
 
+fn reticulumd_receipt_target_success_terminal(target: &ReticulumdReceiptTarget) -> bool {
+    target.sdk_snapshot.as_ref().is_some_and(|snapshot| {
+        sdk_status_delivered_terminal(snapshot) || sdk_status_sent_terminal(snapshot)
+    }) || target.status.as_deref().is_some_and(|status| {
+        status.eq_ignore_ascii_case("delivered") || terminal_reticulumd_sent_status(status)
+    })
+}
+
+fn reticulumd_receipt_target_failure_terminal(target: &ReticulumdReceiptTarget) -> bool {
+    target
+        .status
+        .as_deref()
+        .is_some_and(terminal_reticulumd_failure_status)
+        || target
+            .sdk_snapshot
+            .as_ref()
+            .is_some_and(sdk_status_failure_terminal)
+}
+
+fn propagated_fanout_partial_success_status(
+    message: &OutboundMessageRecord,
+    statuses: &[ReticulumdReceiptTarget],
+) -> Option<String> {
+    if message.delivery_method != "propagated" || message.delivery_mode != DeliveryMode::Fanout {
+        return None;
+    }
+    let has_success = statuses
+        .iter()
+        .any(reticulumd_receipt_target_success_terminal);
+    let has_failure = statuses
+        .iter()
+        .any(reticulumd_receipt_target_failure_terminal);
+    let all_terminal = statuses.iter().all(|target| {
+        reticulumd_receipt_target_success_terminal(target)
+            || reticulumd_receipt_target_failure_terminal(target)
+    });
+    if !has_success || !has_failure || !all_terminal {
+        return None;
+    }
+    statuses
+        .iter()
+        .find(|target| reticulumd_receipt_target_success_terminal(target))
+        .and_then(|target| target.status.clone())
+        .or_else(|| Some("sent".to_string()))
+}
+
 fn terminal_reticulumd_failure_status(status: &str) -> bool {
     let normalized = status.trim().to_ascii_lowercase();
     normalized.starts_with("failed")
@@ -10599,22 +10667,49 @@ fn mark_reticulumd_status_sent(
         };
         message.delivery_state = delivery_success_state(message).to_string();
         clear_success_superseded_delivery_metadata(&mut message.delivery_metadata);
+        let mut metadata = json!({
+            "acked": false,
+            "dispatch_status": "accepted",
+            "receipt_pending": false,
+            "receipt_status": receipt_status,
+            "receipt_sent_ts_ms": now_ms,
+            "receipt_timeout": false,
+        });
         merge_delivery_metadata(
-            &mut message.delivery_metadata,
-            json!({
-                "acked": false,
-                "dispatch_status": "accepted",
-                "receipt_pending": false,
-                "receipt_status": receipt_status,
-                "receipt_sent_ts_ms": now_ms,
-                "receipt_timeout": false,
-            }),
+            &mut metadata,
+            propagated_fanout_partial_success_metadata(message),
         );
+        merge_delivery_metadata(&mut message.delivery_metadata, metadata);
         message.clone()
     };
     persist_outbound_message_row(state, &message)?;
     broadcast_message_event(state, &message);
     Ok(())
+}
+
+fn propagated_fanout_partial_success_metadata(message: &OutboundMessageRecord) -> Value {
+    if message.delivery_method != "propagated" || message.delivery_mode != DeliveryMode::Fanout {
+        return json!({});
+    }
+    let targets = reticulumd_receipt_targets_for_message(message);
+    let failed_destinations = targets
+        .iter()
+        .filter(|target| reticulumd_receipt_target_failure_terminal(target))
+        .filter_map(|target| normalize_identity_key(target.destination.as_str()))
+        .collect::<Vec<_>>();
+    let propagated_destinations = targets
+        .iter()
+        .filter(|target| reticulumd_receipt_target_success_terminal(target))
+        .filter_map(|target| normalize_identity_key(target.destination.as_str()))
+        .collect::<Vec<_>>();
+    if failed_destinations.is_empty() || propagated_destinations.is_empty() {
+        return json!({});
+    }
+    json!({
+        "partial_delivery": true,
+        "failed_destinations": failed_destinations,
+        "propagated_destinations": propagated_destinations,
+    })
 }
 
 fn mark_reticulumd_status_delivery_failure(
@@ -45877,6 +45972,102 @@ mod tests {
             targets
                 .iter()
                 .all(|target| target["sdk_delivery_state"] == "delivered")
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn propagated_fanout_partial_peer_not_announced_stays_propagated() {
+        let (endpoint, rpc_server) = fake_reticulumd_rpc_server_with_results(vec![
+            json!({
+                "message": {
+                    "message_id": "sdk-target-propagated",
+                    "state": "sent",
+                    "terminal": true,
+                    "last_updated_ms": 1_700_000_000_001_u64,
+                    "attempts": 0,
+                    "reason_code": null,
+                    "receipt_status": "sent: propagated resource"
+                }
+            }),
+            json!({
+                "message": {
+                    "message_id": "sdk-target-stale",
+                    "state": "failed",
+                    "terminal": true,
+                    "last_updated_ms": 1_700_000_000_002_u64,
+                    "attempts": 0,
+                    "reason_code": "peer_not_announced",
+                    "receipt_status": "failed: peer not announced"
+                }
+            }),
+        ]);
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-propagated-fanout-partial-peer-not-announced-{}.db",
+            Uuid::new_v4()
+        ));
+        let mut store = RchSqliteStore::open(&db_path).expect("sqlite");
+        let mut snapshot = r3akt_rch_core::RchCore::new().snapshot();
+        snapshot.messages = vec![r3akt_rch_core::MessageRecord {
+            message_id: "propagated-fanout-partial".to_string(),
+            topic_id: Some("direct".to_string()),
+            destination: None,
+            sender: "northbound".to_string(),
+            content: "[topic:direct]\nhello".to_string(),
+            delivery_mode: r3akt_rch_core::DeliveryMode::Fanout,
+            delivery_method: "propagated".to_string(),
+            delivery_policy_reason: "topic_unannounced".to_string(),
+            delivery_state: "propagated".to_string(),
+            delivery_metadata: json!({
+                "dispatch_status": "accepted",
+                "reticulumd_dispatch_count": 2,
+                "reticulumd_receipt_targets": [
+                    {
+                        "message_id": "sdk-target-propagated",
+                        "destination": "live-destination",
+                        "status": "pending"
+                    },
+                    {
+                        "message_id": "sdk-target-stale",
+                        "destination": "stale-destination",
+                        "status": "pending"
+                    }
+                ],
+                "receipt_pending": false,
+            }),
+            created_ts_ms: crate::unix_now_ms(),
+            attachments: Vec::new(),
+        }];
+        store.save_snapshot(&snapshot).expect("save snapshot");
+        let state = crate::AppState::from_sqlite_path(&db_path)
+            .expect("state")
+            .with_reticulumd_rpc(endpoint, "source-destination");
+
+        crate::poll_reticulumd_delivery_receipts(&state).expect("poll statuses");
+
+        let requests = rpc_server.join().expect("rpc server");
+        assert_eq!(requests.len(), 2);
+        let snapshot = RchSqliteStore::open(&db_path)
+            .expect("open sqlite")
+            .load_snapshot()
+            .expect("load snapshot")
+            .expect("snapshot");
+        let stored = snapshot
+            .messages
+            .iter()
+            .find(|message| message.message_id == "propagated-fanout-partial")
+            .expect("stored message");
+        assert_eq!(stored.delivery_state, "propagated");
+        assert_eq!(stored.delivery_metadata["dispatch_status"], "accepted");
+        assert_eq!(
+            stored.delivery_metadata["receipt_status"],
+            "sent: propagated resource"
+        );
+        assert_eq!(stored.delivery_metadata["partial_delivery"], true);
+        assert_eq!(
+            stored.delivery_metadata["failed_destinations"],
+            json!(["stale-destination"])
         );
 
         let _ = std::fs::remove_file(db_path);

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -3890,10 +3890,15 @@ fn relay_reticulumd_inbound_topic_message(
 ) -> Result<Option<OutboundMessageRecord>, ApiError> {
     let topic_id = envelope.topic.to_string();
     let source = envelope.source.to_string();
-    let relay_destinations = topic_subscriber_destinations(state, topic_id.as_str())?
+    let mut relay_destinations = topic_subscriber_destinations(state, topic_id.as_str())?
         .into_iter()
         .filter(|destination| destination != &source)
         .collect::<Vec<_>>();
+    let default_direct_relay =
+        relay_destinations.is_empty() && topic_id.trim().eq_ignore_ascii_case("direct");
+    if default_direct_relay {
+        relay_destinations = active_generic_lxmf_relay_destinations(state, source.as_str())?;
+    }
     if relay_destinations.is_empty() {
         return Ok(None);
     }
@@ -3906,10 +3911,12 @@ fn relay_reticulumd_inbound_topic_message(
         true,
         json!({
             "reticulumd_inbound_relay": true,
+            "reticulumd_inbound_default_direct_relay": default_direct_relay,
             "inbound_message_id": inbound_record.message_id,
-            "source": source,
+            "source": source.clone(),
             "direction": "outbound",
-            "exclude_destinations": [source],
+            "exclude_destinations": [source.clone()],
+            "target_destinations": if default_direct_relay { json!(relay_destinations.clone()) } else { Value::Null },
             "content_type": message.content_type,
             "correlation_id": message.correlation_id,
         }),
@@ -3928,6 +3935,35 @@ fn relay_reticulumd_inbound_topic_message(
         }),
     )?;
     Ok(Some(relay))
+}
+
+fn active_generic_lxmf_relay_destinations(
+    state: &AppState,
+    source: &str,
+) -> Result<Vec<String>, ApiError> {
+    let now = unix_now_ms();
+    let source = normalize_identity_key(source);
+    let mut destinations = client_records_for_state(state)?
+        .into_iter()
+        .filter(|client| {
+            client
+                .client_type
+                .trim()
+                .eq_ignore_ascii_case("generic_lxmf")
+        })
+        .filter_map(|client| {
+            let identity = normalize_identity_key(client.identity.as_str())?;
+            if source.as_deref() == Some(identity.as_str()) {
+                return None;
+            }
+            let last_seen = unix_ms_from_iso8601(client.last_seen.as_str())?;
+            (last_seen >= now - r3akt_rch_core::RECENT_RUNTIME_PRESENCE_WINDOW_MS)
+                .then_some(identity)
+        })
+        .collect::<Vec<_>>();
+    destinations.sort();
+    destinations.dedup();
+    Ok(destinations)
 }
 
 fn process_reticulumd_inbound_command(
@@ -12651,6 +12687,18 @@ fn topic_subscriber_destinations(
         .collect())
 }
 
+fn outbound_target_destinations(message: &OutboundMessageRecord) -> Option<Vec<String>> {
+    let destinations = message
+        .delivery_metadata
+        .get("target_destinations")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(Value::as_str)
+        .filter_map(normalize_identity_key)
+        .collect::<Vec<_>>();
+    Some(destinations)
+}
+
 fn record_outbound_message(
     state: &AppState,
     content: &str,
@@ -13946,7 +13994,11 @@ fn outbound_destinations(
     let mut seen_destinations = HashSet::new();
     let routing_context = outbound_destination_routing_context(state)?;
     if let Some(topic_id) = message.topic_id.as_deref() {
-        for destination in topic_subscriber_destinations(state, topic_id)? {
+        let topic_destinations = match outbound_target_destinations(message) {
+            Some(destinations) => destinations,
+            None => topic_subscriber_destinations(state, topic_id)?,
+        };
+        for destination in topic_destinations {
             let delivery_destination = outbound_destination_for_message_with_context(
                 message,
                 &destination,
@@ -26038,6 +26090,104 @@ mod tests {
             outbound[0]["DeliveryMetadata"]["reticulumd_inbound_relay"],
             true
         );
+        std::fs::remove_file(db_path).expect("cleanup db");
+    }
+
+    #[tokio::test]
+    async fn reticulumd_inbound_direct_topic_relays_to_active_generic_lxmf_clients() {
+        let envelope = r3akt_protocol::ProtocolEnvelope::new(
+            r3akt_protocol::NodeId::new("peer-alpha"),
+            r3akt_protocol::Destination::Topic(r3akt_protocol::Topic::new("direct")),
+            r3akt_protocol::Topic::new("direct"),
+            r3akt_protocol::Payload::TopicMessage(r3akt_protocol::TopicMessage {
+                body: "phone to phone".to_string(),
+                content_type: "text/plain".to_string(),
+                correlation_id: Some("direct-relay-corr-1".to_string()),
+                attachments: Vec::new(),
+            }),
+        );
+        let payload_b64 = BASE64_STANDARD.encode(envelope.encode_msgpack().expect("msgpack"));
+        let (endpoint, rpc_server) = fake_reticulumd_rpc_server_with_results(vec![
+            json!({
+                "messages": [{
+                    "id": "lxmf-inbound-direct-relay-1",
+                    "destination": "local-destination",
+                    "fields": {
+                        "r3akt_payload_b64": payload_b64
+                    }
+                }]
+            }),
+            json!({
+                "message_id": "direct-relay-accepted"
+            }),
+        ]);
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-reticulumd-inbound-direct-relay-{}.db",
+            Uuid::new_v4()
+        ));
+        let state = crate::AppState::from_sqlite_path(&db_path)
+            .expect("state")
+            .with_reticulumd_rpc(endpoint.clone(), "local-destination");
+        let now = crate::unix_now_ms();
+        {
+            let mut clients = state.clients.write().expect("clients");
+            clients.insert(
+                "peer-bravo".to_string(),
+                crate::ClientRecord::new("peer-bravo".to_string(), now),
+            );
+            clients.insert(
+                "peer-stale".to_string(),
+                crate::ClientRecord::new(
+                    "peer-stale".to_string(),
+                    now - r3akt_rch_core::RECENT_RUNTIME_PRESENCE_WINDOW_MS - 1_000,
+                ),
+            );
+        }
+        let adapter = ReticulumdRpcLxmfRsAdapter::new(
+            "local-destination",
+            ReticulumdRpcTransport::new(endpoint),
+        );
+        let mut transport = LxmfRsTransport::new(adapter);
+
+        let received = crate::process_reticulumd_inbound_worker_tick(
+            &state,
+            &mut transport,
+            Duration::from_millis(50),
+        )
+        .await
+        .expect("inbound tick")
+        .expect("envelope");
+
+        assert_eq!(received.source.to_string(), "peer-alpha");
+        let requests = rpc_server.join().expect("rpc server");
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].method, "list_messages");
+        assert_eq!(requests[1].method, "sdk_send_v2");
+        let params = requests[1].params.as_ref().expect("relay params");
+        assert_eq!(params["destination"], "peer-bravo");
+        assert_eq!(params["content"], "[topic:direct]\nphone to phone");
+
+        let messages = state.messages.read().expect("messages");
+        let relay = messages
+            .iter()
+            .find(|message| {
+                message
+                    .delivery_metadata
+                    .get("reticulumd_inbound_default_direct_relay")
+                    .and_then(Value::as_bool)
+                    == Some(true)
+            })
+            .expect("default direct relay");
+        assert_eq!(
+            relay.delivery_metadata["target_destinations"],
+            json!(["peer-bravo"])
+        );
+        assert_eq!(
+            relay.delivery_metadata["exclude_destinations"],
+            json!(["peer-alpha"])
+        );
+        drop(messages);
+
         std::fs::remove_file(db_path).expect("cleanup db");
     }
 

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -10647,7 +10647,21 @@ fn mark_reticulumd_status_delivery_failure(
         } else {
             let direct_fallback_destinations =
                 direct_status_failure_propagation_destinations(message, receipt_status);
-            if !direct_fallback_destinations.is_empty() {
+            if direct_fallback_destinations.is_empty() {
+                message.delivery_state = "failed".to_string();
+                merge_delivery_metadata(
+                    &mut message.delivery_metadata,
+                    json!({
+                        "acked": false,
+                        "dispatch_status": "failed",
+                        "error": receipt_status,
+                        "receipt_pending": false,
+                        "receipt_status": receipt_status,
+                        "delivery_failed_ts_ms": now_ms,
+                    }),
+                );
+                (message.clone(), false)
+            } else {
                 let delivered_destinations = delivered_reticulumd_receipt_destinations(message);
                 let attempts = outbound_attempts(message).saturating_add(1);
                 message.delivery_state = "queued".to_string();
@@ -10685,20 +10699,6 @@ fn mark_reticulumd_status_delivery_failure(
                 }
                 merge_delivery_metadata(&mut message.delivery_metadata, fallback_metadata);
                 (message.clone(), true)
-            } else {
-                message.delivery_state = "failed".to_string();
-                merge_delivery_metadata(
-                    &mut message.delivery_metadata,
-                    json!({
-                        "acked": false,
-                        "dispatch_status": "failed",
-                        "error": receipt_status,
-                        "receipt_pending": false,
-                        "receipt_status": receipt_status,
-                        "delivery_failed_ts_ms": now_ms,
-                    }),
-                );
-                (message.clone(), false)
             }
         }
     };

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -13535,6 +13535,9 @@ fn update_outbound_delivery_state(
         return Ok(());
     };
     message.delivery_state = delivery_state.to_string();
+    if delivery_state_clears_error_metadata(delivery_state) {
+        clear_success_superseded_delivery_metadata(&mut message.delivery_metadata);
+    }
     merge_delivery_metadata(&mut message.delivery_metadata, delivery_metadata);
     let message = message.clone();
     drop(messages);
@@ -13563,6 +13566,10 @@ fn clear_success_superseded_delivery_metadata(metadata: &mut Value) {
     object.remove("dispatch_timed_out_at_ts_ms");
     object.remove("error");
     object.remove("retry_reason");
+}
+
+fn delivery_state_clears_error_metadata(delivery_state: &str) -> bool {
+    matches!(delivery_state, "sent" | "delivered" | "propagated")
 }
 
 fn outbound_delivery_decision(
@@ -47305,6 +47312,80 @@ mod tests {
         assert_eq!(updated.delivery_metadata["dispatch_status"], "accepted");
         assert_eq!(updated.delivery_metadata["receipt_status"], "delivered");
         assert_eq!(updated.delivery_metadata["acked"], true);
+        assert!(updated.delivery_metadata.get("dispatch_timeout").is_none());
+        assert!(
+            updated
+                .delivery_metadata
+                .get("dispatch_timed_out_at_ts_ms")
+                .is_none()
+        );
+        assert!(updated.delivery_metadata.get("error").is_none());
+        assert!(updated.delivery_metadata.get("retry_reason").is_none());
+        drop(messages);
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn successful_dispatch_clears_stale_dispatch_timeout_metadata() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-delivery-timeout-cleared-by-dispatch-{}.db",
+            Uuid::new_v4()
+        ));
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        let destination = "target-destination";
+        state
+            .outbound_delivery_policy
+            .write()
+            .expect("policy")
+            .mark_presence(destination, crate::unix_now_ms());
+        let message = crate::record_outbound_message(
+            &state,
+            "late successful dispatch",
+            None,
+            Some(destination.to_string()),
+            vec![],
+            false,
+        )
+        .expect("record message");
+        let now_ms = crate::unix_now_ms();
+        crate::update_outbound_delivery_state(
+            &state,
+            message.message_id.as_str(),
+            "queued",
+            json!({
+                "attempts": 1,
+                "max_attempts": 2,
+                "dispatch_status": "queued",
+                "dispatch_timeout": true,
+                "dispatch_timed_out_at_ts_ms": now_ms - 1_000,
+                "error": "sqlite operation failed: database is locked",
+                "retry_reason": "send_error",
+                "retry_scheduled": true,
+            }),
+        )
+        .expect("mark stale dispatch metadata");
+
+        crate::update_outbound_delivery_state(
+            &state,
+            message.message_id.as_str(),
+            "sent",
+            json!({
+                "dispatch_status": "accepted",
+                "reticulumd_dispatch_count": 1,
+                "receipt_pending": false,
+            }),
+        )
+        .expect("mark successful dispatch");
+
+        let messages = state.messages.read().expect("messages");
+        let updated = messages
+            .iter()
+            .find(|candidate| candidate.message_id == message.message_id)
+            .expect("updated message");
+        assert_eq!(updated.delivery_state, "sent");
+        assert_eq!(updated.delivery_metadata["dispatch_status"], "accepted");
+        assert_eq!(updated.delivery_metadata["reticulumd_dispatch_count"], 1);
         assert!(updated.delivery_metadata.get("dispatch_timeout").is_none());
         assert!(
             updated

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -97,6 +97,7 @@ const OUTBOUND_RETRY_WORKER_POLL_MS: u64 = 500;
 const OUTBOUND_RETRY_BACKOFF_MS: i64 = 500;
 const OUTBOUND_RATE_LIMIT_RETRY_BACKOFF_MS: i64 = 65_000;
 const OUTBOUND_RETRY_MAX_ATTEMPTS: u64 = 2;
+const OUTBOUND_PROPAGATION_STAMP_COST: u32 = 16;
 const RETICULUMD_RECEIPT_STATUS_POLL_MS: i64 = 5_000;
 const RETICULUMD_INBOUND_WORKER_POLL_MS: u64 = 1_000;
 const RETICULUMD_LIST_MESSAGE_POLL_MS: u64 = 5_000;
@@ -13032,6 +13033,8 @@ fn dispatch_outbound_message(
                 content: outbound_lxmf_content(&dispatch_message).to_string(),
                 fields,
                 delivery_method: lxmf_sdk_delivery_method(message).map(str::to_string),
+                stamp_cost: lxmf_sdk_stamp_cost(message),
+                include_ticket: lxmf_sdk_include_ticket(message),
                 try_propagation_on_fail: lxmf_sdk_try_propagation_on_fail(message),
                 correlation_id: message_id,
             });
@@ -13092,6 +13095,8 @@ fn dispatch_outbound_message(
                 content: outbound_lxmf_content(&dispatch_message).to_string(),
                 fields,
                 delivery_method: lxmf_sdk_delivery_method(message).map(str::to_string),
+                stamp_cost: lxmf_sdk_stamp_cost(message),
+                include_ticket: lxmf_sdk_include_ticket(message),
                 try_propagation_on_fail: lxmf_sdk_try_propagation_on_fail(message),
                 correlation_id: message_id.clone(),
             },
@@ -13194,6 +13199,15 @@ fn lxmf_sdk_delivery_method(message: &OutboundMessageRecord) -> Option<&str> {
         "paper" => Some("paper"),
         _ => None,
     }
+}
+
+fn lxmf_sdk_stamp_cost(message: &OutboundMessageRecord) -> Option<u32> {
+    matches!(lxmf_sdk_delivery_method(message), Some("propagated"))
+        .then_some(OUTBOUND_PROPAGATION_STAMP_COST)
+}
+
+fn lxmf_sdk_include_ticket(message: &OutboundMessageRecord) -> Option<bool> {
+    matches!(lxmf_sdk_delivery_method(message), Some("propagated")).then_some(true)
 }
 
 fn lxmf_sdk_try_propagation_on_fail(message: &OutboundMessageRecord) -> bool {
@@ -46597,6 +46611,8 @@ mod tests {
                         "load_receiver_index": receiver_index,
                     }),
                     delivery_method: Some("direct".to_string()),
+                    stamp_cost: None,
+                    include_ticket: None,
                     try_propagation_on_fail: false,
                     correlation_id: format!("load-{run_id}-{sequence:05}"),
                 },

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -3895,14 +3895,33 @@ fn relay_reticulumd_inbound_topic_message(
         .into_iter()
         .filter(|destination| destination != &source)
         .collect::<Vec<_>>();
-    let default_direct_relay =
-        relay_destinations.is_empty() && topic_id.trim().eq_ignore_ascii_case("direct");
-    if default_direct_relay {
-        relay_destinations = active_generic_lxmf_relay_destinations(state, source.as_str())?;
+    let is_direct_topic = topic_id.trim().eq_ignore_ascii_case("direct");
+    let default_direct_relay = relay_destinations.is_empty() && is_direct_topic;
+    let mut direct_active_relay = false;
+    if is_direct_topic {
+        let active_destinations = active_generic_lxmf_relay_destinations(state, source.as_str())?;
+        if !active_destinations.is_empty() {
+            relay_destinations.retain(|destination| {
+                active_destinations
+                    .iter()
+                    .any(|active| active == destination)
+            });
+            direct_active_relay = true;
+        }
+        for destination in active_destinations {
+            if !relay_destinations
+                .iter()
+                .any(|existing| existing == &destination)
+            {
+                relay_destinations.push(destination);
+            }
+        }
     }
     if relay_destinations.is_empty() {
         return Ok(None);
     }
+    relay_destinations.sort();
+    relay_destinations.dedup();
     let relay = record_outbound_message_with_metadata(
         state,
         &format!("[topic:{topic_id}]\n{}", message.body),
@@ -3913,11 +3932,12 @@ fn relay_reticulumd_inbound_topic_message(
         json!({
             "reticulumd_inbound_relay": true,
             "reticulumd_inbound_default_direct_relay": default_direct_relay,
+            "reticulumd_inbound_direct_active_relay": direct_active_relay,
             "inbound_message_id": inbound_record.message_id,
             "source": source.clone(),
             "direction": "outbound",
             "exclude_destinations": [source.clone()],
-            "target_destinations": if default_direct_relay { json!(relay_destinations.clone()) } else { Value::Null },
+            "target_destinations": if is_direct_topic { json!(relay_destinations.clone()) } else { Value::Null },
             "content_type": message.content_type,
             "correlation_id": message.correlation_id,
         }),
@@ -26416,6 +26436,116 @@ mod tests {
             json!(["peer-alpha"])
         );
         drop(messages);
+
+        std::fs::remove_file(db_path).expect("cleanup db");
+    }
+
+    #[tokio::test]
+    async fn reticulumd_inbound_direct_topic_prunes_stale_subscribers_when_active_clients_exist() {
+        let envelope = r3akt_protocol::ProtocolEnvelope::new(
+            r3akt_protocol::NodeId::new("peer-alpha"),
+            r3akt_protocol::Destination::Topic(r3akt_protocol::Topic::new("direct")),
+            r3akt_protocol::Topic::new("direct"),
+            r3akt_protocol::Payload::TopicMessage(r3akt_protocol::TopicMessage {
+                body: "phone to active phone".to_string(),
+                content_type: "text/plain".to_string(),
+                correlation_id: Some("direct-relay-active-1".to_string()),
+                attachments: Vec::new(),
+            }),
+        );
+        let payload_b64 = BASE64_STANDARD.encode(envelope.encode_msgpack().expect("msgpack"));
+        let (endpoint, rpc_server) = fake_reticulumd_rpc_server_with_results(vec![
+            json!({
+                "messages": [{
+                    "id": "lxmf-inbound-direct-active-relay-1",
+                    "destination": "local-destination",
+                    "fields": {
+                        "r3akt_payload_b64": payload_b64
+                    }
+                }]
+            }),
+            json!({
+                "message_id": "direct-active-relay-accepted"
+            }),
+        ]);
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-reticulumd-inbound-direct-active-relay-{}.db",
+            Uuid::new_v4()
+        ));
+        let mut store = RchSqliteStore::open(&db_path).expect("sqlite");
+        let now = crate::unix_now_ms();
+        let mut snapshot = r3akt_rch_core::RchCore::new().snapshot();
+        snapshot.subscribers = vec![r3akt_rch_core::SubscriberRecord {
+            node_id: "peer-stale".to_string(),
+            topic_id: "direct".to_string(),
+            reject_tests: None,
+            metadata: json!({ "source": "old_phone_hil" }),
+            first_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 10_000,
+            last_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 10_000,
+        }];
+        snapshot.identity_announces = vec![r3akt_rch_core::IdentityAnnounceRecord {
+            destination_hash: "peer-stale".to_string(),
+            announced_identity_hash: None,
+            display_name: Some("stale phone".to_string()),
+            source_interface: Some("reticulumd".to_string()),
+            announce_capabilities: Vec::new(),
+            client_type: "generic_lxmf".to_string(),
+            first_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 10_000,
+            last_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 10_000,
+        }];
+        store.save_snapshot(&snapshot).expect("save snapshot");
+        drop(store);
+
+        let state = crate::AppState::from_sqlite_path(&db_path)
+            .expect("state")
+            .with_reticulumd_rpc(endpoint.clone(), "local-destination");
+        state.clients.write().expect("clients").insert(
+            "peer-bravo".to_string(),
+            crate::ClientRecord::new("peer-bravo".to_string(), now),
+        );
+        let adapter = ReticulumdRpcLxmfRsAdapter::new(
+            "local-destination",
+            ReticulumdRpcTransport::new(endpoint),
+        );
+        let mut transport = LxmfRsTransport::new(adapter);
+
+        let received = crate::process_reticulumd_inbound_worker_tick(
+            &state,
+            &mut transport,
+            Duration::from_millis(50),
+        )
+        .await
+        .expect("inbound tick")
+        .expect("envelope");
+
+        assert_eq!(received.source.to_string(), "peer-alpha");
+        let requests = rpc_server.join().expect("rpc server");
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].method, "list_messages");
+        assert_eq!(requests[1].method, "send_message_v2");
+        let params = requests[1].params.as_ref().expect("relay params");
+        assert_eq!(params["destination"], "peer-bravo");
+        assert_ne!(params["destination"], "peer-stale");
+
+        let messages = state.messages.read().expect("messages");
+        let relay = messages
+            .iter()
+            .find(|message| {
+                message
+                    .delivery_metadata
+                    .get("reticulumd_inbound_direct_active_relay")
+                    .and_then(Value::as_bool)
+                    == Some(true)
+            })
+            .expect("active direct relay");
+        assert_eq!(
+            relay.delivery_metadata["target_destinations"],
+            json!(["peer-bravo"])
+        );
+        assert_eq!(
+            relay.delivery_metadata["reticulumd_inbound_default_direct_relay"],
+            false
+        );
 
         std::fs::remove_file(db_path).expect("cleanup db");
     }

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -3904,16 +3904,16 @@ fn relay_reticulumd_inbound_topic_message(
             source.as_str(),
             &relay_destinations,
         )?;
-        if !active_subscribers.is_empty() {
-            relay_destinations = active_subscribers;
-            direct_active_relay = true;
-        } else {
+        if active_subscribers.is_empty() {
             let active_destinations =
                 active_generic_lxmf_relay_destinations(state, source.as_str())?;
             if !active_destinations.is_empty() {
                 relay_destinations = active_destinations;
                 direct_active_relay = true;
             }
+        } else {
+            relay_destinations = active_subscribers;
+            direct_active_relay = true;
         }
     }
     if relay_destinations.is_empty() {
@@ -13829,6 +13829,20 @@ fn outbound_delivery_decision(
     let now = unix_now_ms();
     let announce_last_seen =
         destination.and_then(|identity| announce_last_seen_ts_ms(state, identity));
+    let has_live_connection =
+        destination.is_some_and(|identity| has_live_client(state, identity, now));
+    if delivery_mode == DeliveryMode::Targeted
+        && has_live_connection
+        && destination
+            .map(|identity| outbound_destination_lacks_fresh_announce_for_any(state, &[identity]))
+            .transpose()?
+            .unwrap_or(false)
+    {
+        return Ok(r3akt_rch_core::OutboundDeliveryDecision {
+            method: "propagated".to_string(),
+            reason: "no_fresh_presence".to_string(),
+        });
+    }
     if delivery_mode == DeliveryMode::Targeted
         && destination
             .map(|identity| outbound_destination_has_stale_known_announce(state, identity))
@@ -13850,8 +13864,6 @@ fn outbound_delivery_decision(
             reason: "direct_cooldown".to_string(),
         });
     }
-    let has_live_connection =
-        destination.is_some_and(|identity| has_live_client(state, identity, now));
     let mut policy = state
         .outbound_delivery_policy
         .write()
@@ -13894,7 +13906,7 @@ fn outbound_route_has_unannounced_destinations(
             &routing_context,
             false,
         );
-        outbound_destination_has_stale_known_announce_for_any(
+        outbound_destination_lacks_fresh_announce_for_any(
             state,
             &[destination.as_str(), delivery_destination.as_str()],
         )
@@ -13928,6 +13940,19 @@ fn outbound_destination_has_stale_known_announce_for_any(
     Ok(destinations.iter().any(|destination| {
         outbound_destination_has_known_announce(state, destination).unwrap_or(false)
     }) && !outbound_destination_has_fresh_announce_for_any(state, destinations)?)
+}
+
+fn outbound_destination_lacks_fresh_announce_for_any(
+    state: &AppState,
+    destinations: &[&str],
+) -> Result<bool, ApiError> {
+    if state.sqlite_path.is_none() {
+        return Ok(false);
+    }
+    Ok(!outbound_destination_has_fresh_announce_for_any(
+        state,
+        destinations,
+    )?)
 }
 
 fn outbound_destination_has_fresh_announce_for_any(
@@ -26312,6 +26337,33 @@ mod tests {
                 .expect("subscriber response");
             assert_eq!(subscriber.status(), StatusCode::OK);
         }
+        let now = crate::unix_now_ms();
+        crate::persist_identity_announce_records(
+            &state,
+            &[
+                r3akt_rch_core::IdentityAnnounceRecord {
+                    destination_hash: "peer-alpha".to_string(),
+                    announced_identity_hash: None,
+                    display_name: Some("peer alpha".to_string()),
+                    source_interface: Some("reticulumd".to_string()),
+                    announce_capabilities: Vec::new(),
+                    client_type: "generic_lxmf".to_string(),
+                    first_seen_ts_ms: now,
+                    last_seen_ts_ms: now,
+                },
+                r3akt_rch_core::IdentityAnnounceRecord {
+                    destination_hash: "peer-charlie".to_string(),
+                    announced_identity_hash: None,
+                    display_name: Some("peer charlie".to_string()),
+                    source_interface: Some("reticulumd".to_string()),
+                    announce_capabilities: Vec::new(),
+                    client_type: "generic_lxmf".to_string(),
+                    first_seen_ts_ms: now,
+                    last_seen_ts_ms: now,
+                },
+            ],
+        )
+        .expect("persist fresh relay announce");
         let adapter = ReticulumdRpcLxmfRsAdapter::new(
             "local-destination",
             ReticulumdRpcTransport::new(endpoint),
@@ -27237,6 +27289,21 @@ mod tests {
                 .expect("setup response");
             assert_eq!(response.status(), StatusCode::OK, "{uri}");
         }
+        let now = crate::unix_now_ms();
+        crate::persist_identity_announce_records(
+            &state,
+            &[r3akt_rch_core::IdentityAnnounceRecord {
+                destination_hash: "peer-mission-source".to_string(),
+                announced_identity_hash: None,
+                display_name: Some("mission source".to_string()),
+                source_interface: Some("reticulumd".to_string()),
+                announce_capabilities: Vec::new(),
+                client_type: "generic_lxmf".to_string(),
+                first_seen_ts_ms: now,
+                last_seen_ts_ms: now,
+            }],
+        )
+        .expect("persist fresh mission source announce");
 
         let adapter = ReticulumdRpcLxmfRsAdapter::new(
             "local-destination",
@@ -50915,6 +50982,33 @@ mod tests {
     }
 
     #[test]
+    fn targeted_delivery_uses_propagation_for_live_client_without_announce() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-unannounced-live-target-propagation-{}.db",
+            Uuid::new_v4()
+        ));
+        let destination = "4f79a98e20b9b8d58d412dbeef60f98d";
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        state.clients.write().expect("clients").insert(
+            destination.to_string(),
+            crate::ClientRecord::new(destination.to_string(), crate::unix_now_ms()),
+        );
+
+        let decision = crate::outbound_delivery_decision(
+            &state,
+            r3akt_rch_core::DeliveryMode::Targeted,
+            None,
+            Some(destination),
+        )
+        .expect("delivery decision");
+
+        assert_eq!(decision.method, "propagated");
+        assert_eq!(decision.reason, "no_fresh_presence");
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
     fn topic_delivery_uses_propagation_when_subscriber_is_not_freshly_announced() {
         let db_path = std::env::temp_dir().join(format!(
             "r3akt-rch-topic-stale-subscriber-propagation-{}.db",
@@ -50941,6 +51035,39 @@ mod tests {
             "stale-s8".to_string(),
             crate::SubscriberRecord {
                 subscriber_id: "stale-s8".to_string(),
+                destination: destination.to_string(),
+                topic_id: "direct".to_string(),
+                reject_tests: None,
+                metadata: json!({}),
+            },
+        );
+
+        let decision = crate::outbound_delivery_decision(
+            &state,
+            r3akt_rch_core::DeliveryMode::Fanout,
+            Some("direct"),
+            None,
+        )
+        .expect("topic decision");
+
+        assert_eq!(decision.method, "propagated");
+        assert_eq!(decision.reason, "topic_unannounced");
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn topic_delivery_uses_propagation_when_subscriber_has_no_announce() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-topic-unannounced-subscriber-propagation-{}.db",
+            Uuid::new_v4()
+        ));
+        let destination = "13b9e446f104d2a38f7e793a94cb1b1d";
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        state.subscribers.write().expect("subscribers").insert(
+            "unannounced-pixel".to_string(),
+            crate::SubscriberRecord {
+                subscriber_id: "unannounced-pixel".to_string(),
                 destination: destination.to_string(),
                 topic_id: "direct".to_string(),
                 reject_tests: None,

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -11191,14 +11191,6 @@ fn reticulumd_status_poll_candidate(message: &OutboundMessageRecord) -> bool {
     ) {
         return false;
     }
-    if message
-        .delivery_metadata
-        .get("delivery_receipt_required")
-        .and_then(Value::as_bool)
-        == Some(false)
-    {
-        return false;
-    }
     if delivery_receipt_pending(message) {
         return true;
     }
@@ -45090,6 +45082,114 @@ mod tests {
             snapshot.messages[0].delivery_metadata["receipt_timeout"],
             false
         );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn status_poll_reconciles_fanout_targets_without_required_receipt() {
+        let (endpoint, rpc_server) = fake_reticulumd_rpc_server_with_results(vec![
+            json!({
+                "message": {
+                    "message_id": "sdk-target-a",
+                    "state": "delivered",
+                    "terminal": true,
+                    "last_updated_ms": 1_700_000_000_001_u64,
+                    "attempts": 0,
+                    "reason_code": null,
+                    "receipt_status": "delivered"
+                }
+            }),
+            json!({
+                "message": {
+                    "message_id": "sdk-target-b",
+                    "state": "delivered",
+                    "terminal": true,
+                    "last_updated_ms": 1_700_000_000_002_u64,
+                    "attempts": 0,
+                    "reason_code": null,
+                    "receipt_status": "delivered"
+                }
+            }),
+        ]);
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-fanout-status-no-required-receipt-{}.db",
+            Uuid::new_v4()
+        ));
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        let message = crate::record_outbound_message(
+            &state,
+            "fanout status poll",
+            Some("direct".to_string()),
+            None,
+            vec![],
+            true,
+        )
+        .expect("record message");
+        crate::update_outbound_delivery_state(
+            &state,
+            message.message_id.as_str(),
+            "sent",
+            json!({
+                "dispatch_status": "accepted",
+                "delivery_receipt_required": false,
+                "reticulumd_dispatch_count": 2,
+                "reticulumd_receipt_targets": [
+                    {
+                        "message_id": "sdk-target-a",
+                        "destination": "destination-a",
+                        "status": "pending"
+                    },
+                    {
+                        "message_id": "sdk-target-b",
+                        "destination": "destination-b",
+                        "status": "pending"
+                    }
+                ],
+                "receipt_pending": false,
+            }),
+        )
+        .expect("mark fanout pending statuses");
+        let state = state.with_reticulumd_rpc(endpoint, "source-destination");
+
+        crate::poll_reticulumd_delivery_receipts(&state).expect("poll statuses");
+
+        let requests = rpc_server.join().expect("rpc server");
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].method, "sdk_status_v2");
+        assert_eq!(
+            requests[0].params.as_ref().expect("params")["message_id"],
+            "sdk-target-a"
+        );
+        assert_eq!(requests[1].method, "sdk_status_v2");
+        assert_eq!(
+            requests[1].params.as_ref().expect("params")["message_id"],
+            "sdk-target-b"
+        );
+
+        let snapshot = RchSqliteStore::open(&db_path)
+            .expect("open sqlite")
+            .load_snapshot()
+            .expect("load snapshot")
+            .expect("snapshot");
+        assert_eq!(snapshot.messages[0].delivery_state, "delivered");
+        assert_eq!(snapshot.messages[0].delivery_metadata["acked"], true);
+        assert_eq!(
+            snapshot.messages[0].delivery_metadata["receipt_pending"],
+            false
+        );
+        assert_eq!(
+            snapshot.messages[0].delivery_metadata["receipt_status"],
+            "delivered"
+        );
+        let targets = snapshot.messages[0].delivery_metadata["reticulumd_receipt_targets"]
+            .as_array()
+            .expect("targets");
+        assert_eq!(targets.len(), 2);
+        assert!(targets.iter().all(|target| target["status"] == "delivered"));
+        assert!(targets
+            .iter()
+            .all(|target| target["sdk_delivery_state"] == "delivered"));
 
         let _ = std::fs::remove_file(db_path);
     }

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -12877,8 +12877,11 @@ fn topic_subscriber_destinations(
 }
 
 fn outbound_target_destinations(message: &OutboundMessageRecord) -> Option<Vec<String>> {
-    let destinations = message
-        .delivery_metadata
+    outbound_target_destinations_from_metadata(&message.delivery_metadata)
+}
+
+fn outbound_target_destinations_from_metadata(delivery_metadata: &Value) -> Option<Vec<String>> {
+    let destinations = delivery_metadata
         .get("target_destinations")
         .and_then(Value::as_array)?
         .iter()
@@ -12967,11 +12970,13 @@ fn record_outbound_message_with_metadata_mode(
 ) -> Result<OutboundMessageRecord, ApiError> {
     let delivery_mode = classify_delivery_mode(topic_id.as_deref(), destination.as_deref())
         .map_err(|error| ApiError::BadRequest(python_delivery_error_detail(&error)))?;
-    let mut delivery_decision = outbound_delivery_decision(
+    let target_destinations = outbound_target_destinations_from_metadata(&delivery_metadata);
+    let mut delivery_decision = outbound_delivery_decision_for_targets(
         state,
         delivery_mode,
         topic_id.as_deref(),
         destination.as_deref(),
+        target_destinations.as_deref(),
     )?;
     let is_rem_command = delivery_metadata
         .get("fanout_channel")
@@ -13895,14 +13900,25 @@ fn delivery_state_clears_error_metadata(delivery_state: &str) -> bool {
     matches!(delivery_state, "sent" | "delivered" | "propagated")
 }
 
+#[cfg(test)]
 fn outbound_delivery_decision(
     state: &AppState,
     delivery_mode: DeliveryMode,
     topic_id: Option<&str>,
     destination: Option<&str>,
 ) -> Result<r3akt_rch_core::OutboundDeliveryDecision, ApiError> {
+    outbound_delivery_decision_for_targets(state, delivery_mode, topic_id, destination, None)
+}
+
+fn outbound_delivery_decision_for_targets(
+    state: &AppState,
+    delivery_mode: DeliveryMode,
+    topic_id: Option<&str>,
+    destination: Option<&str>,
+    target_destinations: Option<&[String]>,
+) -> Result<r3akt_rch_core::OutboundDeliveryDecision, ApiError> {
     if delivery_mode == DeliveryMode::Broadcast {
-        if outbound_route_has_unannounced_destinations(state, delivery_mode, None)? {
+        if outbound_route_has_unannounced_destinations(state, delivery_mode, None, None)? {
             return Ok(r3akt_rch_core::OutboundDeliveryDecision {
                 method: "propagated".to_string(),
                 reason: "broadcast_unannounced".to_string(),
@@ -13914,7 +13930,12 @@ fn outbound_delivery_decision(
         });
     }
     if delivery_mode == DeliveryMode::Fanout {
-        if outbound_route_has_unannounced_destinations(state, delivery_mode, topic_id)? {
+        if outbound_route_has_unannounced_destinations(
+            state,
+            delivery_mode,
+            topic_id,
+            target_destinations,
+        )? {
             return Ok(r3akt_rch_core::OutboundDeliveryDecision {
                 method: "propagated".to_string(),
                 reason: "topic_unannounced".to_string(),
@@ -14037,10 +14058,24 @@ fn outbound_route_has_unannounced_destinations(
     state: &AppState,
     delivery_mode: DeliveryMode,
     topic_id: Option<&str>,
+    target_destinations: Option<&[String]>,
 ) -> Result<bool, ApiError> {
     let destinations = match delivery_mode {
         DeliveryMode::Targeted => return Ok(false),
         DeliveryMode::Fanout => {
+            if let Some(target_destinations) = target_destinations {
+                let destinations = target_destinations
+                    .iter()
+                    .filter_map(|destination| normalize_identity_key(destination))
+                    .collect::<Vec<_>>();
+                if !destinations.is_empty() {
+                    return outbound_destinations_have_unannounced_route(
+                        state,
+                        delivery_mode,
+                        destinations,
+                    );
+                }
+            }
             let Some(topic_id) = topic_id else {
                 return Ok(false);
             };
@@ -14051,6 +14086,14 @@ fn outbound_route_has_unannounced_destinations(
             .map(|client| client.identity)
             .collect(),
     };
+    outbound_destinations_have_unannounced_route(state, delivery_mode, destinations)
+}
+
+fn outbound_destinations_have_unannounced_route(
+    state: &AppState,
+    delivery_mode: DeliveryMode,
+    destinations: Vec<String>,
+) -> Result<bool, ApiError> {
     if destinations.is_empty() || state.sqlite_path.is_none() {
         return Ok(false);
     }
@@ -26573,7 +26616,7 @@ mod tests {
         let requests = rpc_server.join().expect("rpc server");
         assert_eq!(requests.len(), 2);
         assert_eq!(requests[0].method, "list_messages");
-        assert_eq!(requests[1].method, "sdk_send_v2");
+        assert_eq!(requests[1].method, "send_message_v2");
         let params = requests[1].params.as_ref().expect("relay params");
         assert_eq!(params["source"], "local-destination");
         assert_eq!(params["destination"], "peer-charlie");
@@ -26676,7 +26719,7 @@ mod tests {
         let requests = rpc_server.join().expect("rpc server");
         assert_eq!(requests.len(), 2);
         assert_eq!(requests[0].method, "list_messages");
-        assert_eq!(requests[1].method, "sdk_send_v2");
+        assert_eq!(requests[1].method, "send_message_v2");
         let params = requests[1].params.as_ref().expect("relay params");
         assert_eq!(params["destination"], "peer-bravo");
         assert_eq!(params["content"], "[topic:direct]\nphone to phone");
@@ -26921,7 +26964,7 @@ mod tests {
 
         let requests = rpc_server.join().expect("rpc server");
         assert_eq!(requests.len(), 2);
-        assert_eq!(requests[1].method, "send_message_v2");
+        assert_eq!(requests[1].method, "sdk_send_v2");
         let params = requests[1].params.as_ref().expect("relay params");
         assert_eq!(params["destination"], fresh_subscriber);
         assert_ne!(params["destination"], stale_subscriber);
@@ -26942,6 +26985,8 @@ mod tests {
             relay.delivery_metadata["target_destinations"],
             json!([fresh_subscriber])
         );
+        assert_eq!(relay.delivery_method, "direct");
+        assert_eq!(relay.delivery_policy_reason, "topic_direct");
 
         std::fs::remove_file(db_path).expect("cleanup db");
     }

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -3943,14 +3943,11 @@ fn active_generic_lxmf_relay_destinations(
 ) -> Result<Vec<String>, ApiError> {
     let now = unix_now_ms();
     let source = normalize_identity_key(source);
-    let mut destinations = client_records_for_state(state)?
-        .into_iter()
-        .filter(|client| {
-            client
-                .client_type
-                .trim()
-                .eq_ignore_ascii_case("generic_lxmf")
-        })
+    let mut destinations = state
+        .clients
+        .read()
+        .map_err(|error| ApiError::Internal(error.to_string()))?
+        .values()
         .filter_map(|client| {
             let identity = normalize_identity_key(client.identity.as_str())?;
             if source.as_deref() == Some(identity.as_str()) {

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -12823,8 +12823,12 @@ fn record_outbound_message_with_metadata_mode(
 ) -> Result<OutboundMessageRecord, ApiError> {
     let delivery_mode = classify_delivery_mode(topic_id.as_deref(), destination.as_deref())
         .map_err(|error| ApiError::BadRequest(python_delivery_error_detail(&error)))?;
-    let mut delivery_decision =
-        outbound_delivery_decision(state, delivery_mode, destination.as_deref())?;
+    let mut delivery_decision = outbound_delivery_decision(
+        state,
+        delivery_mode,
+        topic_id.as_deref(),
+        destination.as_deref(),
+    )?;
     let is_rem_command = delivery_metadata
         .get("fanout_channel")
         .and_then(Value::as_str)
@@ -13700,15 +13704,28 @@ fn delivery_state_clears_error_metadata(delivery_state: &str) -> bool {
 fn outbound_delivery_decision(
     state: &AppState,
     delivery_mode: DeliveryMode,
+    topic_id: Option<&str>,
     destination: Option<&str>,
 ) -> Result<r3akt_rch_core::OutboundDeliveryDecision, ApiError> {
     if delivery_mode == DeliveryMode::Broadcast {
+        if outbound_route_has_unannounced_destinations(state, delivery_mode, None)? {
+            return Ok(r3akt_rch_core::OutboundDeliveryDecision {
+                method: "propagated".to_string(),
+                reason: "broadcast_unannounced".to_string(),
+            });
+        }
         return Ok(r3akt_rch_core::OutboundDeliveryDecision {
             method: "direct".to_string(),
             reason: "broadcast_direct".to_string(),
         });
     }
     if delivery_mode == DeliveryMode::Fanout {
+        if outbound_route_has_unannounced_destinations(state, delivery_mode, topic_id)? {
+            return Ok(r3akt_rch_core::OutboundDeliveryDecision {
+                method: "propagated".to_string(),
+                reason: "topic_unannounced".to_string(),
+            });
+        }
         return Ok(r3akt_rch_core::OutboundDeliveryDecision {
             method: "direct".to_string(),
             reason: "topic_direct".to_string(),
@@ -13725,6 +13742,16 @@ fn outbound_delivery_decision(
             destination.and_then(|identity| announce_last_seen_ts_ms(state, identity));
         let has_live_connection =
             destination.is_some_and(|identity| has_live_client(state, identity, now));
+        if destination
+            .map(|identity| outbound_destination_has_stale_known_announce(state, identity))
+            .transpose()?
+            .unwrap_or(false)
+        {
+            return Ok(r3akt_rch_core::OutboundDeliveryDecision {
+                method: "propagated".to_string(),
+                reason: "rem_no_fresh_presence".to_string(),
+            });
+        }
         if destination
             .and_then(|identity| latest_failed_direct_delivery_ts_ms(state, identity))
             .is_some_and(|failed_at| announce_last_seen.is_none_or(|seen_at| failed_at >= seen_at))
@@ -13761,6 +13788,17 @@ fn outbound_delivery_decision(
         destination.and_then(|identity| announce_last_seen_ts_ms(state, identity));
     if delivery_mode == DeliveryMode::Targeted
         && destination
+            .map(|identity| outbound_destination_has_stale_known_announce(state, identity))
+            .transpose()?
+            .unwrap_or(false)
+    {
+        return Ok(r3akt_rch_core::OutboundDeliveryDecision {
+            method: "propagated".to_string(),
+            reason: "no_fresh_presence".to_string(),
+        });
+    }
+    if delivery_mode == DeliveryMode::Targeted
+        && destination
             .and_then(|identity| latest_failed_direct_delivery_ts_ms(state, identity))
             .is_some_and(|failed_at| announce_last_seen.is_none_or(|seen_at| failed_at >= seen_at))
     {
@@ -13782,6 +13820,106 @@ fn outbound_delivery_decision(
         has_live_connection,
         now,
     ))
+}
+
+fn outbound_route_has_unannounced_destinations(
+    state: &AppState,
+    delivery_mode: DeliveryMode,
+    topic_id: Option<&str>,
+) -> Result<bool, ApiError> {
+    let destinations = match delivery_mode {
+        DeliveryMode::Targeted => return Ok(false),
+        DeliveryMode::Fanout => {
+            let Some(topic_id) = topic_id else {
+                return Ok(false);
+            };
+            topic_subscriber_destinations(state, topic_id)?
+        }
+        DeliveryMode::Broadcast => broadcast_client_records_for_state(state)?
+            .into_iter()
+            .map(|client| client.identity)
+            .collect(),
+    };
+    if destinations.is_empty() || state.sqlite_path.is_none() {
+        return Ok(false);
+    }
+    let routing_context = outbound_destination_routing_context(state)?;
+    Ok(destinations.into_iter().any(|destination| {
+        let delivery_destination = outbound_destination_for_message_with_context_for_mode(
+            delivery_mode,
+            &destination,
+            &routing_context,
+            false,
+        );
+        outbound_destination_has_stale_known_announce_for_any(
+            state,
+            &[destination.as_str(), delivery_destination.as_str()],
+        )
+        .unwrap_or(false)
+    }))
+}
+
+fn outbound_destination_has_known_announce(
+    state: &AppState,
+    destination: &str,
+) -> Result<bool, ApiError> {
+    let Some(destination) = normalize_identity_key(destination) else {
+        return Ok(false);
+    };
+    Ok(load_identity_announces_for_state(state)?
+        .into_iter()
+        .any(|record| identity_announce_matches_destination(&record, destination.as_str())))
+}
+
+fn outbound_destination_has_stale_known_announce(
+    state: &AppState,
+    destination: &str,
+) -> Result<bool, ApiError> {
+    outbound_destination_has_stale_known_announce_for_any(state, &[destination])
+}
+
+fn outbound_destination_has_stale_known_announce_for_any(
+    state: &AppState,
+    destinations: &[&str],
+) -> Result<bool, ApiError> {
+    Ok(destinations.iter().any(|destination| {
+        outbound_destination_has_known_announce(state, destination).unwrap_or(false)
+    }) && !outbound_destination_has_fresh_announce_for_any(state, destinations)?)
+}
+
+fn outbound_destination_has_fresh_announce_for_any(
+    state: &AppState,
+    destinations: &[&str],
+) -> Result<bool, ApiError> {
+    let now = unix_now_ms();
+    let normalized = destinations
+        .iter()
+        .filter_map(|destination| normalize_identity_key(destination))
+        .collect::<HashSet<_>>();
+    if normalized.is_empty() {
+        return Ok(false);
+    }
+    Ok(load_identity_announces_for_state(state)?
+        .into_iter()
+        .any(|record| {
+            record.last_seen_ts_ms >= now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS
+                && normalized
+                    .iter()
+                    .any(|destination| identity_announce_matches_destination(&record, destination))
+        }))
+}
+
+fn identity_announce_matches_destination(
+    record: &r3akt_rch_core::IdentityAnnounceRecord,
+    destination: &str,
+) -> bool {
+    normalize_identity_key(&record.destination_hash).as_deref() == Some(destination)
+        || record
+            .announced_identity_hash
+            .as_deref()
+            .and_then(normalize_identity_key)
+            .as_deref()
+            == Some(destination)
 }
 
 fn mark_direct_delivery_failure(state: &AppState, identity: &str) -> Result<(), ApiError> {
@@ -14240,12 +14378,26 @@ fn outbound_destination_for_message_with_context(
     destination: &str,
     routing_context: &OutboundDestinationRoutingContext,
 ) -> String {
+    outbound_destination_for_message_with_context_for_mode(
+        message.delivery_mode,
+        destination,
+        routing_context,
+        preserves_requested_outbound_destination(message),
+    )
+}
+
+fn outbound_destination_for_message_with_context_for_mode(
+    delivery_mode: DeliveryMode,
+    destination: &str,
+    routing_context: &OutboundDestinationRoutingContext,
+    preserve_requested_destination: bool,
+) -> String {
     let normalized =
         normalize_identity_key(destination).unwrap_or_else(|| destination.trim().to_string());
-    if preserves_requested_outbound_destination(message) {
+    if preserve_requested_destination {
         return normalized;
     }
-    if message.delivery_mode == DeliveryMode::Broadcast
+    if delivery_mode == DeliveryMode::Broadcast
         && routing_context
             .rem_app_destinations
             .contains(normalized.as_str())
@@ -50416,12 +50568,14 @@ mod tests {
         let app_destination = crate::outbound_delivery_decision(
             &state,
             r3akt_rch_core::DeliveryMode::Targeted,
+            None,
             Some("4bede2a6ecab26f234aac9bb894a441a"),
         )
         .expect("app destination decision");
         let delivery_destination = crate::outbound_delivery_decision(
             &state,
             r3akt_rch_core::DeliveryMode::Targeted,
+            None,
             Some("1123c2623132bf9899ae5d3b28d9f79e"),
         )
         .expect("delivery destination decision");
@@ -50430,6 +50584,96 @@ mod tests {
         assert_eq!(app_destination.reason, "rem_direct");
         assert_eq!(delivery_destination.method, "direct");
         assert_eq!(delivery_destination.reason, "fresh_presence");
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn targeted_delivery_uses_propagation_for_stale_known_lxmf_announce() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-stale-known-target-propagation-{}.db",
+            Uuid::new_v4()
+        ));
+        let mut store = r3akt_rch_core::RchSqliteStore::open(&db_path).expect("sqlite");
+        let mut snapshot = r3akt_rch_core::RchCore::new().snapshot();
+        let now = crate::unix_now_ms();
+        let destination = "52118fa6f1240342cb730dabdf1d4ca1";
+        snapshot.identity_announces = vec![r3akt_rch_core::IdentityAnnounceRecord {
+            destination_hash: destination.to_string(),
+            announced_identity_hash: None,
+            display_name: Some("Pixel Sideband".to_string()),
+            source_interface: Some("reticulumd".to_string()),
+            announce_capabilities: Vec::new(),
+            client_type: "generic_lxmf".to_string(),
+            first_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 10_000,
+            last_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 1_000,
+        }];
+        store.save_snapshot(&snapshot).expect("save snapshot");
+
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        state.clients.write().expect("clients").insert(
+            destination.to_string(),
+            crate::ClientRecord::new(destination.to_string(), now),
+        );
+
+        let decision = crate::outbound_delivery_decision(
+            &state,
+            r3akt_rch_core::DeliveryMode::Targeted,
+            None,
+            Some(destination),
+        )
+        .expect("delivery decision");
+
+        assert_eq!(decision.method, "propagated");
+        assert_eq!(decision.reason, "no_fresh_presence");
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn topic_delivery_uses_propagation_when_subscriber_is_not_freshly_announced() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-topic-stale-subscriber-propagation-{}.db",
+            Uuid::new_v4()
+        ));
+        let mut store = r3akt_rch_core::RchSqliteStore::open(&db_path).expect("sqlite");
+        let mut snapshot = r3akt_rch_core::RchCore::new().snapshot();
+        let now = crate::unix_now_ms();
+        let destination = "7f08e12b3f25f23e62f3a15288303c95";
+        snapshot.identity_announces = vec![r3akt_rch_core::IdentityAnnounceRecord {
+            destination_hash: destination.to_string(),
+            announced_identity_hash: None,
+            display_name: Some("S8 stale Sideband".to_string()),
+            source_interface: Some("reticulumd".to_string()),
+            announce_capabilities: Vec::new(),
+            client_type: "generic_lxmf".to_string(),
+            first_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 10_000,
+            last_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 1_000,
+        }];
+        store.save_snapshot(&snapshot).expect("save snapshot");
+
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        state.subscribers.write().expect("subscribers").insert(
+            "stale-s8".to_string(),
+            crate::SubscriberRecord {
+                subscriber_id: "stale-s8".to_string(),
+                destination: destination.to_string(),
+                topic_id: "direct".to_string(),
+                reject_tests: None,
+                metadata: json!({}),
+            },
+        );
+
+        let decision = crate::outbound_delivery_decision(
+            &state,
+            r3akt_rch_core::DeliveryMode::Fanout,
+            Some("direct"),
+            None,
+        )
+        .expect("topic decision");
+
+        assert_eq!(decision.method, "propagated");
+        assert_eq!(decision.reason, "topic_unannounced");
 
         let _ = std::fs::remove_file(db_path);
     }
@@ -50464,6 +50708,7 @@ mod tests {
         let fresh = crate::outbound_delivery_decision(
             &state,
             r3akt_rch_core::DeliveryMode::Targeted,
+            None,
             Some(rem_destination),
         )
         .expect("fresh rem decision");
@@ -50474,6 +50719,7 @@ mod tests {
         let cooldown = crate::outbound_delivery_decision(
             &state,
             r3akt_rch_core::DeliveryMode::Targeted,
+            None,
             Some(rem_destination),
         )
         .expect("cooldown rem decision");
@@ -50530,6 +50776,7 @@ mod tests {
         let decision = crate::outbound_delivery_decision(
             &state,
             r3akt_rch_core::DeliveryMode::Targeted,
+            None,
             Some(rem_destination),
         )
         .expect("rem decision");
@@ -50586,6 +50833,7 @@ mod tests {
         let decision = crate::outbound_delivery_decision(
             &state,
             r3akt_rch_core::DeliveryMode::Targeted,
+            None,
             Some(rem_destination),
         )
         .expect("rem decision");
@@ -50643,6 +50891,7 @@ mod tests {
         let decision = crate::outbound_delivery_decision(
             &state,
             r3akt_rch_core::DeliveryMode::Targeted,
+            None,
             Some(rem_destination),
         )
         .expect("rem decision");
@@ -50695,6 +50944,7 @@ mod tests {
         let decision = crate::outbound_delivery_decision(
             &state,
             r3akt_rch_core::DeliveryMode::Targeted,
+            None,
             Some(generic_destination),
         )
         .expect("generic decision");
@@ -50769,6 +51019,7 @@ mod tests {
         let decision = crate::outbound_delivery_decision(
             &state,
             r3akt_rch_core::DeliveryMode::Targeted,
+            None,
             Some(generic_destination),
         )
         .expect("generic decision");
@@ -50843,6 +51094,7 @@ mod tests {
         let decision = crate::outbound_delivery_decision(
             &state,
             r3akt_rch_core::DeliveryMode::Targeted,
+            None,
             Some(generic_destination),
         )
         .expect("generic decision");

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -10837,7 +10837,9 @@ fn direct_status_failure_propagation_destinations(
     message: &OutboundMessageRecord,
     receipt_status: &str,
 ) -> Vec<String> {
-    if message.delivery_method != "direct" || message.destination.is_none() {
+    if !matches!(message.delivery_method.as_str(), "auto" | "direct")
+        || message.destination.is_none()
+    {
         if message.delivery_method != "direct"
             || message.delivery_mode != DeliveryMode::Fanout
             || is_rem_command_message(message)
@@ -51652,6 +51654,71 @@ mod tests {
         .expect("generic decision");
         assert_eq!(decision.method, "propagated");
         assert_eq!(decision.reason, "direct_cooldown");
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn reticulumd_auto_direct_status_failure_queues_generic_propagation_fallback() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-generic-auto-status-direct-cooldown-{}.db",
+            Uuid::new_v4()
+        ));
+        let mut store = r3akt_rch_core::RchSqliteStore::open(&db_path).expect("sqlite");
+        let mut snapshot = r3akt_rch_core::RchCore::new().snapshot();
+        let now = crate::unix_now_ms();
+        let generic_destination = "fb4c70e20cfac047b899ca2f3671b50a";
+        snapshot.identity_announces = vec![r3akt_rch_core::IdentityAnnounceRecord {
+            destination_hash: generic_destination.to_string(),
+            announced_identity_hash: None,
+            display_name: Some("Pixel".to_string()),
+            source_interface: Some("reticulumd".to_string()),
+            announce_capabilities: vec!["pixel".to_string()],
+            client_type: "generic_lxmf".to_string(),
+            first_seen_ts_ms: now - 60_000,
+            last_seen_ts_ms: now,
+        }];
+        snapshot.messages = vec![r3akt_rch_core::MessageRecord {
+            message_id: "pending-generic-auto-direct".to_string(),
+            topic_id: None,
+            destination: Some(generic_destination.to_string()),
+            sender: "northbound".to_string(),
+            content: "pending generic auto direct".to_string(),
+            delivery_mode: r3akt_rch_core::DeliveryMode::Targeted,
+            delivery_method: "auto".to_string(),
+            delivery_policy_reason: "fresh_presence".to_string(),
+            delivery_state: "queued".to_string(),
+            delivery_metadata: json!({
+                "dispatch_status": "accepted",
+                "receipt_pending": true,
+            }),
+            created_ts_ms: now,
+            attachments: Vec::new(),
+        }];
+        store.save_snapshot(&snapshot).expect("save snapshot");
+
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        crate::mark_reticulumd_status_delivery_failure(
+            &state,
+            "pending-generic-auto-direct",
+            "failed: link activation timed out",
+        )
+        .expect("mark failure");
+
+        let messages = state.messages.read().expect("messages");
+        let stored = messages
+            .iter()
+            .find(|message| message.message_id == "pending-generic-auto-direct")
+            .expect("stored message");
+        assert_eq!(stored.delivery_state, "queued");
+        assert_eq!(stored.delivery_method, "propagated");
+        assert_eq!(stored.delivery_policy_reason, "direct_failure_fallback");
+        assert_eq!(
+            stored.delivery_metadata["fallback_reason"],
+            "direct_status_failure"
+        );
+        assert_eq!(stored.delivery_metadata["retry_scheduled"], true);
+        drop(messages);
 
         let _ = std::fs::remove_file(db_path);
     }

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -75,9 +75,9 @@ use r3akt_transport_rns::{
     LxmfDeliverySnapshot, LxmfDeliveryState, LxmfSdkOutboundBatch, LxmfSdkOutboundBatchMessage,
     LxmfSdkOutboundMessage, ReticulumdAnnounceRecord, announce_lxmf_zmq_identity,
     delivery_snapshot_from_status_result, delivery_snapshot_receipt_status,
-    list_reticulumd_announces, poll_lxmf_zmq_events, poll_reticulumd_events,
-    reticulumd_event_to_envelope, reticulumd_message_to_envelope, send_lxmf_zmq_outbound_batch,
-    send_lxmf_zmq_outbound_message,
+    enqueue_lxmf_zmq_outbound_batch, list_reticulumd_announces, poll_lxmf_zmq_events,
+    poll_reticulumd_events, reticulumd_event_to_envelope, reticulumd_message_to_envelope,
+    send_lxmf_zmq_outbound_batch, send_lxmf_zmq_outbound_message,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -12880,6 +12880,17 @@ fn record_outbound_message_with_metadata_mode(
         .get("fanout_channel")
         .and_then(Value::as_str)
         .is_some_and(is_rem_command_channel);
+    if is_rem_command
+        && delivery_decision.method != "propagated"
+        && destination
+            .as_deref()
+            .map(|identity| rem_command_destination_should_propagate(state, identity))
+            .transpose()?
+            .unwrap_or(false)
+    {
+        delivery_decision.method = "propagated".to_string();
+        delivery_decision.reason = "no_fresh_presence".to_string();
+    }
     let effective_dispatch_mode = if is_rem_command {
         OutboundDispatchMode::Deferred
     } else {
@@ -13099,16 +13110,20 @@ fn dispatch_outbound_message(
                 correlation_id: message_id,
             });
         }
-        let results = send_lxmf_zmq_outbound_batch(
-            command_endpoint,
-            response_endpoint,
-            LxmfSdkOutboundBatch {
-                batch_id,
-                source: source.to_string(),
-                messages: batch_messages,
-            },
-        )
-        .map_err(|error| {
+        let batch = LxmfSdkOutboundBatch {
+            batch_id,
+            source: source.to_string(),
+            messages: batch_messages,
+        };
+        let batch_result = if should_enqueue_fanout_without_waiting_for_zmq_response(
+            message,
+            fanout_destination_count,
+        ) {
+            enqueue_lxmf_zmq_outbound_batch(command_endpoint, response_endpoint, batch)
+        } else {
+            send_lxmf_zmq_outbound_batch(command_endpoint, response_endpoint, batch)
+        };
+        let results = batch_result.map_err(|error| {
             let error = error.to_string();
             if message.delivery_method == "direct"
                 && direct_failure_error_should_trigger_cooldown(error.as_str())
@@ -13182,6 +13197,13 @@ fn dispatch_outbound_message(
         });
     }
     Ok(report)
+}
+
+fn should_enqueue_fanout_without_waiting_for_zmq_response(
+    message: &OutboundMessageRecord,
+    fanout_destination_count: usize,
+) -> bool {
+    fanout_destination_count > 1 && message.delivery_method == "propagated"
 }
 
 #[cfg(test)]
@@ -13472,7 +13494,7 @@ fn schedule_outbound_retry_after_failure(
     message: &OutboundMessageRecord,
     error_text: String,
 ) -> Result<Option<OutboundMessageRecord>, ApiError> {
-    if message.delivery_method == "propagated" {
+    if message.delivery_method == "propagated" && !is_rem_command_message(message) {
         return Ok(None);
     }
     let attempts = outbound_attempts(message).saturating_add(1);
@@ -13789,10 +13811,15 @@ fn outbound_delivery_decision(
             destination.and_then(|identity| announce_last_seen_ts_ms(state, identity));
         let has_live_connection =
             destination.is_some_and(|identity| has_live_client(state, identity, now));
-        if destination
-            .map(|identity| outbound_destination_has_stale_known_announce(state, identity))
+        let freshness_destinations = destination
+            .map(|identity| outbound_delivery_freshness_destinations(state, identity))
             .transpose()?
-            .unwrap_or(false)
+            .unwrap_or_default();
+        if destination.is_some()
+            && outbound_destination_has_stale_known_announce_for_strings(
+                state,
+                &freshness_destinations,
+            )?
         {
             return Ok(r3akt_rch_core::OutboundDeliveryDecision {
                 method: "propagated".to_string(),
@@ -13937,6 +13964,14 @@ fn outbound_destination_has_stale_known_announce(
     outbound_destination_has_stale_known_announce_for_any(state, &[destination])
 }
 
+fn outbound_destination_has_stale_known_announce_for_strings(
+    state: &AppState,
+    destinations: &[String],
+) -> Result<bool, ApiError> {
+    let destinations = destinations.iter().map(String::as_str).collect::<Vec<_>>();
+    outbound_destination_has_stale_known_announce_for_any(state, &destinations)
+}
+
 fn outbound_destination_has_stale_known_announce_for_any(
     state: &AppState,
     destinations: &[&str],
@@ -13994,6 +14029,20 @@ fn identity_announce_matches_destination(
             == Some(destination)
 }
 
+fn outbound_delivery_freshness_destinations(
+    state: &AppState,
+    destination: &str,
+) -> Result<Vec<String>, ApiError> {
+    let Some(destination) = normalize_identity_key(destination) else {
+        return Ok(Vec::new());
+    };
+    let mut destinations = vec![destination.clone()];
+    if let Some(alias) = chat_delivery_destination_aliases_for_state(state)?.get(&destination) {
+        destinations.push(alias.clone());
+    }
+    Ok(destinations)
+}
+
 fn mark_direct_delivery_failure(state: &AppState, identity: &str) -> Result<(), ApiError> {
     let mut policy = state
         .outbound_delivery_policy
@@ -14020,6 +14069,18 @@ fn latest_failed_direct_delivery_ts_ms(state: &AppState, identity: &str) -> Opti
         })
         .filter_map(failed_direct_delivery_observed_ts_ms)
         .max()
+}
+
+fn rem_command_destination_should_propagate(
+    state: &AppState,
+    destination: &str,
+) -> Result<bool, ApiError> {
+    if outbound_destination_has_stale_known_announce(state, destination)? {
+        return Ok(true);
+    }
+    let announce_last_seen = announce_last_seen_ts_ms(state, destination);
+    Ok(latest_failed_direct_delivery_ts_ms(state, destination)
+        .is_some_and(|failed_at| announce_last_seen.is_none_or(|seen_at| failed_at >= seen_at)))
 }
 
 fn failed_direct_delivery_observed_ts_ms(message: &OutboundMessageRecord) -> Option<i64> {
@@ -50954,6 +51015,119 @@ mod tests {
     }
 
     #[test]
+    fn rem_chat_uses_fresh_lxmf_alias_when_rem_app_announce_is_stale() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-rem-chat-stale-alias-fresh-{}.db",
+            Uuid::new_v4()
+        ));
+        let mut store = r3akt_rch_core::RchSqliteStore::open(&db_path).expect("sqlite");
+        let mut snapshot = r3akt_rch_core::RchCore::new().snapshot();
+        let now = crate::unix_now_ms();
+        let rem_destination = "4bede2a6ecab26f234aac9bb894a441a";
+        let lxmf_destination = "1123c2623132bf9899ae5d3b28d9f79e";
+        snapshot.identity_announces = vec![
+            r3akt_rch_core::IdentityAnnounceRecord {
+                destination_hash: rem_destination.to_string(),
+                announced_identity_hash: None,
+                display_name: Some("R3AKT,EMergencyMessages,Telemetry;name=Poco".to_string()),
+                source_interface: Some("reticulumd".to_string()),
+                announce_capabilities: vec!["r3akt".to_string(), "name=poco".to_string()],
+                client_type: "rem".to_string(),
+                first_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 10_000,
+                last_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 1_000,
+            },
+            r3akt_rch_core::IdentityAnnounceRecord {
+                destination_hash: lxmf_destination.to_string(),
+                announced_identity_hash: None,
+                display_name: Some("Poco".to_string()),
+                source_interface: Some("reticulumd".to_string()),
+                announce_capabilities: vec!["lxmf".to_string()],
+                client_type: "generic_lxmf".to_string(),
+                first_seen_ts_ms: now - 60_000,
+                last_seen_ts_ms: now,
+            },
+        ];
+        store.save_snapshot(&snapshot).expect("save snapshot");
+
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        let decision = crate::outbound_delivery_decision(
+            &state,
+            r3akt_rch_core::DeliveryMode::Targeted,
+            None,
+            Some(rem_destination),
+        )
+        .expect("rem chat decision");
+
+        assert_eq!(decision.method, "direct");
+        assert_eq!(decision.reason, "rem_direct");
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn rem_command_preserves_propagation_when_rem_app_is_stale_even_with_fresh_chat_alias() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-rem-command-stale-app-alias-fresh-{}.db",
+            Uuid::new_v4()
+        ));
+        let mut store = r3akt_rch_core::RchSqliteStore::open(&db_path).expect("sqlite");
+        let mut snapshot = r3akt_rch_core::RchCore::new().snapshot();
+        let now = crate::unix_now_ms();
+        let rem_destination = "4bede2a6ecab26f234aac9bb894a441a";
+        let lxmf_destination = "1123c2623132bf9899ae5d3b28d9f79e";
+        snapshot.identity_announces = vec![
+            r3akt_rch_core::IdentityAnnounceRecord {
+                destination_hash: rem_destination.to_string(),
+                announced_identity_hash: None,
+                display_name: Some("R3AKT,EMergencyMessages,Telemetry;name=Poco".to_string()),
+                source_interface: Some("reticulumd".to_string()),
+                announce_capabilities: vec!["r3akt".to_string(), "name=poco".to_string()],
+                client_type: "rem".to_string(),
+                first_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 10_000,
+                last_seen_ts_ms: now - r3akt_rch_core::RECENT_ANNOUNCE_WINDOW_MS - 1_000,
+            },
+            r3akt_rch_core::IdentityAnnounceRecord {
+                destination_hash: lxmf_destination.to_string(),
+                announced_identity_hash: None,
+                display_name: Some("Poco".to_string()),
+                source_interface: Some("reticulumd".to_string()),
+                announce_capabilities: vec!["lxmf".to_string()],
+                client_type: "generic_lxmf".to_string(),
+                first_seen_ts_ms: now - 60_000,
+                last_seen_ts_ms: now,
+            },
+        ];
+        store.save_snapshot(&snapshot).expect("save snapshot");
+
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        let message = crate::record_outbound_message_with_metadata(
+            &state,
+            "Task Pixel fallback completed",
+            None,
+            Some(rem_destination.to_string()),
+            Vec::new(),
+            false,
+            json!({
+                "fanout_channel": "rem_checklist_command",
+                "lxmf_fields": { crate::FIELD_COMMANDS.to_string(): [{
+                    "command_type": "checklist.task.status.set",
+                    "args": {
+                        "checklist_uid": "checklist-poco",
+                        "task_uid": "task-poco",
+                        "user_status": "COMPLETE"
+                    }
+                }] }
+            }),
+        )
+        .expect("record rem command message");
+
+        assert_eq!(message.delivery_method, "propagated");
+        assert_eq!(message.delivery_policy_reason, "no_fresh_presence");
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
     fn targeted_delivery_uses_propagation_for_stale_known_lxmf_announce() {
         let db_path = std::env::temp_dir().join(format!(
             "r3akt-rch-stale-known-target-propagation-{}.db",
@@ -52097,6 +52271,61 @@ mod tests {
     }
 
     #[test]
+    fn propagated_rem_command_send_error_uses_rem_retry_budget() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-propagated-rem-command-send-error-retry-{}.db",
+            Uuid::new_v4()
+        ));
+        let destination = "6521979f1165965b24731061ef4a6906";
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        let message = crate::OutboundMessageRecord {
+            message_id: "propagated-rem-send-error".to_string(),
+            topic_id: None,
+            destination: Some(destination.to_string()),
+            sender: "northbound".to_string(),
+            content: "Task Pixel fallback completed".to_string(),
+            delivery_mode: r3akt_rch_core::DeliveryMode::Targeted,
+            delivery_method: "propagated".to_string(),
+            delivery_policy_reason: "no_fresh_presence".to_string(),
+            delivery_state: "queued".to_string(),
+            delivery_metadata: json!({
+                "fanout_channel": "rem_checklist_command",
+                "lxmf_fields": { crate::FIELD_COMMANDS.to_string(): [{
+                    "command_type": "checklist.task.status.set",
+                    "args": {
+                        "checklist_uid": "checklist-pixel",
+                        "task_uid": "task-pixel",
+                        "user_status": "COMPLETE"
+                    }
+                }] }
+            }),
+            created_ts_ms: crate::unix_now_ms(),
+            attachments: Vec::new(),
+        };
+        state
+            .messages
+            .write()
+            .expect("messages")
+            .push(message.clone());
+
+        let retry = crate::schedule_outbound_retry_after_failure(
+            &state,
+            &message,
+            "LXMF-rs ZeroMQ SDK request timed out waiting for correlated response".to_string(),
+        )
+        .expect("schedule retry")
+        .expect("propagated REM command should retry");
+
+        assert_eq!(retry.delivery_state, "queued");
+        assert_eq!(retry.delivery_method, "propagated");
+        assert_eq!(retry.delivery_metadata["attempts"], json!(1));
+        assert_eq!(retry.delivery_metadata["retry_scheduled"], json!(true));
+        assert_eq!(retry.delivery_metadata["retry_reason"], json!("send_error"));
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
     fn next_rem_command_attempt_uses_global_queue_spacing() {
         let db_path = std::env::temp_dir().join(format!(
             "r3akt-rch-rem-command-global-spacing-{}.db",
@@ -52372,6 +52601,34 @@ mod tests {
                 .count(),
             100
         );
+    }
+
+    #[test]
+    fn propagated_fanout_enqueues_zmq_batch_without_waiting_for_response() {
+        let now = crate::unix_now_ms();
+        let propagated = crate::OutboundMessageRecord {
+            message_id: "propagated-fanout".to_string(),
+            topic_id: None,
+            destination: None,
+            sender: "northbound".to_string(),
+            content: "propagated fanout".to_string(),
+            delivery_mode: r3akt_rch_core::DeliveryMode::Broadcast,
+            delivery_method: "propagated".to_string(),
+            delivery_policy_reason: "broadcast_unannounced".to_string(),
+            delivery_state: "queued".to_string(),
+            delivery_metadata: json!({}),
+            created_ts_ms: now,
+            attachments: Vec::new(),
+        };
+        let direct = crate::OutboundMessageRecord {
+            delivery_method: "direct".to_string(),
+            delivery_policy_reason: "broadcast_direct".to_string(),
+            ..propagated.clone()
+        };
+
+        assert!(crate::should_enqueue_fanout_without_waiting_for_zmq_response(&propagated, 2));
+        assert!(!crate::should_enqueue_fanout_without_waiting_for_zmq_response(&propagated, 1));
+        assert!(!crate::should_enqueue_fanout_without_waiting_for_zmq_response(&direct, 2));
     }
 
     #[tokio::test]

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -10643,47 +10643,52 @@ fn mark_reticulumd_status_delivery_failure(
                 }),
             );
             (message.clone(), true)
-        } else if direct_status_failure_should_retry_propagated(message, receipt_status) {
-            let attempts = outbound_attempts(message).saturating_add(1);
-            message.delivery_state = "queued".to_string();
-            message.delivery_method = "propagated".to_string();
-            message.delivery_policy_reason = if is_rem_command_message(message) {
-                "rem_direct_failure_fallback".to_string()
-            } else {
-                "direct_failure_fallback".to_string()
-            };
-            merge_delivery_metadata(
-                &mut message.delivery_metadata,
-                json!({
-                    "acked": false,
-                    "attempts": attempts,
-                    "direct_failure_status": receipt_status,
-                    "direct_failed_at_ts_ms": now_ms,
-                    "dispatch_status": "queued",
-                    "error": receipt_status,
-                    "fallback_reason": "direct_status_failure",
-                    "receipt_pending": false,
-                    "receipt_status": receipt_status,
-                    "retry_reason": "direct_status_failure",
-                    "retry_scheduled": true,
-                    "next_attempt_at_ts_ms": now_ms,
-                }),
-            );
-            (message.clone(), true)
         } else {
-            message.delivery_state = "failed".to_string();
-            merge_delivery_metadata(
-                &mut message.delivery_metadata,
-                json!({
-                    "acked": false,
-                    "dispatch_status": "failed",
-                    "error": receipt_status,
-                    "receipt_pending": false,
-                    "receipt_status": receipt_status,
-                    "delivery_failed_ts_ms": now_ms,
-                }),
-            );
-            (message.clone(), false)
+            let direct_fallback_destinations =
+                direct_status_failure_propagation_destinations(message, receipt_status);
+            if !direct_fallback_destinations.is_empty() {
+                let attempts = outbound_attempts(message).saturating_add(1);
+                message.delivery_state = "queued".to_string();
+                message.delivery_method = "propagated".to_string();
+                message.delivery_policy_reason = if is_rem_command_message(message) {
+                    "rem_direct_failure_fallback".to_string()
+                } else {
+                    "direct_failure_fallback".to_string()
+                };
+                merge_delivery_metadata(
+                    &mut message.delivery_metadata,
+                    json!({
+                        "acked": false,
+                        "attempts": attempts,
+                        "direct_failure_status": receipt_status,
+                        "direct_failed_at_ts_ms": now_ms,
+                        "dispatch_status": "queued",
+                        "error": receipt_status,
+                        "fallback_reason": "direct_status_failure",
+                        "receipt_pending": false,
+                        "receipt_status": receipt_status,
+                        "retry_reason": "direct_status_failure",
+                        "retry_scheduled": true,
+                        "next_attempt_at_ts_ms": now_ms,
+                        "target_destinations": direct_fallback_destinations,
+                    }),
+                );
+                (message.clone(), true)
+            } else {
+                message.delivery_state = "failed".to_string();
+                merge_delivery_metadata(
+                    &mut message.delivery_metadata,
+                    json!({
+                        "acked": false,
+                        "dispatch_status": "failed",
+                        "error": receipt_status,
+                        "receipt_pending": false,
+                        "receipt_status": receipt_status,
+                        "delivery_failed_ts_ms": now_ms,
+                    }),
+                );
+                (message.clone(), false)
+            }
         }
     };
     persist_outbound_message_row(state, &message)?;
@@ -10691,6 +10696,11 @@ fn mark_reticulumd_status_delivery_failure(
     if message.delivery_method == "direct" || queued_propagation_fallback {
         if let Some(destination) = message.destination.as_deref() {
             mark_direct_delivery_failure(state, destination)?;
+        }
+        if queued_propagation_fallback {
+            for destination in outbound_target_destinations(&message).unwrap_or_default() {
+                mark_direct_delivery_failure(state, destination.as_str())?;
+            }
         }
     }
     let destination = message.destination.as_deref().unwrap_or("unknown");
@@ -10769,17 +10779,51 @@ fn rem_auto_status_failure_should_retry_propagated(
     rem_auto_status_failure_is_retryable(status.as_str())
 }
 
-fn direct_status_failure_should_retry_propagated(
+fn direct_status_failure_propagation_destinations(
     message: &OutboundMessageRecord,
     receipt_status: &str,
-) -> bool {
+) -> Vec<String> {
     if message.delivery_method != "direct" || message.destination.is_none() {
-        return false;
+        if message.delivery_method != "direct"
+            || message.delivery_mode != DeliveryMode::Fanout
+            || is_rem_command_message(message)
+        {
+            return Vec::new();
+        }
+        let mut destinations = Vec::new();
+        let mut seen = HashSet::new();
+        for target in reticulumd_receipt_targets_for_message(message) {
+            let retryable = target
+                .status
+                .as_deref()
+                .is_some_and(direct_status_failure_is_retryable);
+            if !retryable {
+                continue;
+            }
+            if let Some(destination) = normalize_identity_key(target.destination.as_str()) {
+                if seen.insert(destination.clone()) {
+                    destinations.push(destination);
+                }
+            }
+        }
+        return destinations;
     }
     if is_rem_command_message(message) {
-        return false;
+        return Vec::new();
     }
-    let status = receipt_status.trim().to_ascii_lowercase();
+    if !direct_status_failure_is_retryable(receipt_status) {
+        return Vec::new();
+    }
+    message
+        .destination
+        .as_deref()
+        .and_then(normalize_identity_key)
+        .into_iter()
+        .collect()
+}
+
+fn direct_status_failure_is_retryable(status: &str) -> bool {
+    let status = status.trim().to_ascii_lowercase();
     reticulumd_status_is_retryable_link_failure(status.as_str())
         || (status.starts_with("failed") && status.contains("peer not announced"))
 }
@@ -45188,9 +45232,11 @@ mod tests {
             .expect("targets");
         assert_eq!(targets.len(), 2);
         assert!(targets.iter().all(|target| target["status"] == "delivered"));
-        assert!(targets
-            .iter()
-            .all(|target| target["sdk_delivery_state"] == "delivered"));
+        assert!(
+            targets
+                .iter()
+                .all(|target| target["sdk_delivery_state"] == "delivered")
+        );
 
         let _ = std::fs::remove_file(db_path);
     }
@@ -50774,7 +50820,7 @@ mod tests {
         snapshot.messages = vec![r3akt_rch_core::MessageRecord {
             message_id: "pending-generic-peer-not-announced".to_string(),
             topic_id: Some("direct".to_string()),
-            destination: Some(generic_destination.to_string()),
+            destination: None,
             sender: "northbound".to_string(),
             content: "pending generic direct".to_string(),
             delivery_mode: r3akt_rch_core::DeliveryMode::Fanout,
@@ -50783,6 +50829,12 @@ mod tests {
             delivery_state: "sent".to_string(),
             delivery_metadata: json!({
                 "dispatch_status": "accepted",
+                "reticulumd_dispatch_count": 1,
+                "reticulumd_receipt_targets": [{
+                    "message_id": "sdk-target-peer-not-announced",
+                    "destination": generic_destination,
+                    "status": "failed: peer not announced"
+                }],
                 "receipt_pending": true,
             }),
             created_ts_ms: now,
@@ -50811,20 +50863,14 @@ mod tests {
             "direct_status_failure"
         );
         assert_eq!(stored.delivery_metadata["retry_scheduled"], true);
-        drop(messages);
-
-        let decision = crate::outbound_delivery_decision(
-            &state,
-            r3akt_rch_core::DeliveryMode::Targeted,
-            Some(generic_destination),
-        )
-        .expect("generic decision");
-        assert_eq!(decision.method, "propagated");
         assert!(
-            matches!(decision.reason.as_str(), "direct_cooldown" | "no_fresh_presence"),
-            "unexpected propagation reason: {}",
-            decision.reason
+            stored.delivery_metadata["target_destinations"]
+                .as_array()
+                .expect("target destinations")
+                .iter()
+                .any(|value| value.as_str() == Some(generic_destination))
         );
+        drop(messages);
 
         let _ = std::fs::remove_file(db_path);
     }

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -14069,7 +14069,7 @@ fn outbound_route_has_unannounced_destinations(
                     .filter_map(|destination| normalize_identity_key(destination))
                     .collect::<Vec<_>>();
                 if !destinations.is_empty() {
-                    return outbound_destinations_have_unannounced_route(
+                    return outbound_explicit_targets_have_unannounced_route(
                         state,
                         delivery_mode,
                         destinations,
@@ -14110,6 +14110,33 @@ fn outbound_destinations_have_unannounced_route(
             &[destination.as_str(), delivery_destination.as_str()],
         )
         .unwrap_or(false)
+    }))
+}
+
+fn outbound_explicit_targets_have_unannounced_route(
+    state: &AppState,
+    delivery_mode: DeliveryMode,
+    destinations: Vec<String>,
+) -> Result<bool, ApiError> {
+    if destinations.is_empty() || state.sqlite_path.is_none() {
+        return Ok(false);
+    }
+    let now = unix_now_ms();
+    let routing_context = outbound_destination_routing_context(state)?;
+    Ok(destinations.into_iter().any(|destination| {
+        let delivery_destination = outbound_destination_for_message_with_context_for_mode(
+            delivery_mode,
+            &destination,
+            &routing_context,
+            false,
+        );
+        let candidates = [destination.as_str(), delivery_destination.as_str()];
+        let has_fresh_announce =
+            outbound_destination_has_fresh_announce_for_any(state, &candidates).unwrap_or(false);
+        let has_live_presence = candidates
+            .iter()
+            .any(|candidate| has_live_client(state, candidate, now));
+        !has_fresh_announce && !has_live_presence
     }))
 }
 
@@ -26616,7 +26643,7 @@ mod tests {
         let requests = rpc_server.join().expect("rpc server");
         assert_eq!(requests.len(), 2);
         assert_eq!(requests[0].method, "list_messages");
-        assert_eq!(requests[1].method, "send_message_v2");
+        assert_eq!(requests[1].method, "sdk_send_v2");
         let params = requests[1].params.as_ref().expect("relay params");
         assert_eq!(params["source"], "local-destination");
         assert_eq!(params["destination"], "peer-charlie");
@@ -26719,7 +26746,7 @@ mod tests {
         let requests = rpc_server.join().expect("rpc server");
         assert_eq!(requests.len(), 2);
         assert_eq!(requests[0].method, "list_messages");
-        assert_eq!(requests[1].method, "send_message_v2");
+        assert_eq!(requests[1].method, "sdk_send_v2");
         let params = requests[1].params.as_ref().expect("relay params");
         assert_eq!(params["destination"], "peer-bravo");
         assert_eq!(params["content"], "[topic:direct]\nphone to phone");
@@ -26743,6 +26770,8 @@ mod tests {
             relay.delivery_metadata["exclude_destinations"],
             json!(["peer-alpha"])
         );
+        assert_eq!(relay.delivery_method, "direct");
+        assert_eq!(relay.delivery_policy_reason, "topic_direct");
         drop(messages);
 
         std::fs::remove_file(db_path).expect("cleanup db");
@@ -26830,7 +26859,7 @@ mod tests {
         let requests = rpc_server.join().expect("rpc server");
         assert_eq!(requests.len(), 2);
         assert_eq!(requests[0].method, "list_messages");
-        assert_eq!(requests[1].method, "send_message_v2");
+        assert_eq!(requests[1].method, "sdk_send_v2");
         let params = requests[1].params.as_ref().expect("relay params");
         assert_eq!(params["destination"], "peer-bravo");
         assert_ne!(params["destination"], "peer-stale");
@@ -26854,6 +26883,8 @@ mod tests {
             relay.delivery_metadata["reticulumd_inbound_default_direct_relay"],
             false
         );
+        assert_eq!(relay.delivery_method, "direct");
+        assert_eq!(relay.delivery_policy_reason, "topic_direct");
 
         std::fs::remove_file(db_path).expect("cleanup db");
     }

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -10648,6 +10648,7 @@ fn mark_reticulumd_status_delivery_failure(
             let direct_fallback_destinations =
                 direct_status_failure_propagation_destinations(message, receipt_status);
             if !direct_fallback_destinations.is_empty() {
+                let delivered_destinations = delivered_reticulumd_receipt_destinations(message);
                 let attempts = outbound_attempts(message).saturating_add(1);
                 message.delivery_state = "queued".to_string();
                 message.delivery_method = "propagated".to_string();
@@ -10657,24 +10658,32 @@ fn mark_reticulumd_status_delivery_failure(
                     "direct_failure_fallback".to_string()
                 };
                 clear_retry_superseded_delivery_metadata(&mut message.delivery_metadata);
-                merge_delivery_metadata(
-                    &mut message.delivery_metadata,
-                    json!({
-                        "acked": false,
-                        "attempts": attempts,
-                        "direct_failure_status": receipt_status,
-                        "direct_failed_at_ts_ms": now_ms,
-                        "dispatch_status": "queued",
-                        "error": receipt_status,
-                        "fallback_reason": "direct_status_failure",
-                        "receipt_pending": false,
-                        "receipt_status": receipt_status,
-                        "retry_reason": "direct_status_failure",
-                        "retry_scheduled": true,
-                        "next_attempt_at_ts_ms": now_ms,
-                        "target_destinations": direct_fallback_destinations,
-                    }),
-                );
+                let mut fallback_metadata = json!({
+                    "acked": false,
+                    "attempts": attempts,
+                    "direct_failure_status": receipt_status,
+                    "direct_failed_at_ts_ms": now_ms,
+                    "dispatch_status": "queued",
+                    "error": receipt_status,
+                    "fallback_reason": "direct_status_failure",
+                    "receipt_pending": false,
+                    "receipt_status": receipt_status,
+                    "retry_reason": "direct_status_failure",
+                    "retry_scheduled": true,
+                    "next_attempt_at_ts_ms": now_ms,
+                    "target_destinations": direct_fallback_destinations,
+                });
+                if !delivered_destinations.is_empty() {
+                    merge_delivery_metadata(
+                        &mut fallback_metadata,
+                        json!({
+                            "delivered_destinations": delivered_destinations.clone(),
+                            "exclude_destinations": delivered_destinations,
+                            "partial_delivery": true,
+                        }),
+                    );
+                }
+                merge_delivery_metadata(&mut message.delivery_metadata, fallback_metadata);
                 (message.clone(), true)
             } else {
                 message.delivery_state = "failed".to_string();
@@ -50936,6 +50945,101 @@ mod tests {
                 "stale direct metadata key should be cleared: {cleared_key}"
             );
         }
+        drop(messages);
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn reticulumd_fanout_peer_not_announced_preserves_delivered_targets_for_propagation_fallback() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-fanout-partial-peer-not-announced-{}.db",
+            Uuid::new_v4()
+        ));
+        let mut store = r3akt_rch_core::RchSqliteStore::open(&db_path).expect("sqlite");
+        let mut snapshot = r3akt_rch_core::RchCore::new().snapshot();
+        let now = crate::unix_now_ms();
+        let delivered_destination = "52118fa6f1240342cb730dabdf1d4ca1";
+        let unannounced_destination = "7f08e12b3f25f23e62f3a15288303c95";
+        snapshot.messages = vec![r3akt_rch_core::MessageRecord {
+            message_id: "pending-fanout-partial-peer-not-announced".to_string(),
+            topic_id: Some("direct".to_string()),
+            destination: None,
+            sender: "northbound".to_string(),
+            content: "fanout partial direct".to_string(),
+            delivery_mode: r3akt_rch_core::DeliveryMode::Fanout,
+            delivery_method: "direct".to_string(),
+            delivery_policy_reason: "fanout_route".to_string(),
+            delivery_state: "sent".to_string(),
+            delivery_metadata: json!({
+                "dispatch_status": "accepted",
+                "reticulumd_dispatch_count": 2,
+                "reticulumd_receipt_targets": [
+                    {
+                        "message_id": "sdk-target-delivered",
+                        "destination": delivered_destination,
+                        "sdk_delivery_state": "delivered",
+                        "sdk_message_id": "sdk-target-delivered",
+                        "sdk_reason_code": null,
+                        "sdk_terminal": true,
+                        "status": "delivered"
+                    },
+                    {
+                        "message_id": "sdk-target-peer-not-announced",
+                        "destination": unannounced_destination,
+                        "sdk_delivery_state": "failed",
+                        "sdk_message_id": "sdk-target-peer-not-announced",
+                        "sdk_reason_code": "peer_not_announced",
+                        "sdk_terminal": true,
+                        "status": "failed: peer not announced"
+                    }
+                ],
+                "receipt_pending": true,
+            }),
+            created_ts_ms: now,
+            attachments: Vec::new(),
+        }];
+        store.save_snapshot(&snapshot).expect("save snapshot");
+
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        crate::mark_reticulumd_status_delivery_failure(
+            &state,
+            "pending-fanout-partial-peer-not-announced",
+            "failed: peer not announced",
+        )
+        .expect("mark failure");
+
+        let messages = state.messages.read().expect("messages");
+        let stored = messages
+            .iter()
+            .find(|message| message.message_id == "pending-fanout-partial-peer-not-announced")
+            .expect("stored message");
+        assert_eq!(stored.delivery_state, "queued");
+        assert_eq!(stored.delivery_method, "propagated");
+        assert_eq!(stored.delivery_policy_reason, "direct_failure_fallback");
+        assert_eq!(
+            stored.delivery_metadata["fallback_reason"],
+            "direct_status_failure"
+        );
+        assert_eq!(
+            stored.delivery_metadata["target_destinations"],
+            json!([unannounced_destination])
+        );
+        assert_eq!(
+            stored.delivery_metadata["exclude_destinations"],
+            json!([delivered_destination])
+        );
+        assert_eq!(
+            stored.delivery_metadata["delivered_destinations"],
+            json!([delivered_destination])
+        );
+        assert_eq!(stored.delivery_metadata["partial_delivery"], true);
+        assert!(
+            stored
+                .delivery_metadata
+                .get("reticulumd_receipt_targets")
+                .is_none()
+        );
         drop(messages);
 
         let _ = std::fs::remove_file(db_path);

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -10655,6 +10655,7 @@ fn mark_reticulumd_status_delivery_failure(
                 } else {
                     "direct_failure_fallback".to_string()
                 };
+                clear_retry_superseded_delivery_metadata(&mut message.delivery_metadata);
                 merge_delivery_metadata(
                     &mut message.delivery_metadata,
                     json!({
@@ -13648,6 +13649,25 @@ fn clear_success_superseded_delivery_metadata(metadata: &mut Value) {
     object.remove("dispatch_timed_out_at_ts_ms");
     object.remove("error");
     object.remove("retry_reason");
+}
+
+fn clear_retry_superseded_delivery_metadata(metadata: &mut Value) {
+    clear_success_superseded_delivery_metadata(metadata);
+    let Some(object) = metadata.as_object_mut() else {
+        return;
+    };
+    object.remove("dispatch_started_ts_ms");
+    object.remove("dispatch_deadline_ts_ms");
+    object.remove("receipt_deadline_ts_ms");
+    object.remove("receipt_last_poll_ts_ms");
+    object.remove("receipt_registered_ts_ms");
+    object.remove("reticulumd_receipt_targets");
+    object.remove("sdk_attempts");
+    object.remove("sdk_delivery_state");
+    object.remove("sdk_last_updated_ms");
+    object.remove("sdk_message_id");
+    object.remove("sdk_reason_code");
+    object.remove("sdk_terminal");
 }
 
 fn delivery_state_clears_error_metadata(delivery_state: &str) -> bool {
@@ -50829,13 +50849,26 @@ mod tests {
             delivery_state: "sent".to_string(),
             delivery_metadata: json!({
                 "dispatch_status": "accepted",
+                "dispatch_started_ts_ms": now - 10_000,
+                "dispatch_deadline_ts_ms": now - 1,
                 "reticulumd_dispatch_count": 1,
                 "reticulumd_receipt_targets": [{
                     "message_id": "sdk-target-peer-not-announced",
                     "destination": generic_destination,
+                    "sdk_delivery_state": "failed",
+                    "sdk_message_id": "sdk-target-peer-not-announced",
+                    "sdk_reason_code": "peer_not_announced",
+                    "sdk_terminal": true,
                     "status": "failed: peer not announced"
                 }],
+                "sdk_delivery_state": "failed",
+                "sdk_message_id": "sdk-target-peer-not-announced",
+                "sdk_reason_code": "peer_not_announced",
+                "sdk_terminal": true,
                 "receipt_pending": true,
+                "receipt_deadline_ts_ms": now - 1,
+                "receipt_last_poll_ts_ms": now - 5_000,
+                "receipt_registered_ts_ms": now - 10_000,
             }),
             created_ts_ms: now,
             attachments: Vec::new(),
@@ -50870,6 +50903,23 @@ mod tests {
                 .iter()
                 .any(|value| value.as_str() == Some(generic_destination))
         );
+        for cleared_key in [
+            "dispatch_started_ts_ms",
+            "dispatch_deadline_ts_ms",
+            "receipt_deadline_ts_ms",
+            "receipt_last_poll_ts_ms",
+            "receipt_registered_ts_ms",
+            "reticulumd_receipt_targets",
+            "sdk_delivery_state",
+            "sdk_message_id",
+            "sdk_reason_code",
+            "sdk_terminal",
+        ] {
+            assert!(
+                stored.delivery_metadata.get(cleared_key).is_none(),
+                "stale direct metadata key should be cleared: {cleared_key}"
+            );
+        }
         drop(messages);
 
         let _ = std::fs::remove_file(db_path);

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -10939,7 +10939,9 @@ fn finalize_stale_pending_dispatches(state: &AppState) -> Result<(), ApiError> {
         }
         let attempts = outbound_attempts(message).saturating_add(1);
         let max_attempts = outbound_effective_max_attempts_for_retry(message, false);
-        if message.delivery_method != "propagated" && attempts < max_attempts {
+        if (message.delivery_method != "propagated" || is_rem_command_message(message))
+            && attempts < max_attempts
+        {
             let next_attempt_at_ts_ms = now_ms.saturating_add(
                 outbound_backoff_ms(message)
                     .saturating_mul(i64::try_from(attempts).unwrap_or(i64::MAX)),
@@ -11033,7 +11035,9 @@ fn finalize_expired_delivery_receipts(state: &AppState) -> Result<(), ApiError> 
         }
         let attempts = outbound_attempts(message).saturating_add(1);
         let max_attempts = outbound_effective_max_attempts_for_retry(message, false);
-        if message.delivery_method != "propagated" && attempts < max_attempts {
+        if (message.delivery_method != "propagated" || is_rem_command_message(message))
+            && attempts < max_attempts
+        {
             let next_attempt_at_ts_ms = now_ms.saturating_add(
                 outbound_backoff_ms(message).saturating_mul(i64::try_from(attempts).unwrap_or(1)),
             );
@@ -12881,7 +12885,7 @@ fn record_outbound_message_with_metadata_mode(
     } else {
         dispatch_mode
     };
-    if is_rem_command {
+    if is_rem_command && delivery_decision.method != "propagated" {
         delivery_decision.method = "auto".to_string();
         delivery_decision.reason = "rem_auto".to_string();
     }
@@ -44964,8 +44968,8 @@ mod tests {
         )
         .expect("record REM command");
 
-        assert_eq!(message.delivery_method, "auto");
-        assert_eq!(message.delivery_policy_reason, "rem_auto");
+        assert_eq!(message.delivery_method, "propagated");
+        assert_eq!(message.delivery_policy_reason, "no_fresh_presence");
         assert_eq!(message.delivery_state, "queued");
         assert_eq!(
             message.delivery_metadata["dispatch_status"],
@@ -48875,6 +48879,16 @@ mod tests {
             }),
         )
         .expect("mark expired receipt");
+        {
+            let messages = state.messages.read().expect("messages");
+            let pending = messages.first().expect("message");
+            assert_eq!(pending.delivery_method, "propagated");
+            assert_eq!(
+                pending.delivery_metadata["fanout_channel"],
+                "rem_checklist_command"
+            );
+            assert!(crate::is_rem_command_message(pending));
+        }
 
         crate::finalize_expired_delivery_receipts(&state).expect("finalize receipts");
 
@@ -51971,7 +51985,47 @@ mod tests {
     }
 
     #[test]
-    fn rem_command_message_uses_auto_delivery_even_when_direct_cooldown_exists() {
+    fn rem_command_to_unannounced_target_is_recorded_for_propagation() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-rem-command-unannounced-propagation-{}.db",
+            Uuid::new_v4()
+        ));
+        let destination = "6521979f1165965b24731061ef4a6906";
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        let message = crate::record_outbound_message_with_metadata(
+            &state,
+            "Task Pixel fallback completed",
+            None,
+            Some(destination.to_string()),
+            Vec::new(),
+            false,
+            json!({
+                "fanout_channel": "rem_checklist_command",
+                "lxmf_fields": { crate::FIELD_COMMANDS.to_string(): [{
+                    "command_type": "checklist.task.status.set",
+                    "args": {
+                        "checklist_uid": "checklist-pixel",
+                        "task_uid": "task-pixel",
+                        "user_status": "COMPLETE"
+                    }
+                }] }
+            }),
+        )
+        .expect("record rem command message");
+
+        assert_eq!(message.delivery_method, "propagated");
+        assert_eq!(message.delivery_policy_reason, "no_fresh_presence");
+        assert_eq!(
+            crate::lxmf_sdk_delivery_method(&message),
+            Some("propagated")
+        );
+        assert!(!crate::lxmf_sdk_try_propagation_on_fail(&message));
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn rem_command_message_uses_propagation_when_direct_cooldown_exists() {
         let db_path = std::env::temp_dir().join(format!(
             "r3akt-rch-rem-command-direct-cooldown-{}.db",
             Uuid::new_v4()
@@ -52036,8 +52090,8 @@ mod tests {
         )
         .expect("record rem command message");
 
-        assert_eq!(message.delivery_method, "auto");
-        assert_eq!(message.delivery_policy_reason, "rem_auto");
+        assert_eq!(message.delivery_method, "propagated");
+        assert_eq!(message.delivery_policy_reason, "rem_direct_cooldown");
 
         let _ = std::fs::remove_file(db_path);
     }

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -13115,10 +13115,7 @@ fn dispatch_outbound_message(
             source: source.to_string(),
             messages: batch_messages,
         };
-        let batch_result = if should_enqueue_fanout_without_waiting_for_zmq_response(
-            message,
-            fanout_destination_count,
-        ) {
+        let batch_result = if should_enqueue_without_waiting_for_zmq_response(message) {
             enqueue_lxmf_zmq_outbound_batch(command_endpoint, response_endpoint, batch)
         } else {
             send_lxmf_zmq_outbound_batch(command_endpoint, response_endpoint, batch)
@@ -13160,6 +13157,40 @@ fn dispatch_outbound_message(
                 .cloned()
                 .unwrap_or_else(|| json!({})),
         );
+        if should_enqueue_without_waiting_for_zmq_response(message) {
+            let batch = LxmfSdkOutboundBatch {
+                batch_id: format!(
+                    "{}-single-{}",
+                    message.message_id,
+                    outbound_attempts(message)
+                ),
+                source: source.to_string(),
+                messages: vec![LxmfSdkOutboundBatchMessage {
+                    destination: destination.clone(),
+                    title: outbound_lxmf_title(&dispatch_message).to_string(),
+                    content: outbound_lxmf_content(&dispatch_message).to_string(),
+                    fields,
+                    delivery_method: lxmf_sdk_delivery_method(message).map(str::to_string),
+                    stamp_cost: lxmf_sdk_stamp_cost(message),
+                    include_ticket: lxmf_sdk_include_ticket(message),
+                    try_propagation_on_fail: lxmf_sdk_try_propagation_on_fail(message),
+                    correlation_id: message_id,
+                }],
+            };
+            let results =
+                enqueue_lxmf_zmq_outbound_batch(command_endpoint, response_endpoint, batch)
+                    .map_err(|error| ApiError::ServiceUnavailable(error.to_string()))?;
+            for result in results {
+                report.count += 1;
+                report.receipts.push(ReticulumdReceiptTarget {
+                    message_id: result.message_id,
+                    destination: result.destination,
+                    status: None,
+                    sdk_snapshot: None,
+                });
+            }
+            continue;
+        }
         let dispatch_result = send_lxmf_zmq_outbound_message(
             command_endpoint,
             response_endpoint,
@@ -13199,11 +13230,8 @@ fn dispatch_outbound_message(
     Ok(report)
 }
 
-fn should_enqueue_fanout_without_waiting_for_zmq_response(
-    message: &OutboundMessageRecord,
-    fanout_destination_count: usize,
-) -> bool {
-    fanout_destination_count > 1 && message.delivery_method == "propagated"
+fn should_enqueue_without_waiting_for_zmq_response(message: &OutboundMessageRecord) -> bool {
+    message.delivery_method == "propagated"
 }
 
 #[cfg(test)]
@@ -52604,7 +52632,7 @@ mod tests {
     }
 
     #[test]
-    fn propagated_fanout_enqueues_zmq_batch_without_waiting_for_response() {
+    fn propagated_delivery_enqueues_zmq_batch_without_waiting_for_response() {
         let now = crate::unix_now_ms();
         let propagated = crate::OutboundMessageRecord {
             message_id: "propagated-fanout".to_string(),
@@ -52626,9 +52654,55 @@ mod tests {
             ..propagated.clone()
         };
 
-        assert!(crate::should_enqueue_fanout_without_waiting_for_zmq_response(&propagated, 2));
-        assert!(!crate::should_enqueue_fanout_without_waiting_for_zmq_response(&propagated, 1));
-        assert!(!crate::should_enqueue_fanout_without_waiting_for_zmq_response(&direct, 2));
+        assert!(crate::should_enqueue_without_waiting_for_zmq_response(
+            &propagated
+        ));
+        assert!(!crate::should_enqueue_without_waiting_for_zmq_response(
+            &direct
+        ));
+    }
+
+    #[test]
+    fn propagated_single_dispatch_enqueues_zmq_without_waiting_for_response() {
+        let state = crate::AppState::default().with_lxmf_zmq_sdk(
+            unused_zmq_endpoint_for_rch_test(),
+            unused_zmq_endpoint_for_rch_test(),
+            "source-destination",
+        );
+        let message = crate::OutboundMessageRecord {
+            message_id: "propagated-single".to_string(),
+            topic_id: None,
+            destination: Some("target-destination".to_string()),
+            sender: "northbound".to_string(),
+            content: "propagated single".to_string(),
+            delivery_mode: r3akt_rch_core::DeliveryMode::Targeted,
+            delivery_method: "propagated".to_string(),
+            delivery_policy_reason: "direct_cooldown".to_string(),
+            delivery_state: "queued".to_string(),
+            delivery_metadata: json!({}),
+            created_ts_ms: crate::unix_now_ms(),
+            attachments: Vec::new(),
+        };
+
+        let started = Instant::now();
+        let report = crate::dispatch_outbound_message(&state, &message).expect("dispatch");
+        let elapsed = started.elapsed();
+
+        assert_eq!(report.count, 1);
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "propagated dispatch waited for a ZeroMQ response: {elapsed:?}"
+        );
+        assert_eq!(report.receipts.len(), 1);
+        assert_eq!(report.receipts[0].message_id, "propagated-single");
+        assert_eq!(report.receipts[0].destination, "target-destination");
+    }
+
+    fn unused_zmq_endpoint_for_rch_test() -> String {
+        let listener = StdTcpListener::bind("127.0.0.1:0").expect("reserve tcp port");
+        let port = listener.local_addr().expect("local addr").port();
+        drop(listener);
+        format!("tcp://127.0.0.1:{port}")
     }
 
     #[tokio::test]

--- a/crates/r3akt-transport-rns/src/lib.rs
+++ b/crates/r3akt-transport-rns/src/lib.rs
@@ -594,6 +594,8 @@ pub struct LxmfSdkOutboundMessage {
     pub content: String,
     pub fields: JsonValue,
     pub delivery_method: Option<String>,
+    pub stamp_cost: Option<u32>,
+    pub include_ticket: Option<bool>,
     pub try_propagation_on_fail: bool,
     pub correlation_id: String,
 }
@@ -610,6 +612,8 @@ pub struct LxmfSdkOutboundBatchMessage {
     pub content: String,
     pub fields: JsonValue,
     pub delivery_method: Option<String>,
+    pub stamp_cost: Option<u32>,
+    pub include_ticket: Option<bool>,
     pub try_propagation_on_fail: bool,
     pub correlation_id: String,
 }
@@ -725,6 +729,22 @@ pub fn send_lxmf_sdk_outbound_message_with_runtime(
     let request = LxmfSdkSendRequest::new(message.source, message.destination, payload)
         .with_correlation_id(message.correlation_id.clone())
         .with_idempotency_key(message.correlation_id);
+    let request = if let Some(method) = message.delivery_method {
+        request.with_delivery_method(method)
+    } else {
+        request
+    };
+    let request = if let Some(stamp_cost) = message.stamp_cost {
+        request.with_stamp_cost(stamp_cost)
+    } else {
+        request
+    };
+    let request = if let Some(include_ticket) = message.include_ticket {
+        request.with_include_ticket(include_ticket)
+    } else {
+        request
+    };
+    let request = request.with_try_propagation_on_fail(message.try_propagation_on_fail);
     runtime.send(request)
 }
 
@@ -1566,6 +1586,8 @@ fn lxmf_sdk_outbound_send_params(message: LxmfSdkOutboundMessage) -> JsonValue {
         "content": message.content,
         "fields": fields,
         "method": message.delivery_method,
+        "stamp_cost": message.stamp_cost,
+        "include_ticket": message.include_ticket,
         "try_propagation_on_fail": message.try_propagation_on_fail,
     })
 }
@@ -1604,6 +1626,8 @@ fn lxmf_sdk_outbound_batch_params(batch: LxmfSdkOutboundBatch) -> JsonValue {
                 "content": message.content,
                 "fields": fields,
                 "method": message.delivery_method,
+                "stamp_cost": message.stamp_cost,
+                "include_ticket": message.include_ticket,
                 "try_propagation_on_fail": message.try_propagation_on_fail,
             })
         })
@@ -3334,6 +3358,8 @@ mod tests {
                     content: "one".to_string(),
                     fields: serde_json::json!({ "kind": "a" }),
                     delivery_method: Some("direct".to_string()),
+                    stamp_cost: None,
+                    include_ticket: None,
                     try_propagation_on_fail: true,
                     correlation_id: "message-a".to_string(),
                 },
@@ -3343,6 +3369,8 @@ mod tests {
                     content: "two".to_string(),
                     fields: serde_json::json!({ "kind": "b" }),
                     delivery_method: Some("propagated".to_string()),
+                    stamp_cost: Some(16),
+                    include_ticket: Some(true),
                     try_propagation_on_fail: false,
                     correlation_id: "message-b".to_string(),
                 },
@@ -3359,6 +3387,8 @@ mod tests {
         assert_eq!(messages[1]["id"], "message-b");
         assert_eq!(messages[1]["destination"], "dst-b");
         assert_eq!(messages[1]["method"], "propagated");
+        assert_eq!(messages[1]["stamp_cost"], 16);
+        assert_eq!(messages[1]["include_ticket"], true);
     }
 
     #[test]
@@ -3387,6 +3417,8 @@ mod tests {
                     content: format!("payload {index}"),
                     fields: serde_json::json!({ "bulk_index": index }),
                     delivery_method: Some("propagated".to_string()),
+                    stamp_cost: None,
+                    include_ticket: None,
                     try_propagation_on_fail: false,
                     correlation_id: format!("bulk-message-{index:05}"),
                 },
@@ -3494,6 +3526,8 @@ mod tests {
                     "custom": "value"
                 }),
                 delivery_method: Some("direct".to_string()),
+                stamp_cost: None,
+                include_ticket: None,
                 try_propagation_on_fail: true,
                 correlation_id: "message-1".to_string(),
             },
@@ -3539,6 +3573,8 @@ mod tests {
                     "9": [{"command_type": "checklist.create.online"}],
                 }),
                 delivery_method: Some("propagated".to_string()),
+                stamp_cost: Some(16),
+                include_ticket: Some(true),
                 try_propagation_on_fail: false,
                 correlation_id: "message-1".to_string(),
             },
@@ -3554,6 +3590,8 @@ mod tests {
         assert_eq!(captured[1].params["source"], "source-destination");
         assert_eq!(captured[1].params["destination"], "target-destination");
         assert_eq!(captured[1].params["method"], "propagated");
+        assert_eq!(captured[1].params["stamp_cost"], 16);
+        assert_eq!(captured[1].params["include_ticket"], true);
         assert_eq!(captured[1].params["try_propagation_on_fail"], false);
         assert_eq!(
             captured[1].params["fields"]["9"][0]["command_type"],
@@ -3589,6 +3627,8 @@ mod tests {
                 content: "cmd".to_string(),
                 fields: serde_json::json!({}),
                 delivery_method: Some("direct".to_string()),
+                stamp_cost: None,
+                include_ticket: None,
                 try_propagation_on_fail: false,
                 correlation_id: "message-1".to_string(),
             },
@@ -3700,6 +3740,8 @@ mod tests {
                 content: "cmd".to_string(),
                 fields: serde_json::json!({}),
                 delivery_method: Some("direct".to_string()),
+                stamp_cost: None,
+                include_ticket: None,
                 try_propagation_on_fail: false,
                 correlation_id: "message-1".to_string(),
             },

--- a/crates/r3akt-transport-rns/src/lib.rs
+++ b/crates/r3akt-transport-rns/src/lib.rs
@@ -645,6 +645,15 @@ pub fn send_lxmf_zmq_outbound_batch(
     send_lxmf_zmq_outbound_batch_via_actor(&config, batch)
 }
 
+pub fn enqueue_lxmf_zmq_outbound_batch(
+    command_endpoint: impl Into<String>,
+    response_endpoint: impl Into<String>,
+    batch: LxmfSdkOutboundBatch,
+) -> Result<Vec<LxmfSdkOutboundBatchResult>, TransportError> {
+    let config = rch_local_zmq_pipeline_config(command_endpoint, response_endpoint);
+    enqueue_lxmf_zmq_outbound_batch_via_actor(&config, batch)
+}
+
 pub fn lxmf_zmq_delivery_status(
     command_endpoint: impl Into<String>,
     response_endpoint: impl Into<String>,
@@ -973,6 +982,7 @@ fn send_lxmf_zmq_outbound_message_direct(
 enum ZmqSdkActorPayload {
     Single(LxmfSdkOutboundMessage),
     Batch(LxmfSdkOutboundBatch),
+    EnqueueBatch(LxmfSdkOutboundBatch),
     Status(String),
     Announce,
     PollEvents { cursor: Option<String>, max: usize },
@@ -1088,6 +1098,41 @@ fn send_lxmf_zmq_outbound_batch_via_actor(
                 "LXMF-rs ZeroMQ SDK actor returned non-batch response".to_string(),
             )),
         })
+}
+
+fn enqueue_lxmf_zmq_outbound_batch_via_actor(
+    config: &ZmqPipelineBackendConfig,
+    batch: LxmfSdkOutboundBatch,
+) -> Result<Vec<LxmfSdkOutboundBatchResult>, TransportError> {
+    if batch.messages.is_empty() {
+        return Ok(Vec::new());
+    }
+    let expected_results = batch
+        .messages
+        .iter()
+        .map(|message| LxmfSdkOutboundBatchResult {
+            id: message.correlation_id.clone(),
+            message_id: message.correlation_id.clone(),
+            destination: message.destination.clone(),
+        })
+        .collect::<Vec<_>>();
+    let sender = zmq_sdk_actor_sender(config)?;
+    let (response_tx, response_rx) = mpsc::channel();
+    drop(response_rx);
+    sender
+        .try_send(ZmqSdkActorRequest {
+            payload: ZmqSdkActorPayload::EnqueueBatch(batch),
+            response: response_tx,
+        })
+        .map_err(|error| match error {
+            mpsc::TrySendError::Full(_) => TransportError::Backpressure(format!(
+                "LXMF-rs ZeroMQ SDK send queue is full (capacity {LXMF_ZMQ_SEND_QUEUE_CAPACITY})"
+            )),
+            mpsc::TrySendError::Disconnected(_) => {
+                TransportError::Send("LXMF-rs ZeroMQ SDK send actor stopped".to_string())
+            }
+        })?;
+    Ok(expected_results)
 }
 
 fn lxmf_zmq_delivery_status_via_actor(
@@ -1362,6 +1407,11 @@ async fn send_lxmf_zmq_actor_request(
         ZmqSdkActorPayload::Batch(batch) => send_lxmf_zmq_actor_batch(session, config, batch)
             .await
             .map(ZmqSdkActorResponse::Batch),
+        ZmqSdkActorPayload::EnqueueBatch(batch) => {
+            send_lxmf_zmq_actor_enqueue_batch(session, config, batch)
+                .await
+                .map(ZmqSdkActorResponse::Batch)
+        }
         ZmqSdkActorPayload::Status(message_id) => {
             send_lxmf_zmq_actor_status(session, config, &message_id)
                 .await
@@ -1470,6 +1520,46 @@ async fn send_lxmf_zmq_actor_batch(
         });
     }
     Ok(output)
+}
+
+async fn send_lxmf_zmq_actor_enqueue_batch(
+    session: &mut ZmqSdkActorSession,
+    config: &ZmqPipelineBackendConfig,
+    batch: LxmfSdkOutboundBatch,
+) -> Result<Vec<LxmfSdkOutboundBatchResult>, TransportError> {
+    let expected_results = batch
+        .messages
+        .iter()
+        .map(|message| LxmfSdkOutboundBatchResult {
+            id: message.correlation_id.clone(),
+            message_id: message.correlation_id.clone(),
+            destination: message.destination.clone(),
+        })
+        .collect::<Vec<_>>();
+    let request_id = session.next_request_id;
+    session.next_request_id = session.next_request_id.saturating_add(1);
+    let rpc_request = ReticulumdRpcRequest {
+        id: request_id,
+        method: "sdk_send_batch_v2".to_string(),
+        params: Some(lxmf_sdk_outbound_batch_params(batch)),
+    };
+    let payload =
+        encode_frame(&rpc_request).map_err(|error| TransportError::Send(error.to_string()))?;
+    let envelope = ZmqRpcEnvelope::request(
+        session.session_id.clone(),
+        request_id,
+        config.response_endpoint.clone(),
+        payload,
+        None,
+    );
+    let encoded = zmq::encode_envelope(&envelope)
+        .map_err(|error| TransportError::Send(format!("LXMF-rs ZeroMQ envelope: {error}")))?;
+    session
+        .command
+        .send(ZmqMessage::from(encoded))
+        .await
+        .map_err(|error| TransportError::Send(format!("LXMF-rs ZeroMQ command: {error}")))?;
+    Ok(expected_results)
 }
 
 async fn send_lxmf_zmq_actor_status(


### PR DESCRIPTION
## Summary
- relay inbound direct LXMF phone messages to active generic LXMF clients when RCH has no explicit topic subscribers
- keep explicit direct-topic subscriber fanout targeted to the intended phone destinations
- reconcile SDK2 fanout target statuses even when the original topic message did not require a delivery receipt
- clear stale dispatch timeout/error metadata once a later handoff or delivery receipt succeeds

## Live HIL evidence
- Pixel Sideband and S8 Columba both connected to the Raspberry Pi Hub over ADB-reversed TCP `127.0.0.1:37430 -> reticulumd:4242`.
- Prior phone-originated relays succeeded in both directions:
  - S8 -> Pixel: RCH inbound `s8pxtest`, outbound relay `[topic:direct]\ns8pxtest`, target Pixel `52118fa6f1240342cb730dabdf1d4ca1`, state `delivered`, `acked=true`.
  - Pixel -> S8: RCH inbound `pixs8test`, outbound relay `[topic:direct]\npixs8test`, target S8 `3ac5987d6d5152a6213d9aa3e7d0d0cc`, state `delivered`, `acked=true`.
- New regression found during live Hub-originated probe: reticulumd recorded both phone targets as delivered, but RCH kept the fanout targets pending because `delivery_receipt_required=false` blocked status polling.
- After this fix was deployed on the Pi, probe `codex-hub-probe-awake-012541` reached RCH state `delivered`, `acked=true`, with both phone target statuses `delivered`.

## Tests
- `cargo test -p r3akt-rch-server status_poll_reconciles_fanout_targets_without_required_receipt -- --nocapture`
- `cargo test --locked -p r3akt-rch-server status_poll_reconciles_fanout_targets_without_required_receipt -- --nocapture`
- `cargo test -p r3akt-rch-server outbound_diagnostics_treats_reticulumd_sent_link_as_sent_not_failed -- --nocapture`
- `cargo test -p r3akt-rch-server outbound_diagnostics_persists_typed_sdk_delivery_snapshot -- --nocapture`
- `cargo test -p r3akt-rch-server delivered_receipt_clears_stale_dispatch_timeout_metadata -- --nocapture`

### Latest update: unavailable REM targets use propagation

- Preserves the server's propagated delivery decision for REM command messages when the destination has no fresh announce or is in direct-delivery cooldown, instead of rewriting the message back to `auto`.
- Keeps propagated REM command retries on the extended REM retry budget for dispatch and receipt timeouts.
- Adds regressions for unannounced REM destinations, direct-cooldown REM destinations, and receipt-timeout retry behavior.
- Live Pi deployment updated to commit `c8ea73e`; `/home/pgiuseppe/rch3/bin/r3akt-rch-server` matches the rebuilt release binary hash `7e2a5b25f92585d11a58babb28c7538c6fe5f526b115456dbb0570b27f3162dd`.
