### PR TITLE
[codex] Fix release gate clippy warnings

### DIFF
--- a/crates/r3akt-node/src/lib.rs
+++ b/crates/r3akt-node/src/lib.rs
@@ -464,17 +464,9 @@ where
     F: std::future::Future,
 {
     use std::pin::Pin;
-    use std::sync::Arc;
-    use std::task::{Context, Poll, Wake, Waker};
+    use std::task::{Context, Poll, Waker};
 
-    struct NoopWake;
-
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-
-    let waker = Waker::from(Arc::new(NoopWake));
-    let mut context = Context::from_waker(&waker);
+    let mut context = Context::from_waker(Waker::noop());
     let mut future = Box::pin(future);
 
     loop {

--- a/crates/r3akt-node/tests/rch_vertical.rs
+++ b/crates/r3akt-node/tests/rch_vertical.rs
@@ -1,7 +1,6 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll, Wake, Waker};
+use std::task::{Context, Poll, Waker};
 
 use r3akt_identity::NodeIdentity;
 use r3akt_node::{ProcessStatus, R3aktNode};
@@ -62,14 +61,7 @@ fn block_on<F>(future: F) -> F::Output
 where
     F: Future,
 {
-    struct NoopWake;
-
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-
-    let waker = Waker::from(Arc::new(NoopWake));
-    let mut context = Context::from_waker(&waker);
+    let mut context = Context::from_waker(Waker::noop());
     let mut future = Box::pin(future);
 
     loop {

--- a/crates/r3akt-rch-core/src/lib.rs
+++ b/crates/r3akt-rch-core/src/lib.rs
@@ -2719,7 +2719,7 @@ impl RchSqliteStore {
         for row in rows {
             records.push(decode_msgpack(&row?)?);
         }
-        records.sort_by(|left, right| right.timestamp_ms.cmp(&left.timestamp_ms));
+        records.sort_by_key(|event| std::cmp::Reverse(event.timestamp_ms));
         Ok(records)
     }
 
@@ -7875,7 +7875,7 @@ impl RchCore {
             .filter(|column| column.template_uid.as_deref() == Some(template_uid))
             .cloned()
             .collect();
-        columns.sort_by(|left, right| left.display_order.cmp(&right.display_order));
+        columns.sort_by_key(|column| column.display_order);
         columns
             .into_iter()
             .map(|column| checklist_column_record_value(&column))
@@ -8685,7 +8685,7 @@ impl RchCore {
             .filter(|column| column.checklist_uid.as_deref() == Some(checklist_uid))
             .cloned()
             .collect();
-        columns.sort_by(|left, right| left.display_order.cmp(&right.display_order));
+        columns.sort_by_key(|column| column.display_order);
         columns
     }
 
@@ -9824,7 +9824,7 @@ impl RchCore {
             .filter(|task| task.checklist_uid == checklist_uid)
             .cloned()
             .collect();
-        tasks.sort_by(|left, right| left.number.cmp(&right.number));
+        tasks.sort_by_key(|task| task.number);
         tasks
             .into_iter()
             .map(|task| {

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -10386,7 +10386,7 @@ fn sqlite_runtime_metrics(state: &AppState) -> Value {
         .unwrap_or_default();
     json!({
         "transactions": transactions,
-        "avg_ms": if transactions == 0 { 0 } else { total_ms / transactions },
+        "avg_ms": total_ms.checked_div(transactions).unwrap_or(0),
         "p50_ms": percentile_ms(&samples, 50),
         "p95_ms": percentile_ms(&samples, 95),
         "max_ms": state.runtime_metrics.sqlite_latency_max_ms.load(Ordering::Relaxed),

--- a/crates/r3akt-store/src/lib.rs
+++ b/crates/r3akt-store/src/lib.rs
@@ -445,17 +445,9 @@ pub fn test_block_on<F>(future: F) -> F::Output
 where
     F: Future,
 {
-    use std::sync::Arc;
-    use std::task::{Context, Poll, Wake, Waker};
+    use std::task::{Context, Poll, Waker};
 
-    struct NoopWake;
-
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-
-    let waker = Waker::from(Arc::new(NoopWake));
-    let mut context = Context::from_waker(&waker);
+    let mut context = Context::from_waker(Waker::noop());
     let mut future = Box::pin(future);
 
     loop {

--- a/crates/r3akt-transport-rns/src/lib.rs
+++ b/crates/r3akt-transport-rns/src/lib.rs
@@ -1878,16 +1878,14 @@ async fn lxmf_zmq_rpc_call(
 fn lxmf_zmq_session_id() -> String {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
+        .map_or(0, |duration| duration.as_nanos());
     format!("r3akt-rch-{}-{now}", std::process::id())
 }
 
 fn lxmf_zmq_message_id() -> String {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
+        .map_or(0, |duration| duration.as_nanos());
     format!("sdk-zmq-rch-{now}")
 }
 
@@ -4866,17 +4864,9 @@ pub fn test_block_on<F>(future: F) -> F::Output
 where
     F: Future,
 {
-    use std::sync::Arc;
-    use std::task::{Context, Poll, Wake, Waker};
+    use std::task::{Context, Poll, Waker};
 
-    struct NoopWake;
-
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-
-    let waker = Waker::from(Arc::new(NoopWake));
-    let mut context = Context::from_waker(&waker);
+    let mut context = Context::from_waker(Waker::noop());
     let mut future = Box::pin(future);
 
     loop {

--- a/examples/rch-ingest-sim/src/main.rs
+++ b/examples/rch-ingest-sim/src/main.rs
@@ -1,7 +1,6 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll, Wake, Waker};
+use std::task::{Context, Poll, Waker};
 
 use r3akt_identity::NodeIdentity;
 use r3akt_node::R3aktNode;
@@ -80,14 +79,7 @@ fn block_on<F>(future: F) -> F::Output
 where
     F: Future,
 {
-    struct NoopWake;
-
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-
-    let waker = Waker::from(Arc::new(NoopWake));
-    let mut context = Context::from_waker(&waker);
+    let mut context = Context::from_waker(Waker::noop());
     let mut future = Box::pin(future);
 
     loop {

--- a/examples/sim-agent/src/main.rs
+++ b/examples/sim-agent/src/main.rs
@@ -1,7 +1,6 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll, Wake, Waker};
+use std::task::{Context, Poll, Waker};
 
 use r3akt_identity::NodeIdentity;
 use r3akt_node::R3aktNode;
@@ -84,14 +83,7 @@ fn block_on<F>(future: F) -> F::Output
 where
     F: Future,
 {
-    struct NoopWake;
-
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-
-    let waker = Waker::from(Arc::new(NoopWake));
-    let mut context = Context::from_waker(&waker);
+    let mut context = Context::from_waker(Waker::noop());
     let mut future = Box::pin(future);
 
     loop {


### PR DESCRIPTION
## Summary
- replace local test no-op waker helpers with `Waker::noop()`
- update a few clippy-preferred sort/division/time helper patterns
- keep the release gate passing on the current Rust toolchain

## Validation
- `env OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu CFLAGS="-I/usr/include/x86_64-linux-gnu" pwsh -NoProfile -File ./scripts/release-readiness.ps1 -ServerOnlyAlpha -Bind 127.0.0.1:18182 -ApiKey release-smoke -LxmfZmqCommand tcp://localhost:19110 -LxmfZmqResponse tcp://localhost:19111 -ReticulumdSource release-smoke-source`
- `env OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu CFLAGS="-I/usr/include/x86_64-linux-gnu" cargo build --release -p r3akt-tak-connector --bin r3akt-tak-service`
- `npm --prefix ui run build`
- local prerelease package assembled with `scripts/build-rust-release-package.ps1` for `rch-rust-full-linux-amd64-v3.0.0-preview.5`

## Artifact
- local archive: `dist/rch-rust-full-linux-amd64-v3.0.0-preview.5.tar.gz`
- SHA-256: `EBCEB25A247692692FAD01A31ABC8C7871AD251E348286DD26FB95FB79A9C59B`
