### PR TITLE
[codex] Bound RCH telemetry state per identity

### DIFF
--- a/crates/r3akt-rch-core/src/lib.rs
+++ b/crates/r3akt-rch-core/src/lib.rs
@@ -1847,6 +1847,10 @@ impl RchSqliteStore {
     ) -> Result<(), RchCoreError> {
         let transaction = self.connection.transaction()?;
         transaction.execute(
+            "DELETE FROM rch_telemetry_records WHERE lower(peer_destination) = lower(?1)",
+            params![record.peer_destination],
+        )?;
+        transaction.execute(
             "INSERT INTO rch_telemetry_records (peer_destination, timestamp_s, payload)
              VALUES (?1, ?2, ?3)",
             params![
@@ -1855,10 +1859,33 @@ impl RchSqliteStore {
                 encode_msgpack(record)?
             ],
         )?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    pub fn prune_telemetry_records(
+        &mut self,
+        excluded_peer_destination: Option<&str>,
+    ) -> Result<(), RchCoreError> {
+        let transaction = self.connection.transaction()?;
+        if let Some(destination) = excluded_peer_destination {
+            transaction.execute(
+                "DELETE FROM rch_telemetry_records WHERE lower(peer_destination) = lower(?1)",
+                params![destination],
+            )?;
+        }
         transaction.execute(
             "DELETE FROM rch_telemetry_records
              WHERE id NOT IN (
-                 SELECT id FROM rch_telemetry_records ORDER BY id DESC LIMIT 1000
+                 SELECT keep.id
+                 FROM rch_telemetry_records AS keep
+                 WHERE keep.id = (
+                     SELECT candidate.id
+                     FROM rch_telemetry_records AS candidate
+                     WHERE lower(candidate.peer_destination) = lower(keep.peer_destination)
+                     ORDER BY candidate.timestamp_s DESC, candidate.id DESC
+                     LIMIT 1
+                 )
              )",
             [],
         )?;
@@ -2393,9 +2420,7 @@ impl RchSqliteStore {
         let system_events = self.load_payload_rows::<SystemEventRecord>(
             "SELECT payload FROM rch_system_events ORDER BY id",
         )?;
-        let telemetry_records = self.load_payload_rows::<TelemetryRecord>(
-            "SELECT payload FROM rch_telemetry_records ORDER BY peer_destination, timestamp_s",
-        )?;
+        let telemetry_records = self.load_latest_telemetry_records()?;
         let markers = self.load_payload_rows::<MarkerRecord>(
             "SELECT payload FROM rch_markers ORDER BY object_destination_hash",
         )?;
@@ -2863,6 +2888,21 @@ impl RchSqliteStore {
             records.push(decode_msgpack(&row?)?);
         }
         Ok(records)
+    }
+
+    fn load_latest_telemetry_records(&self) -> Result<Vec<TelemetryRecord>, RchCoreError> {
+        self.load_payload_rows::<TelemetryRecord>(
+            "SELECT payload
+             FROM rch_telemetry_records AS keep
+             WHERE keep.id = (
+                 SELECT candidate.id
+                 FROM rch_telemetry_records AS candidate
+                 WHERE lower(candidate.peer_destination) = lower(keep.peer_destination)
+                 ORDER BY candidate.timestamp_s DESC, candidate.id DESC
+                 LIMIT 1
+             )
+             ORDER BY lower(keep.peer_destination), keep.timestamp_s",
+        )
     }
 
     pub fn setting_value(&self, key: &str) -> Result<Option<String>, RchCoreError> {

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -477,8 +477,10 @@ impl AppState {
         endpoint: impl Into<String>,
         source: impl Into<String>,
     ) -> Self {
+        let source = source.into();
         self.reticulumd_rpc_endpoint = Some(Arc::new(endpoint.into()));
-        self.reticulumd_source = Some(Arc::new(source.into()));
+        self.reticulumd_source = Some(Arc::new(source.clone()));
+        self.prune_telemetry_for_local_source(&source);
         self
     }
 
@@ -539,9 +541,11 @@ impl AppState {
         response_endpoint: impl Into<String>,
         source: impl Into<String>,
     ) -> Self {
+        let source = source.into();
         self.lxmf_zmq_command_endpoint = Some(Arc::new(command_endpoint.into()));
         self.lxmf_zmq_response_endpoint = Some(Arc::new(response_endpoint.into()));
-        self.reticulumd_source = Some(Arc::new(source.into()));
+        self.reticulumd_source = Some(Arc::new(source.clone()));
+        self.prune_telemetry_for_local_source(&source);
         self
     }
 
@@ -678,8 +682,16 @@ impl AppState {
     pub fn from_sqlite_path(
         path: impl AsRef<FsPath>,
     ) -> Result<Self, r3akt_rch_core::RchCoreError> {
+        Self::from_sqlite_path_with_reticulumd_source(path, None)
+    }
+
+    pub fn from_sqlite_path_with_reticulumd_source(
+        path: impl AsRef<FsPath>,
+        reticulumd_source: Option<&str>,
+    ) -> Result<Self, r3akt_rch_core::RchCoreError> {
         let path = path.as_ref().to_path_buf();
-        let store = RchSqliteStore::open(&path)?;
+        let mut store = RchSqliteStore::open_admin(&path)?;
+        store.prune_telemetry_records(reticulumd_source)?;
         let snapshot = store.load_snapshot()?;
         let mut state = Self {
             messages: Arc::default(),
@@ -758,6 +770,27 @@ impl AppState {
             state.telemetry_records = Arc::new(RwLock::new(snapshot.telemetry_records));
         }
         Ok(state)
+    }
+
+    fn prune_telemetry_for_local_source(&self, source: &str) {
+        let Some(source_key) = telemetry_identity_key(source) else {
+            return;
+        };
+        if let Ok(mut records) = self.telemetry_records.write() {
+            let retained = latest_telemetry_records_for_identities(
+                std::mem::take(&mut *records),
+                Some(source_key.as_str()),
+            );
+            *records = retained;
+        }
+        if let Some(path) = &self.sqlite_path {
+            match RchSqliteStore::open_admin(path.as_ref())
+                .and_then(|mut store| store.prune_telemetry_records(Some(source)))
+            {
+                Ok(()) => {}
+                Err(error) => eprintln!("failed to prune local telemetry source: {error}"),
+            }
+        }
     }
 
     #[cfg(test)]
@@ -857,22 +890,36 @@ impl AppState {
         display_name: Option<String>,
     ) -> Result<TelemetryRecord, ApiError> {
         let display_name = normalize_optional_text(display_name);
+        let peer_destination = peer_destination.into();
         let record = TelemetryRecord {
-            peer_destination: peer_destination.into(),
+            peer_destination: peer_destination.clone(),
             timestamp_s,
             telemetry,
             identity_label: display_name.clone(),
             display_name,
         };
+        if self
+            .reticulumd_source
+            .as_deref()
+            .and_then(|source| telemetry_identity_key(source))
+            .is_some_and(|source_key| {
+                telemetry_identity_key(&peer_destination)
+                    .is_some_and(|peer_key| peer_key == source_key)
+            })
+        {
+            return Ok(record);
+        }
         let mut records = self
             .telemetry_records
             .write()
             .map_err(|error| ApiError::Internal(error.to_string()))?;
-        records.push(record.clone());
-        if records.len() > 1000 {
-            let overflow = records.len() - 1000;
-            records.drain(0..overflow);
+        if let Some(peer_key) = telemetry_identity_key(&record.peer_destination) {
+            records.retain(|existing| {
+                telemetry_identity_key(&existing.peer_destination)
+                    .is_none_or(|existing_key| existing_key != peer_key)
+            });
         }
+        records.push(record.clone());
         drop(records);
         persist_telemetry_record_row(self, &record)?;
         broadcast_telemetry_event(self, &record);
@@ -24532,6 +24579,38 @@ fn normalize_identity_key(identity: &str) -> Option<String> {
     if value.is_empty() { None } else { Some(value) }
 }
 
+fn telemetry_identity_key(identity: &str) -> Option<String> {
+    normalize_identity_key(identity)
+}
+
+fn latest_telemetry_records_for_identities(
+    records: Vec<TelemetryRecord>,
+    excluded_identity: Option<&str>,
+) -> Vec<TelemetryRecord> {
+    let mut latest = HashMap::<String, TelemetryRecord>::new();
+    for record in records {
+        let Some(identity) = telemetry_identity_key(&record.peer_destination) else {
+            continue;
+        };
+        if excluded_identity.is_some_and(|excluded| identity == excluded) {
+            continue;
+        }
+        let replace = latest
+            .get(&identity)
+            .is_none_or(|existing| record.timestamp_s >= existing.timestamp_s);
+        if replace {
+            latest.insert(identity, record);
+        }
+    }
+    let mut records = latest.into_values().collect::<Vec<_>>();
+    records.sort_by(|left, right| {
+        left.peer_destination
+            .cmp(&right.peer_destination)
+            .then_with(|| left.timestamp_s.cmp(&right.timestamp_s))
+    });
+    records
+}
+
 fn normalize_optional_text(value: Option<String>) -> Option<String> {
     value.and_then(|value| {
         let value = value.trim().to_string();
@@ -35223,7 +35302,7 @@ mod tests {
             .load_snapshot()
             .expect("load snapshot")
             .expect("snapshot exists");
-        assert_eq!(snapshot.telemetry_records.len(), 5);
+        assert_eq!(snapshot.telemetry_records.len(), 2);
         assert!(
             snapshot
                 .system_events
@@ -54919,6 +54998,138 @@ mod tests {
                 .expect("restored telemetry")
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn telemetry_records_keep_only_latest_snapshot_per_identity() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-telemetry-latest-per-peer-{}.db",
+            Uuid::new_v4()
+        ));
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+
+        state
+            .record_telemetry("peer-a", json!({"battery":{"percent": 50}}), 10, None)
+            .expect("record first telemetry");
+        state
+            .record_telemetry("peer-b", json!({"battery":{"percent": 80}}), 11, None)
+            .expect("record other telemetry");
+        state
+            .record_telemetry("peer-a", json!({"battery":{"percent": 95}}), 12, None)
+            .expect("record latest telemetry");
+
+        let records = state.telemetry_records.read().expect("telemetry records");
+        assert_eq!(records.len(), 2);
+        let peer_a = records
+            .iter()
+            .find(|record| record.peer_destination == "peer-a")
+            .expect("peer-a telemetry");
+        assert_eq!(peer_a.timestamp_s, 12);
+        assert_eq!(peer_a.telemetry["battery"]["percent"], 95);
+        drop(records);
+
+        let restored = crate::AppState::from_sqlite_path(&db_path).expect("restored");
+        let restored_records = restored
+            .telemetry_records
+            .read()
+            .expect("restored telemetry");
+        assert_eq!(restored_records.len(), 2);
+        assert_eq!(
+            restored_records
+                .iter()
+                .filter(|record| record.peer_destination == "peer-a")
+                .count(),
+            1
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn telemetry_records_ignore_configured_local_source() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-telemetry-ignore-source-{}.db",
+            Uuid::new_v4()
+        ));
+        let state = crate::AppState::from_sqlite_path(&db_path)
+            .expect("state")
+            .with_reticulumd_rpc("127.0.0.1:14243", "local-source");
+
+        state
+            .record_telemetry("local-source", json!({"time":{"timestamp": 10}}), 10, None)
+            .expect("ignore local telemetry");
+
+        assert!(
+            state
+                .telemetry_records
+                .read()
+                .expect("telemetry records")
+                .is_empty()
+        );
+        let restored = crate::AppState::from_sqlite_path(&db_path).expect("restored");
+        assert!(
+            restored
+                .telemetry_records
+                .read()
+                .expect("restored telemetry")
+                .is_empty()
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn attaching_local_source_prunes_existing_self_and_duplicate_telemetry_rows() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-telemetry-prune-source-{}.db",
+            Uuid::new_v4()
+        ));
+        let mut store = r3akt_rch_core::RchSqliteStore::open(&db_path).expect("sqlite");
+        let mut snapshot = r3akt_rch_core::RchCore::new().snapshot();
+        snapshot.telemetry_records = vec![
+            r3akt_rch_core::TelemetryRecord {
+                peer_destination: "local-source".to_string(),
+                timestamp_s: 1,
+                telemetry: json!({"self": true}),
+                identity_label: None,
+                display_name: None,
+            },
+            r3akt_rch_core::TelemetryRecord {
+                peer_destination: "peer-a".to_string(),
+                timestamp_s: 2,
+                telemetry: json!({"battery":{"percent": 20}}),
+                identity_label: None,
+                display_name: None,
+            },
+            r3akt_rch_core::TelemetryRecord {
+                peer_destination: "peer-a".to_string(),
+                timestamp_s: 3,
+                telemetry: json!({"battery":{"percent": 30}}),
+                identity_label: None,
+                display_name: None,
+            },
+        ];
+        store.save_snapshot(&snapshot).expect("save snapshot");
+
+        let state = crate::AppState::from_sqlite_path(&db_path)
+            .expect("state")
+            .with_reticulumd_rpc("127.0.0.1:14243", "local-source");
+        let records = state.telemetry_records.read().expect("telemetry records");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].peer_destination, "peer-a");
+        assert_eq!(records[0].timestamp_s, 3);
+        drop(records);
+
+        let restored = crate::AppState::from_sqlite_path(&db_path).expect("restored");
+        let restored_records = restored
+            .telemetry_records
+            .read()
+            .expect("restored telemetry");
+        assert_eq!(restored_records.len(), 1);
+        assert_eq!(restored_records[0].peer_destination, "peer-a");
+        assert_eq!(restored_records[0].timestamp_s, 3);
+
+        let _ = std::fs::remove_file(db_path);
     }
 
     #[tokio::test]

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -914,6 +914,14 @@ impl AppState {
             .write()
             .map_err(|error| ApiError::Internal(error.to_string()))?;
         if let Some(peer_key) = telemetry_identity_key(&record.peer_destination) {
+            if let Some(existing) = records.iter().find(|existing| {
+                telemetry_identity_key(&existing.peer_destination)
+                    .is_some_and(|existing_key| existing_key == peer_key)
+            }) {
+                if existing.timestamp_s > record.timestamp_s {
+                    return Ok(existing.clone());
+                }
+            }
             records.retain(|existing| {
                 telemetry_identity_key(&existing.peer_destination)
                     .is_none_or(|existing_key| existing_key != peer_key)
@@ -25337,6 +25345,7 @@ mod tests {
         ReticulumdEventRecord, ReticulumdRpcLxmfRsAdapter, ReticulumdRpcTransport,
         poll_lxmf_zmq_events, send_lxmf_zmq_outbound_message,
     };
+    use rusqlite::Connection;
     use serde::Serialize;
     use serde_json::{Value, json};
     use sha2::{Digest, Sha256};
@@ -55017,6 +55026,11 @@ mod tests {
         state
             .record_telemetry("peer-a", json!({"battery":{"percent": 95}}), 12, None)
             .expect("record latest telemetry");
+        let stale = state
+            .record_telemetry("peer-a", json!({"battery":{"percent": 10}}), 9, None)
+            .expect("ignore stale telemetry");
+        assert_eq!(stale.timestamp_s, 12);
+        assert_eq!(stale.telemetry["battery"]["percent"], 95);
 
         let records = state.telemetry_records.read().expect("telemetry records");
         assert_eq!(records.len(), 2);
@@ -55027,6 +55041,16 @@ mod tests {
         assert_eq!(peer_a.timestamp_s, 12);
         assert_eq!(peer_a.telemetry["battery"]["percent"], 95);
         drop(records);
+
+        let connection = Connection::open(&db_path).expect("sqlite connection");
+        let peer_a_rows: i64 = connection
+            .query_row(
+                "SELECT count(*) FROM rch_telemetry_records WHERE peer_destination = 'peer-a'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("peer-a row count");
+        assert_eq!(peer_a_rows, 1);
 
         let restored = crate::AppState::from_sqlite_path(&db_path).expect("restored");
         let restored_records = restored

--- a/crates/r3akt-rch-server/src/main.rs
+++ b/crates/r3akt-rch-server/src/main.rs
@@ -205,64 +205,14 @@ fn build_runtime_state(
     let mut state = match args.db_path {
         Some(ref path) => {
             println!("r3akt-rch-server using SQLite state at {}", path.display());
-            let mut state = r3akt_rch_server::AppState::from_sqlite_path(path)?
-                .with_optional_api_key(api_key)
-                .with_optional_system_status_fanout_mode(system_status_fanout_mode)
-                .with_outbound_identity_allowlist(args.outbound_allowlist.clone());
-            if let Some(path) = &args.config_path {
-                state = state.with_config_path(path);
-            }
-            if let Some(path) = &args.reticulum_config_path {
-                state = state.with_reticulum_config_path(path);
-            }
-            if let Some(endpoint) = &args.reticulumd_rpc {
-                let source = args
-                    .reticulumd_source
-                    .as_deref()
-                    .ok_or("--reticulumd-source is required with --reticulumd-rpc")?;
-                state = state.with_reticulumd_rpc(endpoint.as_str(), source);
-            }
-            if let (Some(command), Some(response)) =
-                (&args.lxmf_zmq_command, &args.lxmf_zmq_response)
-            {
-                let source = args
-                    .reticulumd_source
-                    .as_deref()
-                    .ok_or("--reticulumd-source is required with --lxmf-zmq-command")?;
-                state = state.with_lxmf_zmq_sdk(command.as_str(), response.as_str(), source);
-            }
-            state
+            r3akt_rch_server::AppState::from_sqlite_path_with_reticulumd_source(
+                path,
+                args.reticulumd_source.as_deref(),
+            )?
         }
-        None => {
-            let mut state = r3akt_rch_server::AppState::default()
-                .with_optional_api_key(api_key)
-                .with_optional_system_status_fanout_mode(system_status_fanout_mode)
-                .with_outbound_identity_allowlist(args.outbound_allowlist.clone());
-            if let Some(path) = &args.config_path {
-                state = state.with_config_path(path);
-            }
-            if let Some(path) = &args.reticulum_config_path {
-                state = state.with_reticulum_config_path(path);
-            }
-            if let Some(endpoint) = &args.reticulumd_rpc {
-                let source = args
-                    .reticulumd_source
-                    .as_deref()
-                    .ok_or("--reticulumd-source is required with --reticulumd-rpc")?;
-                state = state.with_reticulumd_rpc(endpoint.as_str(), source);
-            }
-            if let (Some(command), Some(response)) =
-                (&args.lxmf_zmq_command, &args.lxmf_zmq_response)
-            {
-                let source = args
-                    .reticulumd_source
-                    .as_deref()
-                    .ok_or("--reticulumd-source is required with --lxmf-zmq-command")?;
-                state = state.with_lxmf_zmq_sdk(command.as_str(), response.as_str(), source);
-            }
-            state
-        }
+        None => r3akt_rch_server::AppState::default(),
     };
+    state = apply_runtime_config(state, args, api_key, system_status_fanout_mode)?;
     if let Some(command_endpoint) = managed_reticulumd_launch.zmq_command.clone() {
         if let Some(exe) = managed_reticulumd_launch.exe.as_ref() {
             state = state
@@ -291,6 +241,39 @@ fn build_runtime_state(
                 )
                 .with_managed_reticulumd_transport(managed_reticulumd_launch.transport.clone());
         }
+    }
+    Ok(state)
+}
+
+fn apply_runtime_config(
+    mut state: r3akt_rch_server::AppState,
+    args: &ServerArgs,
+    api_key: Option<String>,
+    system_status_fanout_mode: Option<String>,
+) -> Result<r3akt_rch_server::AppState, Box<dyn std::error::Error>> {
+    state = state
+        .with_optional_api_key(api_key)
+        .with_optional_system_status_fanout_mode(system_status_fanout_mode)
+        .with_outbound_identity_allowlist(args.outbound_allowlist.clone());
+    if let Some(path) = &args.config_path {
+        state = state.with_config_path(path);
+    }
+    if let Some(path) = &args.reticulum_config_path {
+        state = state.with_reticulum_config_path(path);
+    }
+    if let Some(endpoint) = &args.reticulumd_rpc {
+        let source = args
+            .reticulumd_source
+            .as_deref()
+            .ok_or("--reticulumd-source is required with --reticulumd-rpc")?;
+        state = state.with_reticulumd_rpc(endpoint.as_str(), source);
+    }
+    if let (Some(command), Some(response)) = (&args.lxmf_zmq_command, &args.lxmf_zmq_response) {
+        let source = args
+            .reticulumd_source
+            .as_deref()
+            .ok_or("--reticulumd-source is required with --lxmf-zmq-command")?;
+        state = state.with_lxmf_zmq_sdk(command.as_str(), response.as_str(), source);
     }
     Ok(state)
 }


### PR DESCRIPTION
## Summary
- Store and load only the latest telemetry snapshot per peer identity instead of retaining historical rows in memory.
- Ignore telemetry from the configured local `reticulumd_source`, and prune existing self-source telemetry when runtime state is loaded.
- Add regression coverage for per-identity replacement, self-source filtering, and startup pruning of duplicate/self telemetry rows.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p r3akt-rch-core`
- `cargo test -p r3akt-rch-server`
- `cargo clippy -p r3akt-rch-core -p r3akt-rch-server --all-targets -- -D warnings`
- Large DB copy smoke: `100355` telemetry rows collapsed to `104`; test server reported `telemetry.ingest_count = 104` and about `7.7 MB` private memory.