### PR TITLE
Fix raw LXMF mission command ingestion

### DIFF
--- a/crates/r3akt-rch-server/src/tests/rem_team_directory.rs
+++ b/crates/r3akt-rch-server/src/tests/rem_team_directory.rs
@@ -77,25 +77,20 @@ async fn reticulumd_inbound_team_peer_directory_returns_only_shared_team_rem_pee
         let mut store = RchSqliteStore::open(&db_path).expect("store");
         store.save_snapshot(&core.snapshot()).expect("snapshot");
     }
-    let envelope = r3akt_protocol::ProtocolEnvelope::new(
-        r3akt_protocol::NodeId::new(CALLER_DESTINATION),
-        r3akt_protocol::Destination::Node(r3akt_protocol::NodeId::new("local-destination")),
-        r3akt_protocol::Topic::new("rem-directory"),
-        r3akt_protocol::Payload::Command(r3akt_protocol::Command {
-            name: "rem.registry.team_peers.list".to_string(),
-            args: json!({}),
-            correlation_id: Some("hub-directory-123".to_string()),
-        }),
-    )
-    .with_dedupe_key("dedupe-team-directory");
-    let payload_b64 = BASE64_STANDARD.encode(envelope.encode_msgpack().expect("msgpack"));
     let (endpoint, rpc_server) = fake_reticulumd_rpc_server_with_results_and_accept_timeout(
         vec![
             json!({
                 "messages": [{
                     "id": "lxmf-team-directory-1",
+                    "source": CALLER_DESTINATION,
                     "destination": "local-destination",
-                    "fields": { "r3akt_payload_b64": payload_b64 }
+                    "fields": { crate::FIELD_COMMANDS.to_string(): [{
+                        "command_id": "hub-directory-123",
+                        "command_type": "rem.registry.team_peers.list",
+                        "source": { "rns_identity": CALLER_IDENTITY },
+                        "timestamp": "2026-07-16T12:00:00Z",
+                        "args": {}
+                    }] }
                 }]
             }),
             json!({"message_id": "accepted-reply"}),

--- a/crates/r3akt-transport-rns/src/lib.rs
+++ b/crates/r3akt-transport-rns/src/lib.rs
@@ -24,8 +24,8 @@ use lxmf_sdk::{
     ZmqPipelineBackendClient, ZmqPipelineBackendConfig,
 };
 use r3akt_protocol::{
-    Destination, NodeId, Payload, ProtocolEnvelope, TelemetrySample, Topic, TopicAttachment,
-    TopicMessage,
+    Command, Destination, NodeId, Payload, ProtocolEnvelope, TelemetrySample, Topic,
+    TopicAttachment, TopicMessage,
 };
 use rns_rpc::rpc::zmq;
 #[cfg(test)]
@@ -2363,6 +2363,22 @@ fn direct_lxmf_message_envelope(
     let fields = message.get("fields").and_then(JsonValue::as_object);
     let source = optional_message_string(message, &["source", "source_hash", "source_id"])
         .unwrap_or("unknown");
+    if let Some(command) = direct_lxmf_mission_command(fields) {
+        let mut envelope = ProtocolEnvelope::new(
+            NodeId::new(source),
+            Destination::Node(NodeId::new(local_source)),
+            Topic::new("rem-directory"),
+            Payload::Command(command),
+        );
+        if let Some(message_id) = message
+            .get("id")
+            .and_then(JsonValue::as_str)
+            .filter(|value| !value.trim().is_empty())
+        {
+            envelope = envelope.with_dedupe_key(message_id);
+        }
+        return Some(envelope);
+    }
     if let Some(telemetry) = direct_lxmf_telemetry(fields, message) {
         let topic = Topic::new("telemetry");
         return Some(
@@ -2426,6 +2442,36 @@ fn direct_lxmf_message_envelope(
                 .unwrap_or(local_source),
         ),
     )
+}
+
+fn direct_lxmf_mission_command(
+    fields: Option<&serde_json::Map<String, JsonValue>>,
+) -> Option<Command> {
+    let commands = fields?.get("9")?;
+    let command = commands
+        .as_array()
+        .and_then(|commands| commands.first())
+        .unwrap_or(commands);
+    let command_type = command
+        .get("command_type")
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let command_id = command
+        .get("command_id")
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+    Some(Command {
+        name: command_type.to_string(),
+        args: command
+            .get("args")
+            .cloned()
+            .filter(JsonValue::is_object)
+            .unwrap_or_else(|| serde_json::json!({})),
+        correlation_id: command_id,
+    })
 }
 
 pub fn reticulumd_message_to_envelope(
@@ -4961,6 +5007,49 @@ mod tests {
         );
         assert_eq!(message.attachments[0].category, "file");
         assert_eq!(rpc.calls[0].method, "list_messages");
+    }
+
+    #[test]
+    fn reticulumd_rpc_adapter_maps_field_commands_mission_envelope() {
+        let mut rpc = RecordingReticulumdRpc::with_responses(vec![serde_json::json!({
+            "messages": [{
+                "id": "directory-command-1",
+                "source": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "destination": "local-destination",
+                "fields": {
+                    "9": [{
+                        "command_id": "hub-directory-123",
+                        "command_type": "rem.registry.team_peers.list",
+                        "source": {
+                            "rns_identity": "11111111111111111111111111111111"
+                        },
+                        "timestamp": "2026-07-16T12:00:00Z",
+                        "args": {}
+                    }]
+                }
+            }]
+        })]);
+        let mut adapter = ReticulumdRpcLxmfRsAdapter::new(
+            "local-destination",
+            ReticulumdRpcTransport::from_rpc(&mut rpc),
+        );
+
+        let frame = crate::test_block_on(adapter.receive_frame())
+            .expect("receive")
+            .expect("frame");
+        let envelope = ProtocolEnvelope::decode_msgpack(&frame.bytes).expect("envelope");
+
+        assert_eq!(
+            envelope.source.to_string(),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        assert_eq!(envelope.stable_dedupe_key(), "directory-command-1");
+        let Payload::Command(command) = envelope.payload else {
+            panic!("expected command");
+        };
+        assert_eq!(command.name, "rem.registry.team_peers.list");
+        assert_eq!(command.correlation_id.as_deref(), Some("hub-directory-123"));
+        assert_eq!(command.args, serde_json::json!({}));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Decode standard LXMF `FIELD_COMMANDS` mission envelopes received from reticulumd into protocol commands.
- Preserve the signed LXMF source destination, command correlation ID, and message deduplication key.
- Exercise `rem.registry.team_peers.list` through the actual raw field-9 inbound shape in the server integration test.

## Why

REM sends the team directory request as a normal LXMF mission command. RCH previously consumed only the legacy `r3akt_payload_b64` wrapper, so the new command was stored by reticulumd but never dispatched by RCH.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- Live Pixel 7 to local RCH/reticulumd: accepted/result lifecycle returned a `shared_teams` snapshot containing only the two eligible teammates.
