### PR TITLE
Fix RCH preview.8 release metadata

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -6,7 +6,7 @@ on:
       release_version:
         description: "Version label to embed in manually built artifacts"
         required: false
-        default: "v3.0.0-preview.7"
+        default: "v3.0.0-preview.8"
   release:
     types: [published]
   push:

--- a/apps/rch-desktop/package-lock.json
+++ b/apps/rch-desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rch-desktop-tauri",
-  "version": "3.0.0-preview.7",
+  "version": "3.0.0-preview.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rch-desktop-tauri",
-      "version": "3.0.0-preview.7",
+      "version": "3.0.0-preview.8",
       "devDependencies": {
         "@tauri-apps/cli": "^2.0.0"
       }

--- a/apps/rch-desktop/package.json
+++ b/apps/rch-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rch-desktop-tauri",
   "private": true,
-  "version": "3.0.0-preview.7",
+  "version": "3.0.0-preview.8",
   "type": "module",
   "scripts": {
     "build": "npm --prefix ../../ui run build && npm run prepare:sidecar && tauri build",

--- a/apps/rch-desktop/src-tauri/Cargo.lock
+++ b/apps/rch-desktop/src-tauri/Cargo.lock
@@ -2393,7 +2393,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rch-desktop"
-version = "3.0.0-preview.7"
+version = "3.0.0-preview.8"
 dependencies = [
  "tauri",
  "tauri-build",

--- a/apps/rch-desktop/src-tauri/Cargo.toml
+++ b/apps/rch-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rch-desktop"
-version = "3.0.0-preview.7"
+version = "3.0.0-preview.8"
 edition = "2024"
 rust-version = "1.85"
 license = "EPL-2.0"

--- a/apps/rch-desktop/src-tauri/tauri.conf.json
+++ b/apps/rch-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "RCH Desktop",
-  "version": "3.0.0-preview.7",
+  "version": "3.0.0-preview.8",
   "identifier": "org.freetakteam.rch",
   "build": {
     "frontendDist": "../../../ui/dist",

--- a/docs/release-notes-v3.0.0-preview.8.md
+++ b/docs/release-notes-v3.0.0-preview.8.md
@@ -1,0 +1,31 @@
+# RCH Rust v3.0.0-preview.8 Release Notes
+
+This prerelease adds the authoritative team-scoped REM peer directory used by REM 1.2.6 SemiAutonomous mode.
+
+Python `2.9.x` remains the stable maintenance line on `rch-python`; this is a Rust preview intended for validation of the 3.0 runtime, packaging, migration, LXMF, TAK integration, and local operator desktop path.
+
+## Highlights Since preview.7
+
+- Added the LXMF command `rem.registry.team_peers.list` with accepted/result lifecycle responses in `FIELD_RESULTS`.
+- Scopes results to active REM-capable identities that share at least one team with the requester.
+- Supports primary and linked client identities, canonical `lxmf.delivery` destinations, deduplication, moderation exclusions, and the existing one-hour announce freshness window.
+- Rejects unrostered or non-REM callers before acceptance and excludes the requesting destination from its own result.
+- Returns `scope: shared_teams`, `effective_connected_mode`, and the existing peer metadata contract while preserving the legacy peer command and HTTP endpoint.
+- Ingests standard raw LXMF `FIELD_COMMANDS` envelopes from reticulumd while preserving the signed LXMF source, command correlation ID, and message deduplication key.
+- Documents the RCH-before-REM upgrade order and fail-closed behavior of newer REM clients against older hubs.
+
+## Validation
+
+- Formatting, clippy, full workspace tests, dependency audit, release builds, release-readiness, and the ZMQ projection floor passed in CI.
+- Core and server tests cover shared-team inclusion, other-team exclusion, linked identities, canonical destinations, deduplication, caller exclusion, moderation, stale/non-REM filtering, connected-mode calculation, and unrostered rejection.
+- A live Pixel 7 received an accepted/result response containing only its two eligible shared-team peers; REM then targeted telemetry only to those two telemetry-capable destinations.
+
+## Upgrade Order
+
+Deploy this RCH release before enabling SemiAutonomous mode in REM 1.2.6. The legacy `rem.registry.peers.list` command and `GET /api/rem/peers` remain available for older REM clients.
+
+## Known Boundaries
+
+- This remains a preview release, not stable `v3.0.0`.
+- Operator packaging and desktop bundles remain preview artifacts while field feedback and multi-device receipt validation continue.
+- Python parity and Rust transition gaps remain tracked in the repository release/readiness documentation.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -21,9 +21,9 @@ The server-only alpha gate remains `scripts/release-readiness.ps1
 shape: manual workflow artifacts on `workflow_dispatch` and file attachment
 when a GitHub release is published. Server package names include the resolved
 release version, for example
-`rch-rust-full-windows-x64-v3.0.0-preview.7.zip`; the same version, Git ref,
+`rch-rust-full-windows-x64-v3.0.0-preview.8.zip`; the same version, Git ref,
 and commit SHA are written into `release-manifest.json` inside the archive.
-Manual workflow runs default to `v3.0.0-preview.7` and can override that label
+Manual workflow runs default to `v3.0.0-preview.8` and can override that label
 with the `release_version` input. While `main` remains the default branch,
 GitHub does not expose `workflow_dispatch` for workflows that only exist on
 `rust-next`, so the release workflow also runs on relevant `rust-next` pushes
@@ -37,7 +37,7 @@ passed on commit `8dc69773af38ced251138c007c6f0bdc9543ea02`. It uploaded
 artifacts matched their SHA-256 sidecars.
 
 Draft notes for the latest Rust preview are in
-`docs/release-notes-v3.0.0-preview.7.md`.
+`docs/release-notes-v3.0.0-preview.8.md`.
 
 Pull request quality control is handled by
 `.github/workflows/rust-pr-quality.yml`. It runs Rust 1.88 formatting, clippy,


### PR DESCRIPTION
## What changed

- bump all RCH Desktop package metadata from `3.0.0-preview.7` to `3.0.0-preview.8`
- update the release workflow default and current packaging documentation
- add the committed preview.8 release notes

## Why

The first preview.8 release run built correct server archives but produced desktop bundles named and internally versioned as preview.7 because the desktop manifests had not been advanced. This aligns every release input before the preview.8 tag is recreated.

## Validation

- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1` for the Tauri crate
- JSON parsing for `package.json`, `package-lock.json`, and `tauri.conf.json`
- `git diff --check`
- active release-input search confirms all desktop and workflow versions are preview.8; historical preview.7 evidence remains unchanged
