### PR TITLE
[codex] Fallback timed-out broadcasts to propagation

### DIFF
--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -13911,7 +13911,9 @@ fn dispatch_outbound_message(
         .reticulumd_source
         .as_ref()
         .map_or("r3akt-rch-server", |value| value.as_str());
-    ensure_outbound_propagation_node_selected(state, message)?;
+    if should_select_outbound_propagation_node(message) {
+        ensure_outbound_propagation_node_selected(state, message)?;
+    }
     let destinations = outbound_destinations(state, message)?;
     let fanout_destination_count = destinations.len();
     let fanout_requires_child_ids = fanout_destination_count > 1;
@@ -14135,6 +14137,14 @@ fn ensure_outbound_propagation_node_selected(
         )));
     }
     Ok(())
+}
+
+fn should_select_outbound_propagation_node(message: &OutboundMessageRecord) -> bool {
+    message.delivery_method == "propagated"
+        && !matches!(
+            message.delivery_mode,
+            DeliveryMode::Broadcast | DeliveryMode::Fanout
+        )
 }
 
 fn reticulumd_rpc_error_text(error: &r3akt_rch_bridge::ReticulumdRpcError) -> String {
@@ -15408,7 +15418,16 @@ fn refresh_reticulumd_announces_for_state(state: &AppState) {
 }
 
 fn broadcast_client_records_for_state(state: &AppState) -> Result<Vec<ClientRecord>, ApiError> {
-    refresh_reticulumd_announces_for_state(state);
+    broadcast_client_records_for_state_with_refresh(state, true)
+}
+
+fn broadcast_client_records_for_state_with_refresh(
+    state: &AppState,
+    refresh_announces: bool,
+) -> Result<Vec<ClientRecord>, ApiError> {
+    if refresh_announces {
+        refresh_reticulumd_announces_for_state(state);
+    }
     let mut records = client_records_for_state(state)?;
     records.sort_by(|left, right| left.identity.cmp(&right.identity));
     Ok(records)
@@ -15417,9 +15436,34 @@ fn broadcast_client_records_for_state(state: &AppState) -> Result<Vec<ClientReco
 fn broadcast_outbound_client_records_for_state(
     state: &AppState,
 ) -> Result<Vec<ClientRecord>, ApiError> {
+    broadcast_outbound_client_records_for_state_with_refresh(state, true)
+}
+
+fn broadcast_outbound_client_records_for_message(
+    state: &AppState,
+    message: &OutboundMessageRecord,
+) -> Result<Vec<ClientRecord>, ApiError> {
+    if should_enqueue_without_waiting_for_zmq_response(message) {
+        return broadcast_client_records_for_state_with_refresh(state, false);
+    }
+    broadcast_outbound_client_records_for_state_with_refresh(
+        state,
+        !should_enqueue_without_waiting_for_zmq_response(message),
+    )
+}
+
+fn broadcast_outbound_client_records_for_state_with_refresh(
+    state: &AppState,
+    refresh_announces: bool,
+) -> Result<Vec<ClientRecord>, ApiError> {
     let now = unix_now_ms();
     let routing_context = outbound_destination_routing_context(state)?;
-    Ok(broadcast_client_records_for_state(state)?
+    let records = if refresh_announces {
+        broadcast_client_records_for_state(state)?
+    } else {
+        broadcast_client_records_for_state_with_refresh(state, false)?
+    };
+    Ok(records
         .into_iter()
         .filter(|client| {
             let delivery_destination = outbound_destination_for_message_with_context_for_mode(
@@ -15507,7 +15551,7 @@ fn outbound_destinations(
             }
         }
     } else {
-        for client in broadcast_outbound_client_records_for_state(state)? {
+        for client in broadcast_outbound_client_records_for_message(state, message)? {
             let delivery_destination = outbound_destination_for_message_with_context(
                 message,
                 &client.identity,
@@ -55206,6 +55250,145 @@ mod tests {
         assert_eq!(report.receipts.len(), 1);
         assert_eq!(report.receipts[0].message_id, "propagated-single");
         assert_eq!(report.receipts[0].destination, "target-destination");
+    }
+
+    #[test]
+    fn propagated_broadcast_dispatch_skips_slow_node_selection_before_zmq_enqueue() {
+        let state = crate::AppState::default()
+            .with_reticulumd_rpc("127.0.0.1:1", "source-destination")
+            .with_lxmf_zmq_sdk(
+                unused_zmq_endpoint_for_rch_test(),
+                unused_zmq_endpoint_for_rch_test(),
+                "source-destination",
+            );
+        let now = crate::unix_now_ms();
+        for identity in [
+            "22c8ba9c883e06c7e540ed6dc87ceecf",
+            "77b2539b72259af927e48c0f90721767",
+        ] {
+            state.clients.write().expect("clients").insert(
+                identity.to_string(),
+                crate::ClientRecord::new(identity.to_string(), now),
+            );
+        }
+        let message = crate::OutboundMessageRecord {
+            message_id: "propagated-broadcast".to_string(),
+            topic_id: None,
+            destination: None,
+            sender: "northbound".to_string(),
+            content: "propagated broadcast".to_string(),
+            delivery_mode: r3akt_rch_core::DeliveryMode::Broadcast,
+            delivery_method: "propagated".to_string(),
+            delivery_policy_reason: "broadcast_direct_timeout_fallback".to_string(),
+            delivery_state: "queued".to_string(),
+            delivery_metadata: json!({}),
+            created_ts_ms: now,
+            attachments: Vec::new(),
+        };
+
+        let report = crate::dispatch_outbound_message(&state, &message).expect("dispatch");
+
+        assert_eq!(report.count, 2);
+        assert_eq!(report.receipts.len(), 2);
+        assert!(
+            report
+                .receipts
+                .iter()
+                .any(|receipt| receipt.destination == "22c8ba9c883e06c7e540ed6dc87ceecf")
+        );
+        assert!(
+            report
+                .receipts
+                .iter()
+                .any(|receipt| receipt.destination == "77b2539b72259af927e48c0f90721767")
+        );
+    }
+
+    #[test]
+    fn propagated_broadcast_dispatch_skips_announce_refresh_before_zmq_enqueue() {
+        let (endpoint, rpc_server) = fake_reticulumd_rpc_server_with_results_and_accept_timeout(
+            vec![empty_reticulumd_announce_response()],
+            Duration::from_millis(200),
+        );
+        let state = crate::AppState::default()
+            .with_reticulumd_rpc(endpoint, "source-destination")
+            .with_lxmf_zmq_sdk(
+                unused_zmq_endpoint_for_rch_test(),
+                unused_zmq_endpoint_for_rch_test(),
+                "source-destination",
+            );
+        let now = crate::unix_now_ms();
+        for identity in [
+            "22c8ba9c883e06c7e540ed6dc87ceecf",
+            "77b2539b72259af927e48c0f90721767",
+        ] {
+            state.clients.write().expect("clients").insert(
+                identity.to_string(),
+                crate::ClientRecord::new(identity.to_string(), now),
+            );
+        }
+        let message = crate::OutboundMessageRecord {
+            message_id: "propagated-broadcast-no-refresh".to_string(),
+            topic_id: None,
+            destination: None,
+            sender: "northbound".to_string(),
+            content: "propagated broadcast no refresh".to_string(),
+            delivery_mode: r3akt_rch_core::DeliveryMode::Broadcast,
+            delivery_method: "propagated".to_string(),
+            delivery_policy_reason: "broadcast_direct_timeout_fallback".to_string(),
+            delivery_state: "queued".to_string(),
+            delivery_metadata: json!({}),
+            created_ts_ms: now,
+            attachments: Vec::new(),
+        };
+
+        let report = crate::dispatch_outbound_message(&state, &message).expect("dispatch");
+
+        assert_eq!(report.count, 2);
+        let requests = rpc_server.join().expect("rpc server");
+        assert!(
+            requests.is_empty(),
+            "propagated broadcast dispatch refreshed announces before enqueue: {requests:?}"
+        );
+    }
+
+    #[test]
+    fn propagated_broadcast_dispatch_includes_stale_known_clients() {
+        let state = crate::AppState::default().with_lxmf_zmq_sdk(
+            unused_zmq_endpoint_for_rch_test(),
+            unused_zmq_endpoint_for_rch_test(),
+            "source-destination",
+        );
+        let now = crate::unix_now_ms();
+        let stale_ts_ms = now - r3akt_rch_core::RECENT_RUNTIME_PRESENCE_WINDOW_MS - 10_000;
+        for identity in [
+            "22c8ba9c883e06c7e540ed6dc87ceecf",
+            "77b2539b72259af927e48c0f90721767",
+        ] {
+            state.clients.write().expect("clients").insert(
+                identity.to_string(),
+                crate::ClientRecord::new(identity.to_string(), stale_ts_ms),
+            );
+        }
+        let message = crate::OutboundMessageRecord {
+            message_id: "propagated-broadcast-stale-clients".to_string(),
+            topic_id: None,
+            destination: None,
+            sender: "northbound".to_string(),
+            content: "propagated broadcast stale clients".to_string(),
+            delivery_mode: r3akt_rch_core::DeliveryMode::Broadcast,
+            delivery_method: "propagated".to_string(),
+            delivery_policy_reason: "broadcast_direct_timeout_fallback".to_string(),
+            delivery_state: "queued".to_string(),
+            delivery_metadata: json!({}),
+            created_ts_ms: now,
+            attachments: Vec::new(),
+        };
+
+        let report = crate::dispatch_outbound_message(&state, &message).expect("dispatch");
+
+        assert_eq!(report.count, 2);
+        assert_eq!(report.receipts.len(), 2);
     }
 
     #[test]

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -98,6 +98,7 @@ const OUTBOUND_RETRY_WORKER_POLL_MS: u64 = 500;
 const OUTBOUND_RETRY_BACKOFF_MS: i64 = 500;
 const OUTBOUND_RATE_LIMIT_RETRY_BACKOFF_MS: i64 = 65_000;
 const OUTBOUND_RETRY_MAX_ATTEMPTS: u64 = 2;
+const OUTBOUND_PROPAGATED_MULTI_RECIPIENT_RETRY_MAX_ATTEMPTS: u64 = 5;
 const OUTBOUND_PROPAGATION_STAMP_COST: u32 = 16;
 const RETICULUMD_RECEIPT_STATUS_POLL_MS: i64 = 5_000;
 const RETICULUMD_INBOUND_WORKER_POLL_MS: u64 = 1_000;
@@ -11710,6 +11711,38 @@ fn finalize_stale_pending_dispatches(state: &AppState) -> Result<(), ApiError> {
             }
         }
         let attempts = outbound_attempts(message).saturating_add(1);
+        if direct_broadcast_dispatch_timeout_should_propagate(message) {
+            message.delivery_state = "queued".to_string();
+            message.delivery_method = "propagated".to_string();
+            message.delivery_policy_reason = "broadcast_direct_timeout_fallback".to_string();
+            clear_retry_superseded_delivery_metadata(&mut message.delivery_metadata);
+            merge_delivery_metadata(
+                &mut message.delivery_metadata,
+                json!({
+                    "acked": false,
+                    "attempts": 0,
+                    "direct_attempts": attempts,
+                    "dispatch_status": "queued",
+                    "dispatch_timeout": true,
+                    "dispatch_timed_out_at_ts_ms": now_ms,
+                    "error": "send_timeout",
+                    "fallback_reason": "direct_dispatch_timeout",
+                    "max_attempts": OUTBOUND_PROPAGATED_MULTI_RECIPIENT_RETRY_MAX_ATTEMPTS,
+                    "previous_delivery_method": "direct",
+                    "receipt_pending": false,
+                    "retry_reason": "send_timeout",
+                    "retry_scheduled": true,
+                    "next_attempt_at_ts_ms": now_ms,
+                }),
+            );
+            changed_messages.push(message.clone());
+            system_events.push((
+                "message_propagation_queued",
+                "Direct broadcast timed out; queued message for propagation".to_string(),
+                outbound_delivery_propagation_metadata(message, "direct_dispatch_timeout"),
+            ));
+            continue;
+        }
         let max_attempts = outbound_effective_max_attempts_for_retry(message, false);
         if (message.delivery_method != "propagated"
             || is_rem_command_message(message)
@@ -11792,6 +11825,12 @@ fn finalize_stale_pending_dispatches(state: &AppState) -> Result<(), ApiError> {
         let _ = record_system_event(state, event_type, &message, metadata)?;
     }
     Ok(())
+}
+
+fn direct_broadcast_dispatch_timeout_should_propagate(message: &OutboundMessageRecord) -> bool {
+    message.delivery_method == "direct"
+        && message.delivery_mode == DeliveryMode::Broadcast
+        && !is_rem_command_message(message)
 }
 
 fn finalize_expired_delivery_receipts(state: &AppState) -> Result<(), ApiError> {
@@ -14513,7 +14552,7 @@ fn outbound_effective_max_attempts_for_retry(
         || rate_limited
         || propagated_multi_recipient_allows_partial_success(message)
     {
-        max_attempts = max_attempts.max(5);
+        max_attempts = max_attempts.max(OUTBOUND_PROPAGATED_MULTI_RECIPIENT_RETRY_MAX_ATTEMPTS);
     }
     max_attempts
 }
@@ -50085,6 +50124,122 @@ mod tests {
         .expect("record next message");
         assert_eq!(next_message.delivery_method, "propagated");
         assert_eq!(next_message.delivery_policy_reason, "direct_cooldown");
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn direct_broadcast_dispatch_timeout_falls_back_to_propagation() {
+        let db_path = std::env::temp_dir().join(format!(
+            "r3akt-rch-broadcast-timeout-propagation-{}.db",
+            Uuid::new_v4()
+        ));
+        let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+        let now_ms = crate::unix_now_ms();
+        let first_client = "22c8ba9c883e06c7e540ed6dc87ceecf";
+        let second_client = "77b2539b72259af927e48c0f90721767";
+        {
+            let mut clients = state.clients.write().expect("clients");
+            clients.insert(
+                first_client.to_string(),
+                crate::ClientRecord::new(first_client.to_string(), now_ms - 1_000),
+            );
+            clients.insert(
+                second_client.to_string(),
+                crate::ClientRecord::new(second_client.to_string(), now_ms - 1_000),
+            );
+        }
+
+        let message = crate::record_outbound_message(
+            &state,
+            "broadcast should fallback",
+            None,
+            None,
+            vec![],
+            false,
+        )
+        .expect("record broadcast");
+        assert_eq!(
+            message.delivery_mode,
+            r3akt_rch_core::DeliveryMode::Broadcast
+        );
+        assert_eq!(message.delivery_method, "direct");
+        assert_eq!(message.delivery_policy_reason, "broadcast_direct");
+
+        crate::update_outbound_delivery_state(
+            &state,
+            message.message_id.as_str(),
+            "queued",
+            json!({
+                "attempts": 3,
+                "max_attempts": 1,
+                "dispatch_status": "in_progress",
+                "dispatch_started_ts_ms": now_ms - 60_000,
+                "dispatch_deadline_ts_ms": now_ms - 1,
+                "retry_scheduled": false,
+            }),
+        )
+        .expect("mark stale dispatch");
+
+        let diagnostics = crate::outbound_delivery_diagnostics(&state).expect("diagnostics");
+        assert_eq!(diagnostics["pending_dispatches"], 0);
+        assert_eq!(diagnostics["queued"], 1);
+        assert_eq!(diagnostics["failed"], 0);
+        assert_eq!(diagnostics["timeout_total"], 1);
+
+        let messages = state.messages.read().expect("messages");
+        let updated = messages
+            .iter()
+            .find(|candidate| candidate.message_id == message.message_id)
+            .expect("updated message");
+        assert_eq!(updated.delivery_state, "queued");
+        assert_eq!(updated.delivery_method, "propagated");
+        assert_eq!(
+            updated.delivery_policy_reason,
+            "broadcast_direct_timeout_fallback"
+        );
+        assert_eq!(updated.delivery_metadata["dispatch_status"], "queued");
+        assert_eq!(updated.delivery_metadata["dispatch_timeout"], true);
+        assert_eq!(updated.delivery_metadata["error"], "send_timeout");
+        assert_eq!(updated.delivery_metadata["attempts"], 0);
+        assert_eq!(updated.delivery_metadata["direct_attempts"], 4);
+        assert_eq!(
+            updated.delivery_metadata["max_attempts"],
+            crate::OUTBOUND_PROPAGATED_MULTI_RECIPIENT_RETRY_MAX_ATTEMPTS
+        );
+        assert_eq!(
+            updated.delivery_metadata["fallback_reason"],
+            "direct_dispatch_timeout"
+        );
+        assert_eq!(updated.delivery_metadata["retry_scheduled"], true);
+        let updated_for_retry = updated.clone();
+        drop(messages);
+
+        let retry = crate::schedule_outbound_retry_after_failure(
+            &state,
+            &updated_for_retry,
+            "outbound request failed: No connection could be made because the target machine actively refused it. (os error 10061)".to_string(),
+        )
+        .expect("schedule propagated retry")
+        .expect("fallback broadcast send_error should retry");
+        assert_eq!(retry.delivery_state, "queued");
+        assert_eq!(retry.delivery_method, "propagated");
+        assert_eq!(retry.delivery_metadata["attempts"], 1);
+        assert_eq!(retry.delivery_metadata["direct_attempts"], 4);
+        assert_eq!(retry.delivery_metadata["retry_reason"], "send_error");
+        assert_eq!(retry.delivery_metadata["retry_scheduled"], true);
+
+        let events = state.system_events.read().expect("events");
+        let propagation_event = events
+            .iter()
+            .find(|event| event.event_type == "message_propagation_queued")
+            .expect("propagation event");
+        assert_eq!(
+            propagation_event.metadata["fallback_reason"],
+            "direct_dispatch_timeout"
+        );
+        assert_eq!(propagation_event.metadata["route_type"], "broadcast");
+        drop(events);
 
         let _ = std::fs::remove_file(db_path);
     }

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -11739,7 +11739,10 @@ fn finalize_stale_pending_dispatches(state: &AppState) -> Result<(), ApiError> {
             system_events.push((
                 "message_propagation_queued",
                 "Direct broadcast timed out; queued message for propagation".to_string(),
-                outbound_delivery_propagation_metadata(message, "direct_dispatch_timeout"),
+                outbound_delivery_callback_metadata(
+                    outbound_delivery_propagation_metadata(message, "direct_dispatch_timeout"),
+                    "propagation_fallback",
+                ),
             ));
             continue;
         }
@@ -50282,8 +50285,19 @@ mod tests {
             propagation_event.metadata["fallback_reason"],
             "direct_dispatch_timeout"
         );
+        assert_eq!(
+            propagation_event.metadata["callback_source"],
+            "reticulumd_internal_adapter"
+        );
+        assert_eq!(
+            propagation_event.metadata["callback_type"],
+            "propagation_fallback"
+        );
         assert_eq!(propagation_event.metadata["route_type"], "broadcast");
         drop(events);
+
+        let diagnostics = crate::outbound_delivery_diagnostics(&state).expect("diagnostics");
+        assert_eq!(diagnostics["propagation_fallback_total"], 1);
 
         let _ = std::fs::remove_file(db_path);
     }

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -10636,7 +10636,9 @@ fn outbound_delivery_diagnostics_with_refresh(
             .delivery_metadata
             .get("fallback_reason")
             .and_then(Value::as_str)
-            .is_some_and(|reason| reason == "direct_delivery_failed")
+            .is_some_and(|reason| {
+                matches!(reason, "direct_delivery_failed" | "direct_dispatch_timeout")
+            })
             || message
                 .delivery_metadata
                 .get("local_propagation_fallback")
@@ -14473,7 +14475,9 @@ fn schedule_outbound_retry_after_failure(
     let attempts = outbound_attempts(message).saturating_add(1);
     let rate_limited = outbound_error_is_rate_limited(error_text.as_str());
     let max_attempts = outbound_effective_max_attempts_for_retry(message, rate_limited);
-    if attempts >= max_attempts {
+    if attempts >= max_attempts
+        && !propagated_broadcast_fallback_should_retry_transport_failure(message, &error_text)
+    {
         return Ok(None);
     }
     let retry_reason = retry_reason_for_error(error_text.as_str());
@@ -14519,6 +14523,23 @@ fn outbound_error_is_rate_limited(error_text: &str) -> bool {
     normalized.contains("sdk_security_rate_limited")
         || normalized.contains("rate limit")
         || normalized.contains("rate_limited")
+}
+
+fn propagated_broadcast_fallback_should_retry_transport_failure(
+    message: &OutboundMessageRecord,
+    error_text: &str,
+) -> bool {
+    message.delivery_method == "propagated"
+        && message.delivery_mode == DeliveryMode::Broadcast
+        && message.delivery_policy_reason == "broadcast_direct_timeout_fallback"
+        && outbound_error_is_local_transport_unavailable(error_text)
+}
+
+fn outbound_error_is_local_transport_unavailable(error_text: &str) -> bool {
+    let normalized = error_text.trim().to_ascii_lowercase();
+    normalized.contains("connection refused")
+        || normalized.contains("actively refused")
+        || normalized.contains("os error 10061")
 }
 
 fn retry_reason_for_error(error_text: &str) -> &'static str {
@@ -50275,6 +50296,47 @@ mod tests {
         assert_eq!(retry.delivery_metadata["direct_attempts"], 4);
         assert_eq!(retry.delivery_metadata["retry_reason"], "send_error");
         assert_eq!(retry.delivery_metadata["retry_scheduled"], true);
+
+        crate::update_outbound_delivery_state(
+            &state,
+            message.message_id.as_str(),
+            "queued",
+            json!({
+                "attempts": crate::OUTBOUND_PROPAGATED_MULTI_RECIPIENT_RETRY_MAX_ATTEMPTS,
+                "dispatch_status": "queued",
+                "retry_scheduled": true,
+                "next_attempt_at_ts_ms": crate::unix_now_ms() - 1,
+            }),
+        )
+        .expect("mark fallback at propagated retry budget");
+        let exhausted_for_retry = state
+            .messages
+            .read()
+            .expect("messages")
+            .iter()
+            .find(|candidate| candidate.message_id == message.message_id)
+            .cloned()
+            .expect("exhausted message");
+        let exhausted_retry = crate::schedule_outbound_retry_after_failure(
+            &state,
+            &exhausted_for_retry,
+            "outbound request failed: No connection could be made because the target machine actively refused it. (os error 10061)".to_string(),
+        )
+        .expect("schedule transport-unavailable propagated retry")
+        .expect("transport-unavailable fallback broadcast should stay queued");
+        assert_eq!(exhausted_retry.delivery_state, "queued");
+        assert_eq!(exhausted_retry.delivery_method, "propagated");
+        assert!(
+            exhausted_retry.delivery_metadata["attempts"]
+                .as_u64()
+                .expect("attempts")
+                > crate::OUTBOUND_PROPAGATED_MULTI_RECIPIENT_RETRY_MAX_ATTEMPTS
+        );
+        assert_eq!(
+            exhausted_retry.delivery_metadata["retry_reason"],
+            "send_error"
+        );
+        assert_eq!(exhausted_retry.delivery_metadata["retry_scheduled"], true);
 
         let events = state.system_events.read().expect("events");
         let propagation_event = events

--- a/crates/r3akt-transport-rns/Cargo.toml
+++ b/crates/r3akt-transport-rns/Cargo.toml
@@ -8,10 +8,10 @@ repository.workspace = true
 
 [dependencies]
 base64.workspace = true
-lxmf = { package = "lxmf-wire", path = "../../../LXMF-rs/crates/libs/lxmf-core", version = "0.2.0", default-features = false, features = ["std"] }
-lxmf-sdk = { path = "../../../LXMF-rs/crates/libs/lxmf-sdk", version = "0.2.1", default-features = false, features = ["zmq-pipeline-backend"] }
+lxmf = { package = "lxmf-wire", path = "../../../LXMF-rs/crates/libs/lxmf-core", version = ">=0.2.0, <0.6.0", default-features = false, features = ["std"] }
+lxmf-sdk = { path = "../../../LXMF-rs/crates/libs/lxmf-sdk", version = ">=0.2.1, <0.6.0", default-features = false, features = ["zmq-pipeline-backend"] }
 r3akt-protocol.workspace = true
-rns-rpc = { package = "reticulum-rs-rpc", path = "../../../LXMF-rs/crates/libs/rns-rpc", version = "0.3.0" }
+rns-rpc = { package = "reticulum-rs-rpc", path = "../../../LXMF-rs/crates/libs/rns-rpc", version = ">=0.3.0, <0.6.0" }
 rmp-serde.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/r3akt-transport-rns/src/lib.rs
+++ b/crates/r3akt-transport-rns/src/lib.rs
@@ -3246,18 +3246,28 @@ mod tests {
         (endpoint, server)
     }
 
-    fn unused_zmq_endpoint() -> String {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve tcp port");
-        let port = listener.local_addr().expect("local addr").port();
-        drop(listener);
-        format!("tcp://localhost:{port}")
+    fn unused_zmq_endpoint_pair() -> (String, String) {
+        let command = TcpListener::bind("127.0.0.1:0").expect("reserve command tcp port");
+        let response = TcpListener::bind("127.0.0.1:0").expect("reserve response tcp port");
+        let command_port = command.local_addr().expect("command local addr").port();
+        let response_port = response.local_addr().expect("response local addr").port();
+        drop((command, response));
+        (
+            format!("tcp://localhost:{command_port}"),
+            format!("tcp://localhost:{response_port}"),
+        )
     }
 
-    fn unused_zmq_endpoint_v4() -> String {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve tcp port");
-        let port = listener.local_addr().expect("local addr").port();
-        drop(listener);
-        format!("tcp://127.0.0.1:{port}")
+    fn unused_zmq_endpoint_pair_v4() -> (String, String) {
+        let command = TcpListener::bind("127.0.0.1:0").expect("reserve command tcp port");
+        let response = TcpListener::bind("127.0.0.1:0").expect("reserve response tcp port");
+        let command_port = command.local_addr().expect("command local addr").port();
+        let response_port = response.local_addr().expect("response local addr").port();
+        drop((command, response));
+        (
+            format!("tcp://127.0.0.1:{command_port}"),
+            format!("tcp://127.0.0.1:{response_port}"),
+        )
     }
 
     fn spawn_zmq_sequence_server(
@@ -3661,8 +3671,7 @@ mod tests {
     fn lxmf_zmq_outbound_ten_thousand_regular_single_messages_complete() {
         const MESSAGE_COUNT: usize = 10_000;
 
-        let command_endpoint = unused_zmq_endpoint_v4();
-        let response_endpoint = unused_zmq_endpoint_v4();
+        let (command_endpoint, response_endpoint) = unused_zmq_endpoint_pair_v4();
         let captured_methods = Arc::new(Mutex::new(Vec::new()));
         let server = spawn_zmq_single_send_load_server(
             command_endpoint.clone(),
@@ -3815,8 +3824,7 @@ mod tests {
 
     #[test]
     fn lxmf_zmq_outbound_message_sends_delivery_options_over_sdk_rpc() {
-        let command_endpoint = unused_zmq_endpoint();
-        let response_endpoint = unused_zmq_endpoint();
+        let (command_endpoint, response_endpoint) = unused_zmq_endpoint_pair();
         let captured = Arc::new(Mutex::new(Vec::new()));
         let server = spawn_zmq_sequence_server(
             command_endpoint.clone(),
@@ -3871,8 +3879,7 @@ mod tests {
 
     #[test]
     fn lxmf_zmq_outbound_message_preserves_explicit_loopback_response_endpoint() {
-        let command_endpoint = unused_zmq_endpoint_v4();
-        let response_endpoint = unused_zmq_endpoint_v4();
+        let (command_endpoint, response_endpoint) = unused_zmq_endpoint_pair_v4();
         let captured = Arc::new(Mutex::new(Vec::new()));
         let server = spawn_zmq_sequence_server(
             command_endpoint.clone(),
@@ -3917,8 +3924,7 @@ mod tests {
 
     #[test]
     fn poll_lxmf_zmq_events_preserves_explicit_loopback_response_endpoint() {
-        let command_endpoint = unused_zmq_endpoint_v4();
-        let response_endpoint = unused_zmq_endpoint_v4();
+        let (command_endpoint, response_endpoint) = unused_zmq_endpoint_pair_v4();
         let captured = Arc::new(Mutex::new(Vec::new()));
         let server = spawn_zmq_sequence_server(
             command_endpoint.clone(),
@@ -3978,8 +3984,7 @@ mod tests {
 
     #[test]
     fn poll_lxmf_zmq_events_reuses_actor_response_socket_after_outbound_send() {
-        let command_endpoint = unused_zmq_endpoint_v4();
-        let response_endpoint = unused_zmq_endpoint_v4();
+        let (command_endpoint, response_endpoint) = unused_zmq_endpoint_pair_v4();
         let captured = Arc::new(Mutex::new(Vec::new()));
         let server = spawn_zmq_sequence_server(
             command_endpoint.clone(),
@@ -4054,8 +4059,7 @@ mod tests {
 
     #[test]
     fn announce_lxmf_zmq_identity_uses_sdk_identity_announce_rpc() {
-        let command_endpoint = unused_zmq_endpoint_v4();
-        let response_endpoint = unused_zmq_endpoint_v4();
+        let (command_endpoint, response_endpoint) = unused_zmq_endpoint_pair_v4();
         let captured = Arc::new(Mutex::new(Vec::new()));
         let server = spawn_zmq_sequence_server(
             command_endpoint.clone(),
@@ -4137,8 +4141,7 @@ mod tests {
 
     #[test]
     fn lxmf_zmq_delivery_status_uses_negotiated_sdk_status_rpc() {
-        let command_endpoint = unused_zmq_endpoint_v4();
-        let response_endpoint = unused_zmq_endpoint_v4();
+        let (command_endpoint, response_endpoint) = unused_zmq_endpoint_pair_v4();
         let captured = Arc::new(Mutex::new(Vec::new()));
         let server = spawn_zmq_sequence_server(
             command_endpoint.clone(),


### PR DESCRIPTION
## Summary
- fallback legitimate direct broadcast `send_timeout` events into propagated delivery instead of leaving the broadcast terminally failed
- avoid slow propagated broadcast preflight paths: propagation-node selection and live announce refresh are skipped before ZMQ enqueue
- include stale known broadcast clients for propagated fallback, so propagation has actual recipients even when direct freshness is gone
- align RCH transport path dependency versions with the current sibling `LXMF-rs` 0.5.1 workspace and harden ZMQ test endpoint isolation

## Root cause
A broadcast could start as direct delivery, time out locally, then be converted to `broadcast_direct_timeout_fallback`. The propagated retry still had two release-blocking gaps: it could block on Reticulum RPC preflight before enqueue, and its broadcast recipient expansion reused the direct/active-recipient freshness filter. With the real test DB, all known clients were stale, so propagated dispatch produced zero recipients and eventually failed with `send_timeout`.

## Behavior
After a legitimate direct broadcast timeout, the message is requeued as propagated with `delivery_policy_reason = broadcast_direct_timeout_fallback`, a propagated multi-recipient retry budget, no synchronous announce/node preflight, and known broadcast clients included as propagation recipients.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- targeted regression tests for direct timeout fallback, propagated broadcast no-refresh enqueue, propagated broadcast stale known clients, and propagated targeted node selection
- release server rebuilt and restarted locally on `http://127.0.0.1:18080/` with `RTH_Store\rch_state.sqlite3`, `RTH_Store\config.ini`, built UI assets, reticulumd RPC, and LXMF ZMQ endpoints
- live canary `14d2c744ab6d436eb17ff2ccd987e2be`: direct broadcast timed out, converted to propagated fallback, and reached `delivery_state=propagated`, `dispatch_status=accepted`, `reticulumd_dispatch_count=13`
- UI HTTP sanity: `/` returned 200, all linked JS/CSS assets returned 200, `/Status` returned real DB counts