### PR TITLE
Add team-scoped REM directory routing

### DIFF
--- a/crates/r3akt-profile-rch/src/fields.rs
+++ b/crates/r3akt-profile-rch/src/fields.rs
@@ -1,0 +1,4 @@
+pub const FIELD_COMMANDS: i64 = 0x09;
+pub const FIELD_RESULTS: i64 = 0x0A;
+pub const FIELD_GROUP: i64 = 0x0B;
+pub const FIELD_EVENT: i64 = 0x0D;

--- a/crates/r3akt-profile-rch/src/lib.rs
+++ b/crates/r3akt-profile-rch/src/lib.rs
@@ -17,6 +17,7 @@ use thiserror::Error;
 
 pub const FIELD_COMMANDS: i64 = 0x09;
 pub const FIELD_RESULTS: i64 = 0x0A;
+pub const FIELD_GROUP: i64 = 0x0B;
 pub const FIELD_EVENT: i64 = 0x0D;
 const MECP_PREFIX: &str = "MECP/";
 

--- a/crates/r3akt-profile-rch/src/lib.rs
+++ b/crates/r3akt-profile-rch/src/lib.rs
@@ -15,10 +15,8 @@ use r3akt_protocol::{Ack, Command, Destination, NodeId, Payload, ProtocolEnvelop
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-pub const FIELD_COMMANDS: i64 = 0x09;
-pub const FIELD_RESULTS: i64 = 0x0A;
-pub const FIELD_GROUP: i64 = 0x0B;
-pub const FIELD_EVENT: i64 = 0x0D;
+mod fields;
+pub use fields::{FIELD_COMMANDS, FIELD_EVENT, FIELD_GROUP, FIELD_RESULTS};
 const MECP_PREFIX: &str = "MECP/";
 
 #[derive(Debug, Error)]

--- a/crates/r3akt-profile-rch/src/lib.rs
+++ b/crates/r3akt-profile-rch/src/lib.rs
@@ -668,32 +668,6 @@ mod tests {
     }
 
     #[test]
-    fn team_scoped_result_field_ignores_group_metadata() {
-        let result = CommandResultEnvelope {
-            command_id: "cmd-team-result".to_string(),
-            status: CommandResultStatus::Completed,
-            detail: None,
-            reason_code: None,
-            reason: None,
-            required_capabilities: Vec::new(),
-            accepted_at: None,
-            by_identity: None,
-            correlation_id: Some("corr-team-result".to_string()),
-            result: serde_json::json!({ "ok": true }),
-        };
-        let fields = BTreeMap::from([
-            (FIELD_RESULTS, serde_json::json!([result.clone()])),
-            (
-                FIELD_GROUP,
-                serde_json::json!("d6b6e188b910d6bdd24d04b7a7ec5444"),
-            ),
-        ]);
-        let bytes = rmp_serde::to_vec_named(&fields).expect("encode");
-
-        assert_eq!(decode_results(&bytes).expect("decode"), vec![result]);
-    }
-
-    #[test]
     fn command_profile_converts_to_protocol_envelope_with_dedupe() {
         let command = command();
 

--- a/crates/r3akt-profile-rch/src/lib.rs
+++ b/crates/r3akt-profile-rch/src/lib.rs
@@ -12,7 +12,7 @@
 use std::collections::BTreeMap;
 
 use r3akt_protocol::{Ack, Command, Destination, NodeId, Payload, ProtocolEnvelope, Topic};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;
 
 mod fields;
@@ -532,11 +532,7 @@ pub fn encode_commands(commands: &[MissionCommandEnvelope]) -> Result<Vec<u8>, R
 }
 
 pub fn decode_commands(bytes: &[u8]) -> Result<Vec<MissionCommandEnvelope>, RchProfileError> {
-    let mut fields: BTreeMap<i64, Vec<MissionCommandEnvelope>> =
-        rmp_serde::from_slice(bytes).map_err(|error| RchProfileError::Decode(error.to_string()))?;
-    fields
-        .remove(&FIELD_COMMANDS)
-        .ok_or(RchProfileError::MissingField(FIELD_COMMANDS))
+    decode_field(bytes, FIELD_COMMANDS)
 }
 
 pub fn encode_results(results: &[CommandResultEnvelope]) -> Result<Vec<u8>, RchProfileError> {
@@ -545,12 +541,7 @@ pub fn encode_results(results: &[CommandResultEnvelope]) -> Result<Vec<u8>, RchP
 }
 
 pub fn decode_results(bytes: &[u8]) -> Result<Vec<CommandResultEnvelope>, RchProfileError> {
-    let mut fields: BTreeMap<i64, OneOrMany<CommandResultEnvelope>> =
-        rmp_serde::from_slice(bytes).map_err(|error| RchProfileError::Decode(error.to_string()))?;
-    Ok(fields
-        .remove(&FIELD_RESULTS)
-        .ok_or(RchProfileError::MissingField(FIELD_RESULTS))?
-        .into_vec())
+    Ok(decode_field::<OneOrMany<CommandResultEnvelope>>(bytes, FIELD_RESULTS)?.into_vec())
 }
 
 pub fn encode_events(events: &[EventEnvelope]) -> Result<Vec<u8>, RchProfileError> {
@@ -559,12 +550,16 @@ pub fn encode_events(events: &[EventEnvelope]) -> Result<Vec<u8>, RchProfileErro
 }
 
 pub fn decode_events(bytes: &[u8]) -> Result<Vec<EventEnvelope>, RchProfileError> {
-    let mut fields: BTreeMap<i64, OneOrMany<EventEnvelope>> =
+    Ok(decode_field::<OneOrMany<EventEnvelope>>(bytes, FIELD_EVENT)?.into_vec())
+}
+
+fn decode_field<T: DeserializeOwned>(bytes: &[u8], field: i64) -> Result<T, RchProfileError> {
+    let mut fields: BTreeMap<i64, serde_json::Value> =
         rmp_serde::from_slice(bytes).map_err(|error| RchProfileError::Decode(error.to_string()))?;
-    Ok(fields
-        .remove(&FIELD_EVENT)
-        .ok_or(RchProfileError::MissingField(FIELD_EVENT))?
-        .into_vec())
+    let value = fields
+        .remove(&field)
+        .ok_or(RchProfileError::MissingField(field))?;
+    serde_json::from_value(value).map_err(|error| RchProfileError::Decode(error.to_string()))
 }
 
 pub fn ack_to_result(
@@ -668,6 +663,32 @@ mod tests {
 
         let result = ack_to_result(&envelope).expect("ack result");
         let bytes = encode_results(std::slice::from_ref(&result)).expect("encode");
+
+        assert_eq!(decode_results(&bytes).expect("decode"), vec![result]);
+    }
+
+    #[test]
+    fn team_scoped_result_field_ignores_group_metadata() {
+        let result = CommandResultEnvelope {
+            command_id: "cmd-team-result".to_string(),
+            status: CommandResultStatus::Completed,
+            detail: None,
+            reason_code: None,
+            reason: None,
+            required_capabilities: Vec::new(),
+            accepted_at: None,
+            by_identity: None,
+            correlation_id: Some("corr-team-result".to_string()),
+            result: serde_json::json!({ "ok": true }),
+        };
+        let fields = BTreeMap::from([
+            (FIELD_RESULTS, serde_json::json!([result.clone()])),
+            (
+                FIELD_GROUP,
+                serde_json::json!("d6b6e188b910d6bdd24d04b7a7ec5444"),
+            ),
+        ]);
+        let bytes = rmp_serde::to_vec_named(&fields).expect("encode");
 
         assert_eq!(decode_results(&bytes).expect("decode"), vec![result]);
     }

--- a/crates/r3akt-profile-rch/tests/team_group.rs
+++ b/crates/r3akt-profile-rch/tests/team_group.rs
@@ -1,0 +1,31 @@
+use std::collections::BTreeMap;
+
+use r3akt_profile_rch::{
+    CommandResultEnvelope, CommandResultStatus, FIELD_GROUP, FIELD_RESULTS, decode_results,
+};
+
+#[test]
+fn team_scoped_result_field_ignores_group_metadata() {
+    let result = CommandResultEnvelope {
+        command_id: "cmd-team-result".to_string(),
+        status: CommandResultStatus::Completed,
+        detail: None,
+        reason_code: None,
+        reason: None,
+        required_capabilities: Vec::new(),
+        accepted_at: None,
+        by_identity: None,
+        correlation_id: Some("corr-team-result".to_string()),
+        result: serde_json::json!({ "ok": true }),
+    };
+    let fields = BTreeMap::from([
+        (FIELD_RESULTS, serde_json::json!([result.clone()])),
+        (
+            FIELD_GROUP,
+            serde_json::json!("d6b6e188b910d6bdd24d04b7a7ec5444"),
+        ),
+    ]);
+    let bytes = rmp_serde::to_vec_named(&fields).expect("encode");
+
+    assert_eq!(decode_results(&bytes).expect("decode"), vec![result]);
+}

--- a/crates/r3akt-rch-core/src/lib.rs
+++ b/crates/r3akt-rch-core/src/lib.rs
@@ -37,6 +37,7 @@ use text::decode_utf8_ignoring_errors;
 
 pub mod python_migration;
 mod rem_team_directory;
+mod rem_team_scope;
 
 pub const DELIVERY_ENVELOPE_FIELD: &str = "RTHDelivery";
 pub const DELIVERY_SCHEMA_VERSION: &str = "1";
@@ -4554,12 +4555,8 @@ impl RchCore {
                 format!("Unsupported mission command '{}'", command.command_type),
             ))];
         }
-        if let Err((reason_code, reason)) = self.validate_rem_team_scope(command) {
-            return vec![MissionSyncResponse::results(Self::rejected_result(
-                command,
-                reason_code,
-                reason,
-            ))];
+        if let Some(rejection) = self.rem_team_scope_rejection(command) {
+            return vec![rejection];
         }
         if let Some(required_capability) = required_capability(command.command_type.as_str()) {
             if self.authorization_required
@@ -4679,12 +4676,8 @@ impl RchCore {
                 format!("Unsupported checklist command '{}'", command.command_type),
             ))];
         }
-        if let Err((reason_code, reason)) = self.validate_rem_team_scope(command) {
-            return vec![MissionSyncResponse::results(Self::rejected_result(
-                command,
-                reason_code,
-                reason,
-            ))];
+        if let Some(rejection) = self.rem_team_scope_rejection(command) {
+            return vec![rejection];
         }
         if let Some(required_capability) =
             checklist_required_capability(command.command_type.as_str())
@@ -4752,37 +4745,6 @@ impl RchCore {
         reason: impl Into<String>,
     ) -> CommandResultEnvelope {
         Self::rejected_result_with_capabilities(command, reason_code, reason, Vec::new())
-    }
-
-    fn validate_rem_team_scope(
-        &self,
-        command: &MissionCommandEnvelope,
-    ) -> Result<(), (&'static str, String)> {
-        let Some(team_uid) = command
-            .args
-            .get("_rem_team_uid")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        else {
-            return Ok(());
-        };
-        if canonical_team_for_uid(team_uid).is_none() {
-            return Err((
-                "invalid_team",
-                "FIELD_GROUP must contain a canonical TEAM UID".to_string(),
-            ));
-        }
-        if !self
-            .shared_team_uids_for_rem_source(&command.source.rns_identity)
-            .contains(team_uid)
-        {
-            return Err((
-                "unauthorized_team",
-                "The REM caller is not a member of the requested TEAM".to_string(),
-            ));
-        }
-        Ok(())
     }
 
     fn rejected_result_with_capabilities(

--- a/crates/r3akt-rch-core/src/lib.rs
+++ b/crates/r3akt-rch-core/src/lib.rs
@@ -4554,6 +4554,13 @@ impl RchCore {
                 format!("Unsupported mission command '{}'", command.command_type),
             ))];
         }
+        if let Err((reason_code, reason)) = self.validate_rem_team_scope(command) {
+            return vec![MissionSyncResponse::results(Self::rejected_result(
+                command,
+                reason_code,
+                reason,
+            ))];
+        }
         if let Some(required_capability) = required_capability(command.command_type.as_str()) {
             if self.authorization_required
                 && !self.has_identity_capability(&command.source.rns_identity, required_capability)
@@ -4672,6 +4679,13 @@ impl RchCore {
                 format!("Unsupported checklist command '{}'", command.command_type),
             ))];
         }
+        if let Err((reason_code, reason)) = self.validate_rem_team_scope(command) {
+            return vec![MissionSyncResponse::results(Self::rejected_result(
+                command,
+                reason_code,
+                reason,
+            ))];
+        }
         if let Some(required_capability) =
             checklist_required_capability(command.command_type.as_str())
         {
@@ -4738,6 +4752,37 @@ impl RchCore {
         reason: impl Into<String>,
     ) -> CommandResultEnvelope {
         Self::rejected_result_with_capabilities(command, reason_code, reason, Vec::new())
+    }
+
+    fn validate_rem_team_scope(
+        &self,
+        command: &MissionCommandEnvelope,
+    ) -> Result<(), (&'static str, String)> {
+        let Some(team_uid) = command
+            .args
+            .get("_rem_team_uid")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return Ok(());
+        };
+        if canonical_team_for_uid(team_uid).is_none() {
+            return Err((
+                "invalid_team",
+                "FIELD_GROUP must contain a canonical TEAM UID".to_string(),
+            ));
+        }
+        if !self
+            .shared_team_uids_for_rem_source(&command.source.rns_identity)
+            .contains(team_uid)
+        {
+            return Err((
+                "unauthorized_team",
+                "The REM caller is not a member of the requested TEAM".to_string(),
+            ));
+        }
+        Ok(())
     }
 
     fn rejected_result_with_capabilities(

--- a/crates/r3akt-rch-core/src/lib.rs
+++ b/crates/r3akt-rch-core/src/lib.rs
@@ -4612,6 +4612,9 @@ impl RchCore {
                 format!("Unsupported REM command '{}'", command.command_type),
             ))];
         }
+        if let Some(rejection) = self.rem_registry_team_scope_rejection(command) {
+            return vec![rejection];
+        }
         let Some(source_identity) = normalize_hash(Some(&command.source.rns_identity)) else {
             return vec![MissionSyncResponse::rem_results(Self::rejected_result(
                 command,

--- a/crates/r3akt-rch-core/src/rem_team_directory.rs
+++ b/crates/r3akt-rch-core/src/rem_team_directory.rs
@@ -3,11 +3,45 @@ use std::collections::{HashMap, HashSet};
 use serde_json::{Value, json};
 
 use super::{
-    IdentityAnnounceRecord, RECENT_ANNOUNCE_WINDOW_MS, RchCore, millis_to_rfc3339, normalize_hash,
-    utc_now_ms,
+    IdentityAnnounceRecord, RECENT_ANNOUNCE_WINDOW_MS, RchCore, TeamMemberRecord,
+    canonical_team_for_uid, millis_to_rfc3339, normalize_hash, utc_now_ms,
 };
 
+const REM_TEAM_DIRECTORY_SCHEMA_VERSION: u64 = 2;
+
 impl RchCore {
+    /// Returns validated REM destinations in one canonical TEAM for Connected-mode fanout.
+    /// The caller must itself belong to the requested TEAM.
+    #[must_use]
+    pub fn rem_team_routing_destinations(&self, source: &str, team_uid: &str) -> Vec<String> {
+        if canonical_team_for_uid(team_uid).is_none()
+            || !self
+                .shared_team_uids_for_rem_source(source)
+                .contains(team_uid)
+        {
+            return Vec::new();
+        }
+        let team_uids = HashSet::from([team_uid.to_string()]);
+        let requester_identity = self.canonical_identity_for_rem_source(source);
+        let requester_destination = normalize_hash(Some(source));
+        let cutoff_ms = utc_now_ms().saturating_sub(RECENT_ANNOUNCE_WINDOW_MS);
+        let rem_modes = self
+            .identity_rem_modes
+            .iter()
+            .map(|(identity, record)| (identity.clone(), record.mode.trim().to_ascii_lowercase()))
+            .collect::<HashMap<_, _>>();
+        self.durable_team_directory_members(
+            &team_uids,
+            requester_identity.as_deref(),
+            requester_destination.as_deref(),
+            &rem_modes,
+            cutoff_ms,
+        )
+        .into_iter()
+        .filter_map(|member| member["destination_hash"].as_str().map(ToString::to_string))
+        .collect()
+    }
+
     fn identity_announce_has_rem_capabilities(record: &IdentityAnnounceRecord) -> bool {
         let capabilities: HashSet<_> = record
             .announce_capabilities
@@ -75,6 +109,68 @@ impl RchCore {
             .collect()
     }
 
+    fn caller_memberships_for_rem_source(&self, source: &str) -> Vec<Value> {
+        let Some(identity) = self.canonical_identity_for_rem_source(source) else {
+            return Vec::new();
+        };
+        let mut memberships = self
+            .team_members
+            .values()
+            .filter(|member| Self::member_has_identity(self, member, &identity))
+            .filter_map(|member| {
+                let team_uid = member.team_uid.as_deref()?;
+                canonical_team_for_uid(team_uid)?;
+                Some(json!({
+                    "team_uid": team_uid,
+                    "team_member_uid": member.uid,
+                }))
+            })
+            .collect::<Vec<_>>();
+        memberships.sort_by(|left, right| {
+            left["team_uid"]
+                .as_str()
+                .unwrap_or_default()
+                .cmp(right["team_uid"].as_str().unwrap_or_default())
+                .then_with(|| {
+                    left["team_member_uid"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .cmp(right["team_member_uid"].as_str().unwrap_or_default())
+                })
+        });
+        memberships
+    }
+
+    fn member_has_identity(&self, member: &TeamMemberRecord, identity: &str) -> bool {
+        normalize_hash(Some(&member.rns_identity)).as_deref() == Some(identity)
+            || member.client_identities.iter().any(|client_identity| {
+                normalize_hash(Some(client_identity)).as_deref() == Some(identity)
+            })
+            || self
+                .team_member_client_links
+                .contains(&(member.uid.clone(), identity.to_string()))
+    }
+
+    fn member_identities(&self, member: &TeamMemberRecord) -> HashSet<String> {
+        let mut identities = HashSet::new();
+        if let Some(identity) = normalize_hash(Some(&member.rns_identity)) {
+            identities.insert(identity);
+        }
+        identities.extend(
+            member
+                .client_identities
+                .iter()
+                .filter_map(|identity| normalize_hash(Some(identity))),
+        );
+        identities.extend(
+            self.team_member_client_links
+                .iter()
+                .filter(|(member_uid, _)| member_uid == &member.uid)
+                .filter_map(|(_, identity)| normalize_hash(Some(identity))),
+        );
+        identities
+    }
+
     fn team_member_identities_for_teams(&self, team_uids: &HashSet<String>) -> HashSet<String> {
         let mut identities = HashSet::new();
         for member in self.team_members.values().filter(|member| {
@@ -102,6 +198,133 @@ impl RchCore {
         identities
     }
 
+    fn best_rem_announce_for_identity(&self, identity: &str) -> Option<&IdentityAnnounceRecord> {
+        self.identity_announces
+            .values()
+            .filter(|record| {
+                record
+                    .announced_identity_hash
+                    .as_deref()
+                    .and_then(|value| normalize_hash(Some(value)))
+                    .or_else(|| normalize_hash(Some(&record.destination_hash)))
+                    .as_deref()
+                    == Some(identity)
+                    && record.client_type.trim().eq_ignore_ascii_case("rem")
+                    && Self::identity_announce_has_rem_capabilities(record)
+            })
+            .max_by_key(|record| {
+                (
+                    record.source_interface.as_deref() == Some("destination"),
+                    record.last_seen_ts_ms,
+                )
+            })
+    }
+
+    fn rem_mode_for_announce(
+        rem_modes: &HashMap<String, String>,
+        identity: &str,
+        record: &IdentityAnnounceRecord,
+    ) -> String {
+        rem_modes
+            .get(identity)
+            .or_else(|| {
+                normalize_hash(Some(&record.destination_hash))
+                    .as_ref()
+                    .and_then(|destination| rem_modes.get(destination))
+            })
+            .cloned()
+            .unwrap_or_else(|| "autonomous".to_string())
+    }
+
+    fn durable_team_directory_members(
+        &self,
+        team_uids: &HashSet<String>,
+        requester_identity: Option<&str>,
+        requester_destination: Option<&str>,
+        rem_modes: &HashMap<String, String>,
+        cutoff_ms: i64,
+    ) -> Vec<Value> {
+        let mut members = Vec::new();
+        let mut seen = HashSet::new();
+        for member in self.team_members.values() {
+            let Some(team_uid) = member.team_uid.as_deref() else {
+                continue;
+            };
+            if !team_uids.contains(team_uid) || canonical_team_for_uid(team_uid).is_none() {
+                continue;
+            }
+            for identity in self.member_identities(member) {
+                if requester_identity == Some(identity.as_str()) {
+                    continue;
+                }
+                if self
+                    .identity_states
+                    .get(&identity)
+                    .is_some_and(|state| state.is_banned || state.is_blackholed)
+                {
+                    continue;
+                }
+                let Some(record) = self.best_rem_announce_for_identity(&identity) else {
+                    continue;
+                };
+                let destination_hash = normalize_hash(Some(&record.destination_hash))
+                    .unwrap_or_else(|| identity.clone());
+                if requester_destination == Some(destination_hash.as_str())
+                    || self
+                        .identity_states
+                        .get(&destination_hash)
+                        .is_some_and(|state| state.is_banned || state.is_blackholed)
+                {
+                    continue;
+                }
+                if !seen.insert((
+                    team_uid.to_string(),
+                    member.uid.clone(),
+                    identity.clone(),
+                    destination_hash.clone(),
+                )) {
+                    continue;
+                }
+                members.push(json!({
+                    "team_uid": team_uid,
+                    "team_member_uid": member.uid,
+                    "identity": identity,
+                    "destination_hash": destination_hash,
+                    "display_name": record
+                        .display_name
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .or_else(|| (!member.display_name.trim().is_empty()).then_some(member.display_name.trim())),
+                    "announce_capabilities": record.announce_capabilities.clone(),
+                    "client_type": "rem",
+                    "registered_mode": Self::rem_mode_for_announce(rem_modes, &identity, record),
+                    "last_seen": millis_to_rfc3339(record.last_seen_ts_ms),
+                    "status": if record.last_seen_ts_ms >= cutoff_ms { "active" } else { "offline" },
+                }));
+            }
+        }
+        members.sort_by(|left, right| {
+            left["team_uid"]
+                .as_str()
+                .unwrap_or_default()
+                .cmp(right["team_uid"].as_str().unwrap_or_default())
+                .then_with(|| {
+                    left["team_member_uid"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .cmp(right["team_member_uid"].as_str().unwrap_or_default())
+                })
+                .then_with(|| {
+                    left["identity"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .cmp(right["identity"].as_str().unwrap_or_default())
+                })
+        });
+        members
+    }
+
     pub(super) fn rem_team_peer_registry_payload(&self, source: &str) -> Value {
         let team_uids = self.shared_team_uids_for_rem_source(source);
         let team_identities = self.team_member_identities_for_teams(&team_uids);
@@ -123,6 +346,42 @@ impl RchCore {
                 )
             })
             .collect();
+        let canonical_team_uids = team_uids
+            .iter()
+            .filter(|team_uid| canonical_team_for_uid(team_uid).is_some())
+            .cloned()
+            .collect::<HashSet<_>>();
+        let mut teams = canonical_team_uids
+            .iter()
+            .filter_map(|team_uid| {
+                let (_, color) = canonical_team_for_uid(team_uid)?;
+                let team_name = self
+                    .teams
+                    .get(team_uid)
+                    .map(|team| team.team_name.trim())
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or(color);
+                Some(json!({
+                    "uid": team_uid,
+                    "color": color,
+                    "team_name": team_name,
+                }))
+            })
+            .collect::<Vec<_>>();
+        teams.sort_by(|left, right| {
+            left["color"]
+                .as_str()
+                .unwrap_or_default()
+                .cmp(right["color"].as_str().unwrap_or_default())
+        });
+        let caller_memberships = self.caller_memberships_for_rem_source(source);
+        let members = self.durable_team_directory_members(
+            &canonical_team_uids,
+            requester_identity.as_deref(),
+            requester_destination.as_deref(),
+            &rem_modes,
+            cutoff_ms,
+        );
         let mut candidates: HashMap<String, (&IdentityAnnounceRecord, String)> = HashMap::new();
         for record in self.identity_announces.values() {
             let identity = record
@@ -217,8 +476,12 @@ impl RchCore {
         });
 
         json!({
+            "schema_version": REM_TEAM_DIRECTORY_SCHEMA_VERSION,
             "scope": "shared_teams",
             "effective_connected_mode": effective_connected_mode,
+            "teams": teams,
+            "caller_memberships": caller_memberships,
+            "members": members,
             "items": items,
         })
     }

--- a/crates/r3akt-rch-core/src/rem_team_scope.rs
+++ b/crates/r3akt-rch-core/src/rem_team_scope.rs
@@ -1,0 +1,48 @@
+use serde_json::Value;
+
+use super::{MissionCommandEnvelope, MissionSyncResponse, RchCore, canonical_team_for_uid};
+
+impl RchCore {
+    pub(super) fn rem_team_scope_rejection(
+        &self,
+        command: &MissionCommandEnvelope,
+    ) -> Option<MissionSyncResponse> {
+        let (reason_code, reason) = self.validate_rem_team_scope(command).err()?;
+        Some(MissionSyncResponse::results(Self::rejected_result(
+            command,
+            reason_code,
+            reason,
+        )))
+    }
+
+    fn validate_rem_team_scope(
+        &self,
+        command: &MissionCommandEnvelope,
+    ) -> Result<(), (&'static str, String)> {
+        let Some(team_uid) = command
+            .args
+            .get("_rem_team_uid")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return Ok(());
+        };
+        if canonical_team_for_uid(team_uid).is_none() {
+            return Err((
+                "invalid_team",
+                "FIELD_GROUP must contain a canonical TEAM UID".to_string(),
+            ));
+        }
+        if !self
+            .shared_team_uids_for_rem_source(&command.source.rns_identity)
+            .contains(team_uid)
+        {
+            return Err((
+                "unauthorized_team",
+                "The REM caller is not a member of the requested TEAM".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}

--- a/crates/r3akt-rch-core/src/rem_team_scope.rs
+++ b/crates/r3akt-rch-core/src/rem_team_scope.rs
@@ -15,6 +15,18 @@ impl RchCore {
         )))
     }
 
+    pub(super) fn rem_registry_team_scope_rejection(
+        &self,
+        command: &MissionCommandEnvelope,
+    ) -> Option<MissionSyncResponse> {
+        let (reason_code, reason) = self.validate_rem_team_scope(command).err()?;
+        Some(MissionSyncResponse::rem_results(Self::rejected_result(
+            command,
+            reason_code,
+            reason,
+        )))
+    }
+
     fn validate_rem_team_scope(
         &self,
         command: &MissionCommandEnvelope,

--- a/crates/r3akt-rch-core/src/tests/rem_team_directory.rs
+++ b/crates/r3akt-rch-core/src/tests/rem_team_directory.rs
@@ -21,6 +21,8 @@ fn command_from(source_identity: &str, command_type: &str, args: Value) -> Missi
 
 #[test]
 fn rem_team_peer_registry_returns_only_recent_shared_team_rem_destinations() {
+    const YELLOW_TEAM_UID: &str = "d6b6e188b910d6bdd24d04b7a7ec5444";
+    const BLUE_TEAM_UID: &str = "43341e5c822d99857fa6e8641f2ca9c0";
     const CALLER_IDENTITY: &str = "11111111111111111111111111111111";
     const CALLER_CLIENT_IDENTITY: &str = "99999999999999999999999999999999";
     const CALLER_DESTINATION: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -35,20 +37,20 @@ fn rem_team_peer_registry_returns_only_recent_shared_team_rem_destinations() {
     const GENERIC_IDENTITY: &str = "88888888888888888888888888888888";
 
     let mut core = RchCore::new();
-    for (uid, name) in [("team-alpha", "Alpha"), ("team-bravo", "Bravo")] {
+    for (uid, name) in [(YELLOW_TEAM_UID, "Yellow"), (BLUE_TEAM_UID, "Blue")] {
         core.handle_command(&command(
             "mission.registry.team.upsert",
             json!({ "uid": uid, "team_name": name }),
         ));
     }
     for (uid, team_uid, identity) in [
-        ("member-caller", "team-alpha", CALLER_IDENTITY),
-        ("member-teammate", "team-alpha", TEAMMATE_IDENTITY),
-        ("member-linked", "team-alpha", LINKED_MEMBER_IDENTITY),
-        ("member-blocked", "team-alpha", BLOCKED_IDENTITY),
-        ("member-stale", "team-alpha", STALE_IDENTITY),
-        ("member-generic", "team-alpha", GENERIC_IDENTITY),
-        ("member-outsider", "team-bravo", OUTSIDER_IDENTITY),
+        ("member-caller", YELLOW_TEAM_UID, CALLER_IDENTITY),
+        ("member-teammate", YELLOW_TEAM_UID, TEAMMATE_IDENTITY),
+        ("member-linked", YELLOW_TEAM_UID, LINKED_MEMBER_IDENTITY),
+        ("member-blocked", YELLOW_TEAM_UID, BLOCKED_IDENTITY),
+        ("member-stale", YELLOW_TEAM_UID, STALE_IDENTITY),
+        ("member-generic", YELLOW_TEAM_UID, GENERIC_IDENTITY),
+        ("member-outsider", BLUE_TEAM_UID, OUTSIDER_IDENTITY),
     ] {
         core.handle_command(&command(
             "mission.registry.team_member.upsert",
@@ -147,8 +149,47 @@ fn rem_team_peer_registry_returns_only_recent_shared_team_rem_destinations() {
         "rem.registry.team_peers.listed"
     );
     let result = &responses[1].results_field().expect("result")["result"];
+    assert_eq!(result["schema_version"], 2);
     assert_eq!(result["scope"], "shared_teams");
     assert_eq!(result["effective_connected_mode"], false);
+    assert_eq!(
+        result["teams"],
+        json!([{
+            "uid": YELLOW_TEAM_UID,
+            "color": "YELLOW",
+            "team_name": "YELLOW",
+        }])
+    );
+    assert_eq!(
+        result["caller_memberships"],
+        json!([{
+            "team_uid": YELLOW_TEAM_UID,
+            "team_member_uid": "member-caller",
+        }])
+    );
+    let members = result["members"].as_array().expect("members");
+    assert_eq!(members.len(), 3);
+    assert!(members.iter().any(|member| {
+        member["identity"] == STALE_IDENTITY
+            && member["team_uid"] == YELLOW_TEAM_UID
+            && member["team_member_uid"] == "member-stale"
+            && member["status"] == "offline"
+    }));
+    assert!(
+        members
+            .iter()
+            .all(|member| member["identity"] != BLOCKED_IDENTITY)
+    );
+    assert!(
+        members
+            .iter()
+            .all(|member| member["identity"] != GENERIC_IDENTITY)
+    );
+    assert!(
+        members
+            .iter()
+            .all(|member| member["identity"] != CALLER_CLIENT_IDENTITY)
+    );
     let items = result["items"].as_array().expect("items");
     assert_eq!(items.len(), 2);
     assert_eq!(items[0]["identity"], TEAMMATE_IDENTITY);
@@ -159,6 +200,91 @@ fn rem_team_peer_registry_returns_only_recent_shared_team_rem_destinations() {
     assert_eq!(items[1]["registered_mode"], "semi_autonomous");
     assert!(items.iter().all(|item| item["client_type"] == "rem"));
     assert!(items.iter().all(|item| item["status"] == "active"));
+
+    let routed = core.rem_team_routing_destinations(CALLER_DESTINATION, YELLOW_TEAM_UID);
+    assert!(routed.contains(&TEAMMATE_DESTINATION.to_string()));
+    assert!(routed.contains(&LINKED_DESTINATION.to_string()));
+    assert!(!routed.contains(&CALLER_DESTINATION.to_string()));
+    assert!(
+        core.rem_team_routing_destinations(CALLER_DESTINATION, BLUE_TEAM_UID)
+            .is_empty()
+    );
+
+    let denied = core.handle_mission_sync_command(&command_from(
+        CALLER_DESTINATION,
+        "mission.registry.eam.list",
+        json!({ "_rem_team_uid": BLUE_TEAM_UID }),
+    ));
+    let denied_result = denied[0].results_field().expect("team rejection");
+    assert_eq!(denied_result["status"], "rejected");
+    assert_eq!(denied_result["reason_code"], "unauthorized_team");
+}
+
+#[test]
+fn rem_team_peer_registry_preserves_multi_team_membership_rows() {
+    const YELLOW_TEAM_UID: &str = "d6b6e188b910d6bdd24d04b7a7ec5444";
+    const BLUE_TEAM_UID: &str = "43341e5c822d99857fa6e8641f2ca9c0";
+    const CALLER_IDENTITY: &str = "11111111111111111111111111111111";
+    const CALLER_DESTINATION: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const PEER_IDENTITY: &str = "22222222222222222222222222222222";
+    const PEER_DESTINATION: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    let mut core = RchCore::new();
+    for (uid, color) in [(YELLOW_TEAM_UID, "Yellow"), (BLUE_TEAM_UID, "Blue")] {
+        core.handle_command(&command(
+            "mission.registry.team.upsert",
+            json!({ "uid": uid, "team_name": color }),
+        ));
+    }
+    for (uid, team_uid, identity) in [
+        ("caller-yellow", YELLOW_TEAM_UID, CALLER_IDENTITY),
+        ("caller-blue", BLUE_TEAM_UID, CALLER_IDENTITY),
+        ("peer-yellow", YELLOW_TEAM_UID, PEER_IDENTITY),
+        ("peer-blue", BLUE_TEAM_UID, PEER_IDENTITY),
+    ] {
+        core.handle_command(&command(
+            "mission.registry.team_member.upsert",
+            json!({
+                "uid": uid,
+                "team_uid": team_uid,
+                "rns_identity": identity,
+                "display_name": uid,
+            }),
+        ));
+    }
+    let capabilities = vec!["r3akt".to_string(), "EmergencyMessages".to_string()];
+    for (identity, destination) in [
+        (CALLER_IDENTITY, CALLER_DESTINATION),
+        (PEER_IDENTITY, PEER_DESTINATION),
+    ] {
+        core.record_identity_announce(
+            destination,
+            Some(identity.to_string()),
+            Some(identity.to_string()),
+            Some("destination".to_string()),
+            capabilities.clone(),
+        )
+        .expect("destination announce");
+    }
+
+    let responses = core.handle_mission_sync_command(&command_from(
+        CALLER_DESTINATION,
+        "rem.registry.team_peers.list",
+        json!({}),
+    ));
+    let result = &responses[1].results_field().expect("result")["result"];
+    let caller_memberships = result["caller_memberships"]
+        .as_array()
+        .expect("caller memberships");
+    assert_eq!(caller_memberships.len(), 2);
+    let members = result["members"].as_array().expect("members");
+    assert_eq!(members.len(), 2);
+    assert!(members.iter().any(|member| {
+        member["team_uid"] == YELLOW_TEAM_UID && member["team_member_uid"] == "peer-yellow"
+    }));
+    assert!(members.iter().any(|member| {
+        member["team_uid"] == BLUE_TEAM_UID && member["team_member_uid"] == "peer-blue"
+    }));
 }
 
 #[test]

--- a/crates/r3akt-rch-core/src/tests/rem_team_directory.rs
+++ b/crates/r3akt-rch-core/src/tests/rem_team_directory.rs
@@ -210,6 +210,17 @@ fn rem_team_peer_registry_returns_only_recent_shared_team_rem_destinations() {
             .is_empty()
     );
 
+    let denied_registry = core.handle_mission_sync_command(&command_from(
+        CALLER_DESTINATION,
+        "rem.registry.team_peers.list",
+        json!({ "_rem_team_uid": BLUE_TEAM_UID }),
+    ));
+    let denied_registry_result = denied_registry[0]
+        .results_field()
+        .expect("REM team rejection");
+    assert_eq!(denied_registry_result["status"], "rejected");
+    assert_eq!(denied_registry_result["reason_code"], "unauthorized_team");
+
     let denied = core.handle_mission_sync_command(&command_from(
         CALLER_DESTINATION,
         "mission.registry.eam.list",

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -38,6 +38,11 @@
 )]
 
 mod auth;
+mod rem_team_routing;
+
+use rem_team_routing::{
+    fanout_mission_sync_response_to_team, send_mission_sync_response_to_source,
+};
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::future::pending;
@@ -67,9 +72,7 @@ use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
 use futures_util::SinkExt;
 #[cfg(test)]
 use r3akt_profile_rch::FIELD_EVENT;
-use r3akt_profile_rch::{
-    CommandResultStatus, FIELD_COMMANDS, FIELD_GROUP, MissionCommandEnvelope, RchSource,
-};
+use r3akt_profile_rch::{CommandResultStatus, FIELD_COMMANDS, MissionCommandEnvelope, RchSource};
 use r3akt_protocol::{Destination, HealthTelemetry, Payload, ProtocolEnvelope};
 use r3akt_rch_bridge::{ReticulumdRpc, ReticulumdRpcClient};
 use r3akt_rch_core::{
@@ -5016,97 +5019,6 @@ fn mission_sync_command_from_reticulumd(
         correlation_id: command.correlation_id.clone(),
         topics: vec![envelope.topic.to_string()],
     }
-}
-
-fn send_mission_sync_response_to_source(
-    state: &AppState,
-    source: &str,
-    topic: &str,
-    command: &r3akt_protocol::Command,
-    response: &r3akt_rch_core::MissionSyncResponse,
-    team_uid: Option<&str>,
-) -> Result<OutboundMessageRecord, ApiError> {
-    let lxmf_fields = mission_response_fields(response, team_uid)?;
-    record_outbound_message_with_metadata(
-        state,
-        response.content.as_str(),
-        None,
-        Some(source.to_string()),
-        Vec::new(),
-        true,
-        json!({
-            "reticulumd_inbound_command_reply": true,
-            "source": "r3akt-rch-server",
-            "direction": "outbound",
-            "inbound_source": source,
-            "inbound_topic": topic,
-            "command": command.name,
-            "correlation_id": command.correlation_id,
-            "lxmf_fields": lxmf_fields,
-        }),
-    )
-}
-
-fn mission_response_fields(
-    response: &r3akt_rch_core::MissionSyncResponse,
-    team_uid: Option<&str>,
-) -> Result<Value, ApiError> {
-    let mut fields = serde_json::to_value(&response.fields).map_err(|error| {
-        ApiError::Internal(format!(
-            "failed to serialize mission response LXMF fields: {error}"
-        ))
-    })?;
-    if let (Some(team_uid), Some(fields)) = (team_uid, fields.as_object_mut()) {
-        fields.insert(FIELD_GROUP.to_string(), json!(team_uid));
-    }
-    Ok(fields)
-}
-
-fn fanout_mission_sync_response_to_team(
-    state: &AppState,
-    response: &r3akt_rch_core::MissionSyncResponse,
-    team_uid: Option<&str>,
-    team_destinations: Option<&[String]>,
-) -> Result<(), ApiError> {
-    let Some(event) = response.event_field() else {
-        return Ok(());
-    };
-    let mission_uid = mission_uid_from_response_fields(response);
-    let destinations = if let Some(destinations) = team_destinations {
-        destinations.to_vec()
-    } else {
-        let Some(mission_uid) = mission_uid.as_deref() else {
-            return Ok(());
-        };
-        mission_team_member_destinations(state, mission_uid)?
-    };
-    if destinations.is_empty() {
-        return Ok(());
-    }
-    let lxmf_fields = mission_response_fields(response, team_uid)?;
-    let event_type = event
-        .get("event_type")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    for destination in destinations {
-        record_outbound_message_with_metadata(
-            state,
-            format!("r3akt mission event {event_type}").trim(),
-            None,
-            Some(destination),
-            Vec::new(),
-            true,
-            json!({
-                "reticulumd_inbound_mission_team_fanout": true,
-                "source": "r3akt-rch-server",
-                "direction": "outbound",
-                "mission_uid": mission_uid,
-                "team_uid": team_uid,
-                "lxmf_fields": lxmf_fields.clone(),
-            }),
-        )?;
-    }
-    Ok(())
 }
 
 fn mission_uid_from_response_fields(

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -67,7 +67,9 @@ use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
 use futures_util::SinkExt;
 #[cfg(test)]
 use r3akt_profile_rch::FIELD_EVENT;
-use r3akt_profile_rch::{CommandResultStatus, FIELD_COMMANDS, MissionCommandEnvelope, RchSource};
+use r3akt_profile_rch::{
+    CommandResultStatus, FIELD_COMMANDS, FIELD_GROUP, MissionCommandEnvelope, RchSource,
+};
 use r3akt_protocol::{Destination, HealthTelemetry, Payload, ProtocolEnvelope};
 use r3akt_rch_bridge::{ReticulumdRpc, ReticulumdRpcClient};
 use r3akt_rch_core::{
@@ -4946,6 +4948,16 @@ fn process_reticulumd_inbound_mission_sync_command(
     };
     let mut core = RchCore::from_snapshot(snapshot.clone())
         .map_err(|error| ApiError::Internal(error.to_string()))?;
+    let team_uid = command
+        .args
+        .get("_rem_team_uid")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+    let team_destinations = team_uid.as_deref().map(|team_uid| {
+        core.rem_team_routing_destinations(envelope.source.to_string().as_str(), team_uid)
+    });
     let responses = if checklist {
         core.handle_checklist_sync_command(&mission_command)
     } else {
@@ -4970,8 +4982,14 @@ fn process_reticulumd_inbound_mission_sync_command(
             envelope.topic.to_string().as_str(),
             command,
             &response,
+            team_uid.as_deref(),
         )?;
-        fanout_mission_sync_response_to_team(state, &response)?;
+        fanout_mission_sync_response_to_team(
+            state,
+            &response,
+            team_uid.as_deref(),
+            team_destinations.as_deref(),
+        )?;
     }
     Ok(())
 }
@@ -5006,7 +5024,9 @@ fn send_mission_sync_response_to_source(
     topic: &str,
     command: &r3akt_protocol::Command,
     response: &r3akt_rch_core::MissionSyncResponse,
+    team_uid: Option<&str>,
 ) -> Result<OutboundMessageRecord, ApiError> {
+    let lxmf_fields = mission_response_fields(response, team_uid)?;
     record_outbound_message_with_metadata(
         state,
         response.content.as_str(),
@@ -5022,25 +5042,48 @@ fn send_mission_sync_response_to_source(
             "inbound_topic": topic,
             "command": command.name,
             "correlation_id": command.correlation_id,
-            "lxmf_fields": response.fields,
+            "lxmf_fields": lxmf_fields,
         }),
     )
+}
+
+fn mission_response_fields(
+    response: &r3akt_rch_core::MissionSyncResponse,
+    team_uid: Option<&str>,
+) -> Result<Value, ApiError> {
+    let mut fields = serde_json::to_value(&response.fields).map_err(|error| {
+        ApiError::Internal(format!(
+            "failed to serialize mission response LXMF fields: {error}"
+        ))
+    })?;
+    if let (Some(team_uid), Some(fields)) = (team_uid, fields.as_object_mut()) {
+        fields.insert(FIELD_GROUP.to_string(), json!(team_uid));
+    }
+    Ok(fields)
 }
 
 fn fanout_mission_sync_response_to_team(
     state: &AppState,
     response: &r3akt_rch_core::MissionSyncResponse,
+    team_uid: Option<&str>,
+    team_destinations: Option<&[String]>,
 ) -> Result<(), ApiError> {
     let Some(event) = response.event_field() else {
         return Ok(());
     };
-    let Some(mission_uid) = mission_uid_from_response_fields(response) else {
-        return Ok(());
+    let mission_uid = mission_uid_from_response_fields(response);
+    let destinations = if let Some(destinations) = team_destinations {
+        destinations.to_vec()
+    } else {
+        let Some(mission_uid) = mission_uid.as_deref() else {
+            return Ok(());
+        };
+        mission_team_member_destinations(state, mission_uid)?
     };
-    let destinations = mission_team_member_destinations(state, mission_uid.as_str())?;
     if destinations.is_empty() {
         return Ok(());
     }
+    let lxmf_fields = mission_response_fields(response, team_uid)?;
     let event_type = event
         .get("event_type")
         .and_then(Value::as_str)
@@ -5058,7 +5101,8 @@ fn fanout_mission_sync_response_to_team(
                 "source": "r3akt-rch-server",
                 "direction": "outbound",
                 "mission_uid": mission_uid,
-                "lxmf_fields": response.fields,
+                "team_uid": team_uid,
+                "lxmf_fields": lxmf_fields.clone(),
             }),
         )?;
     }
@@ -12888,7 +12932,9 @@ fn supported_commands_document() -> String {
             .to_string(),
         "`rem.registry.peers.list` returns active REM peers and `effective_connected_mode`."
             .to_string(),
-        "`rem.registry.team_peers.list` returns recent REM-capable peers in teams shared with the requesting REM identity."
+        "`rem.registry.team_peers.list` returns a versioned canonical TEAM directory, caller memberships, durable REM-member destinations, and legacy recent `items`."
+            .to_string(),
+        "Team-scoped REM commands use LXMF `FIELD_GROUP` (`0x0B`); RCH validates caller membership and constrains Connected-mode fanout to that TEAM."
             .to_string(),
         String::new(),
     ]);

--- a/crates/r3akt-rch-server/src/rem_team_routing.rs
+++ b/crates/r3akt-rch-server/src/rem_team_routing.rs
@@ -1,0 +1,98 @@
+use r3akt_profile_rch::FIELD_GROUP;
+use serde_json::{Value, json};
+
+use super::{
+    ApiError, AppState, OutboundMessageRecord, mission_team_member_destinations,
+    mission_uid_from_response_fields, record_outbound_message_with_metadata,
+};
+
+pub(super) fn send_mission_sync_response_to_source(
+    state: &AppState,
+    source: &str,
+    topic: &str,
+    command: &r3akt_protocol::Command,
+    response: &r3akt_rch_core::MissionSyncResponse,
+    team_uid: Option<&str>,
+) -> Result<OutboundMessageRecord, ApiError> {
+    let lxmf_fields = mission_response_fields(response, team_uid)?;
+    record_outbound_message_with_metadata(
+        state,
+        response.content.as_str(),
+        None,
+        Some(source.to_string()),
+        Vec::new(),
+        true,
+        json!({
+            "reticulumd_inbound_command_reply": true,
+            "source": "r3akt-rch-server",
+            "direction": "outbound",
+            "inbound_source": source,
+            "inbound_topic": topic,
+            "command": command.name,
+            "correlation_id": command.correlation_id,
+            "lxmf_fields": lxmf_fields,
+        }),
+    )
+}
+
+fn mission_response_fields(
+    response: &r3akt_rch_core::MissionSyncResponse,
+    team_uid: Option<&str>,
+) -> Result<Value, ApiError> {
+    let mut fields = serde_json::to_value(&response.fields).map_err(|error| {
+        ApiError::Internal(format!(
+            "failed to serialize mission response LXMF fields: {error}"
+        ))
+    })?;
+    if let (Some(team_uid), Some(fields)) = (team_uid, fields.as_object_mut()) {
+        fields.insert(FIELD_GROUP.to_string(), json!(team_uid));
+    }
+    Ok(fields)
+}
+
+pub(super) fn fanout_mission_sync_response_to_team(
+    state: &AppState,
+    response: &r3akt_rch_core::MissionSyncResponse,
+    team_uid: Option<&str>,
+    team_destinations: Option<&[String]>,
+) -> Result<(), ApiError> {
+    let Some(event) = response.event_field() else {
+        return Ok(());
+    };
+    let mission_uid = mission_uid_from_response_fields(response);
+    let destinations = if let Some(destinations) = team_destinations {
+        destinations.to_vec()
+    } else {
+        let Some(mission_uid) = mission_uid.as_deref() else {
+            return Ok(());
+        };
+        mission_team_member_destinations(state, mission_uid)?
+    };
+    if destinations.is_empty() {
+        return Ok(());
+    }
+    let lxmf_fields = mission_response_fields(response, team_uid)?;
+    let event_type = event
+        .get("event_type")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    for destination in destinations {
+        record_outbound_message_with_metadata(
+            state,
+            format!("r3akt mission event {event_type}").trim(),
+            None,
+            Some(destination),
+            Vec::new(),
+            true,
+            json!({
+                "reticulumd_inbound_mission_team_fanout": true,
+                "source": "r3akt-rch-server",
+                "direction": "outbound",
+                "mission_uid": mission_uid,
+                "team_uid": team_uid,
+                "lxmf_fields": lxmf_fields.clone(),
+            }),
+        )?;
+    }
+    Ok(())
+}

--- a/crates/r3akt-rch-server/src/tests/rem_team_directory.rs
+++ b/crates/r3akt-rch-server/src/tests/rem_team_directory.rs
@@ -2,6 +2,8 @@ use super::*;
 
 #[tokio::test]
 async fn reticulumd_inbound_team_peer_directory_returns_only_shared_team_rem_peers() {
+    const YELLOW_TEAM_UID: &str = "d6b6e188b910d6bdd24d04b7a7ec5444";
+    const BLUE_TEAM_UID: &str = "43341e5c822d99857fa6e8641f2ca9c0";
     const CALLER_IDENTITY: &str = "11111111111111111111111111111111";
     const CALLER_DESTINATION: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const TEAMMATE_IDENTITY: &str = "22222222222222222222222222222222";
@@ -21,16 +23,16 @@ async fn reticulumd_inbound_team_peer_directory_returns_only_shared_team_rem_pee
         }
     };
     let mut core = RchCore::new();
-    for (uid, name) in [("team-alpha", "Alpha"), ("team-bravo", "Bravo")] {
+    for (uid, name) in [(YELLOW_TEAM_UID, "Yellow"), (BLUE_TEAM_UID, "Blue")] {
         core.handle_command(&setup_command(
             "mission.registry.team.upsert",
             json!({ "uid": uid, "team_name": name }),
         ));
     }
     for (uid, team_uid, identity) in [
-        ("member-caller", "team-alpha", CALLER_IDENTITY),
-        ("member-teammate", "team-alpha", TEAMMATE_IDENTITY),
-        ("member-outsider", "team-bravo", OUTSIDER_IDENTITY),
+        ("member-caller", YELLOW_TEAM_UID, CALLER_IDENTITY),
+        ("member-teammate", YELLOW_TEAM_UID, TEAMMATE_IDENTITY),
+        ("member-outsider", BLUE_TEAM_UID, OUTSIDER_IDENTITY),
     ] {
         core.handle_command(&setup_command(
             "mission.registry.team_member.upsert",
@@ -132,6 +134,15 @@ async fn reticulumd_inbound_team_peer_directory_returns_only_shared_team_rem_pee
         .expect("result reply");
     assert_eq!(result["fields"]["10"]["command_id"], "hub-directory-123");
     assert_eq!(result["fields"]["10"]["result"]["scope"], "shared_teams");
+    assert_eq!(result["fields"]["10"]["result"]["schema_version"], 2);
+    assert_eq!(
+        result["fields"]["10"]["result"]["caller_memberships"][0]["team_uid"],
+        YELLOW_TEAM_UID
+    );
+    assert_eq!(
+        result["fields"]["10"]["result"]["members"][0]["team_uid"],
+        YELLOW_TEAM_UID
+    );
     let items = result["fields"]["10"]["result"]["items"]
         .as_array()
         .expect("items");

--- a/crates/r3akt-transport-rns/src/lib.rs
+++ b/crates/r3akt-transport-rns/src/lib.rs
@@ -2349,7 +2349,17 @@ fn direct_lxmf_message_envelope(
     let fields = message.get("fields").and_then(JsonValue::as_object);
     let source = optional_message_string(message, &["source", "source_hash", "source_id"])
         .unwrap_or("unknown");
-    if let Some(command) = direct_lxmf_mission_command(fields) {
+    if let Some(mut command) = direct_lxmf_mission_command(fields) {
+        if let Some(team_uid) = fields.and_then(|fields| {
+            optional_field_string(fields, &["11", "FIELD_GROUP", "group", "Group"])
+        }) {
+            if let Some(args) = command.args.as_object_mut() {
+                args.insert(
+                    "_rem_team_uid".to_string(),
+                    JsonValue::String(team_uid.to_string()),
+                );
+            }
+        }
         let mut envelope = ProtocolEnvelope::new(
             NodeId::new(source),
             Destination::Node(NodeId::new(local_source)),
@@ -5003,6 +5013,7 @@ mod tests {
                 "source": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "destination": "local-destination",
                 "fields": {
+                    "11": "43341e5c822d99857fa6e8641f2ca9c0",
                     "9": [{
                         "command_id": "hub-directory-123",
                         "command_type": "rem.registry.team_peers.list",
@@ -5035,7 +5046,12 @@ mod tests {
         };
         assert_eq!(command.name, "rem.registry.team_peers.list");
         assert_eq!(command.correlation_id.as_deref(), Some("hub-directory-123"));
-        assert_eq!(command.args, serde_json::json!({}));
+        assert_eq!(
+            command.args,
+            serde_json::json!({
+                "_rem_team_uid": "43341e5c822d99857fa6e8641f2ca9c0"
+            })
+        );
     }
 
     #[test]

--- a/crates/r3akt-transport-rns/src/lib.rs
+++ b/crates/r3akt-transport-rns/src/lib.rs
@@ -3633,6 +3633,9 @@ mod tests {
 
     use super::*;
 
+    #[path = "rem_team_scope.rs"]
+    mod rem_team_scope;
+
     #[derive(Debug, Clone)]
     struct RecordedRpcCall {
         method: String,
@@ -5003,55 +5006,6 @@ mod tests {
         );
         assert_eq!(message.attachments[0].category, "file");
         assert_eq!(rpc.calls[0].method, "list_messages");
-    }
-
-    #[test]
-    fn reticulumd_rpc_adapter_maps_field_commands_mission_envelope() {
-        let mut rpc = RecordingReticulumdRpc::with_responses(vec![serde_json::json!({
-            "messages": [{
-                "id": "directory-command-1",
-                "source": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "destination": "local-destination",
-                "fields": {
-                    "11": "43341e5c822d99857fa6e8641f2ca9c0",
-                    "9": [{
-                        "command_id": "hub-directory-123",
-                        "command_type": "rem.registry.team_peers.list",
-                        "source": {
-                            "rns_identity": "11111111111111111111111111111111"
-                        },
-                        "timestamp": "2026-07-16T12:00:00Z",
-                        "args": {}
-                    }]
-                }
-            }]
-        })]);
-        let mut adapter = ReticulumdRpcLxmfRsAdapter::new(
-            "local-destination",
-            ReticulumdRpcTransport::from_rpc(&mut rpc),
-        );
-
-        let frame = crate::test_block_on(adapter.receive_frame())
-            .expect("receive")
-            .expect("frame");
-        let envelope = ProtocolEnvelope::decode_msgpack(&frame.bytes).expect("envelope");
-
-        assert_eq!(
-            envelope.source.to_string(),
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
-        assert_eq!(envelope.stable_dedupe_key(), "directory-command-1");
-        let Payload::Command(command) = envelope.payload else {
-            panic!("expected command");
-        };
-        assert_eq!(command.name, "rem.registry.team_peers.list");
-        assert_eq!(command.correlation_id.as_deref(), Some("hub-directory-123"));
-        assert_eq!(
-            command.args,
-            serde_json::json!({
-                "_rem_team_uid": "43341e5c822d99857fa6e8641f2ca9c0"
-            })
-        );
     }
 
     #[test]

--- a/crates/r3akt-transport-rns/src/tests/rem_team_scope.rs
+++ b/crates/r3akt-transport-rns/src/tests/rem_team_scope.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+#[test]
+fn reticulumd_rpc_adapter_maps_field_commands_mission_envelope() {
+    let mut rpc = RecordingReticulumdRpc::with_responses(vec![serde_json::json!({
+        "messages": [{
+            "id": "directory-command-1",
+            "source": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "destination": "local-destination",
+            "fields": {
+                "11": "43341e5c822d99857fa6e8641f2ca9c0",
+                "9": [{
+                    "command_id": "hub-directory-123",
+                    "command_type": "rem.registry.team_peers.list",
+                    "source": {
+                        "rns_identity": "11111111111111111111111111111111"
+                    },
+                    "timestamp": "2026-07-16T12:00:00Z",
+                    "args": {}
+                }]
+            }
+        }]
+    })]);
+    let mut adapter = ReticulumdRpcLxmfRsAdapter::new(
+        "local-destination",
+        ReticulumdRpcTransport::from_rpc(&mut rpc),
+    );
+
+    let frame = crate::test_block_on(adapter.receive_frame())
+        .expect("receive")
+        .expect("frame");
+    let envelope = ProtocolEnvelope::decode_msgpack(&frame.bytes).expect("envelope");
+
+    assert_eq!(
+        envelope.source.to_string(),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
+    assert_eq!(envelope.stable_dedupe_key(), "directory-command-1");
+    let Payload::Command(command) = envelope.payload else {
+        panic!("expected command");
+    };
+    assert_eq!(command.name, "rem.registry.team_peers.list");
+    assert_eq!(command.correlation_id.as_deref(), Some("hub-directory-123"));
+    assert_eq!(
+        command.args,
+        serde_json::json!({
+            "_rem_team_uid": "43341e5c822d99857fa6e8641f2ca9c0"
+        })
+    );
+}

--- a/docs/rem-southbound-interface.md
+++ b/docs/rem-southbound-interface.md
@@ -112,17 +112,47 @@ normal mission-style command envelope in `FIELD_COMMANDS` (`0x09`):
 ```
 
 RCH requires the caller to have REM announce capabilities and to be linked to a
-TEAM member. It returns only recent, active, non-moderated REM destinations from
-teams shared with that member. Primary TEAM member identities and explicitly
-linked client identities are both eligible. The caller's own identity is
-excluded.
+TEAM member. Version 2 returns canonical shared TEAM records, caller
+memberships, and durable REM-member destinations, including members whose last
+validated announce is now offline. Non-REM, unverified, banned, blackholed, and
+self entries are excluded. Primary TEAM member identities and explicitly linked
+client identities are both eligible. The legacy `items` array remains recent
+and active only so older REM clients retain their existing behavior.
 
 The terminal `FIELD_RESULTS` (`0x0a`) result payload is:
 
 ```json
 {
+  "schema_version": 2,
   "scope": "shared_teams",
   "effective_connected_mode": false,
+  "teams": [
+    {
+      "uid": "d6b6e188b910d6bdd24d04b7a7ec5444",
+      "color": "YELLOW",
+      "team_name": "Yellow"
+    }
+  ],
+  "caller_memberships": [
+    {
+      "team_uid": "d6b6e188b910d6bdd24d04b7a7ec5444",
+      "team_member_uid": "<caller TEAM member UID>"
+    }
+  ],
+  "members": [
+    {
+      "team_uid": "d6b6e188b910d6bdd24d04b7a7ec5444",
+      "team_member_uid": "<peer TEAM member UID>",
+      "identity": "<TEAM member identity>",
+      "destination_hash": "<last validated lxmf.delivery destination>",
+      "display_name": "Field Phone",
+      "announce_capabilities": ["r3akt", "emergencymessages", "telemetry"],
+      "client_type": "rem",
+      "registered_mode": "semi_autonomous",
+      "last_seen": "2026-07-16T12:00:00Z",
+      "status": "offline"
+    }
+  ],
   "items": [
     {
       "identity": "<TEAM member identity>",
@@ -137,6 +167,12 @@ The terminal `FIELD_RESULTS` (`0x0a`) result payload is:
   ]
 }
 ```
+
+REM team-scoped traffic carries the canonical TEAM UID in LXMF `FIELD_GROUP`
+(`0x0B`). RCH rejects unknown TEAM UIDs and callers that do not belong to the
+requested TEAM. In Connected mode, RCH fanout is restricted to the validated
+TEAM's durable REM destinations. Commands without `FIELD_GROUP` remain accepted
+for compatibility with older REM clients.
 
 `rem.registry.peers.list` remains available as the legacy unscoped REM registry
 command, and `GET /api/rem/peers` remains the operator-facing HTTP registry.


### PR DESCRIPTION
## Summary

- add the canonical versioned REM TEAM directory schema while retaining legacy directory items
- preserve multiple team memberships and return only recent destinations shared with the requesting REM client
- carry `FIELD_GROUP` through the current RCH profile and Reticulum adapter
- validate `_rem_team_uid`, reject unauthorized team requests, and scope mission response fanout to the selected team
- document the compatible southbound contract and add regression coverage across profile, core, server, and transport layers

## Compatibility

Existing commands without a field group remain accepted. The change adds team scoping without renaming or removing current northbound or southbound fields.

During self-review, the mission response field serializer was changed from an empty-object fallback to a propagated contextual error so malformed output cannot be reported as a successful send.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- focused REM team directory and server tests
- `git diff --check`
