### PR TITLE
Add client type filters to announces UI

### DIFF
--- a/ui/src/pages/UsersPage.vue
+++ b/ui/src/pages/UsersPage.vue
@@ -58,9 +58,35 @@
 
           <div v-if="activeTab === 'clients'" class="tree-search">
             <input v-model="clientFilter" type="text" placeholder="Filter users by name/hash" />
+            <div class="client-type-filter" role="group" aria-label="Filter users by client type">
+              <button
+                v-for="option in clientTypeFilterOptions"
+                :key="`client-${option.value}`"
+                class="client-type-filter__option"
+                :class="{ active: clientTypeFilter === option.value }"
+                type="button"
+                :aria-pressed="clientTypeFilter === option.value"
+                @click="clientTypeFilter = option.value"
+              >
+                {{ option.label }}
+              </button>
+            </div>
           </div>
           <div v-else-if="activeTab === 'identities'" class="tree-search">
             <input v-model="identityFilter" type="text" placeholder="Filter identities by name/hash" />
+            <div class="client-type-filter" role="group" aria-label="Filter announces by client type">
+              <button
+                v-for="option in clientTypeFilterOptions"
+                :key="`identity-${option.value}`"
+                class="client-type-filter__option"
+                :class="{ active: identityTypeFilter === option.value }"
+                type="button"
+                :aria-pressed="identityTypeFilter === option.value"
+                @click="identityTypeFilter = option.value"
+              >
+                {{ option.label }}
+              </button>
+            </div>
           </div>
           <div v-else-if="activeTab === 'rem-peers'" class="tree-search">
             <input v-model="remPeerFilter" type="text" placeholder="Filter REM peers by name/hash/mode" />
@@ -520,6 +546,13 @@ import { resolveIdentityLabel, shortHash } from "../utils/identity";
 import { resolveTeamMemberPrimaryLabel } from "../utils/team-members";
 
 type ActiveTab = "clients" | "identities" | "rem-peers" | "routing" | "teams" | "team-members" | "rights";
+type ClientTypeFilter = "all" | "rem" | "generic_lxmf";
+
+const clientTypeFilterOptions: { label: string; value: ClientTypeFilter }[] = [
+  { label: "All", value: "all" },
+  { label: "REM", value: "rem" },
+  { label: "LXMF", value: "generic_lxmf" }
+];
 
 const toStringList = (value: unknown): string[] =>
   Array.isArray(value)
@@ -620,6 +653,8 @@ const teamsPageSize = 9;
 const teamMembersPageSize = 9;
 const identityFilter = ref("");
 const clientFilter = ref("");
+const clientTypeFilter = ref<ClientTypeFilter>("all");
+const identityTypeFilter = ref<ClientTypeFilter>("all");
 const remPeerFilter = ref("");
 const teamFilter = ref("");
 const teamMemberFilter = ref("");
@@ -691,13 +726,12 @@ const activeTabTitle = computed(() => {
 
 const filteredClients = computed(() => {
   const filter = clientFilter.value.trim().toLowerCase();
-  if (!filter) {
-    return usersStore.clients;
-  }
   return usersStore.clients.filter((client) => {
     const displayName = resolveClientDisplayName(client) ?? "";
     const id = client.id ?? "";
-    return displayName.toLowerCase().includes(filter) || id.toLowerCase().includes(filter);
+    const matchesText =
+      !filter || displayName.toLowerCase().includes(filter) || id.toLowerCase().includes(filter);
+    return matchesText && matchesClientType(client.client_type, client.is_rem_capable, clientTypeFilter.value);
   });
 });
 
@@ -726,20 +760,18 @@ const pagedClients = computed(() => {
 
 const filteredIdentities = computed(() => {
   const filter = identityFilter.value.trim().toLowerCase();
-  if (!filter) {
-    return usersStore.identities;
-  }
   return usersStore.identities.filter((identity) => {
     const displayName = identity.display_name ?? "";
     const id = identity.id ?? "";
     const announceSource = identity.announce_source ?? "";
     const announceDestination = identity.announce_destination_hash ?? "";
-    return (
+    const matchesText =
+      !filter ||
       displayName.toLowerCase().includes(filter) ||
       id.toLowerCase().includes(filter) ||
       announceSource.toLowerCase().includes(filter) ||
-      announceDestination.toLowerCase().includes(filter)
-    );
+      announceDestination.toLowerCase().includes(filter);
+    return matchesText && matchesClientType(identity.client_type, identity.is_rem_capable, identityTypeFilter.value);
   });
 });
 
@@ -1204,6 +1236,18 @@ const clientTypeLabel = (clientType?: string, isRemCapable?: boolean): string =>
   return isRemCapable || clientType === "rem" ? "REM Client" : "Generic LXMF";
 };
 
+const matchesClientType = (
+  clientType: string | undefined,
+  isRemCapable: boolean | undefined,
+  filter: ClientTypeFilter
+): boolean => {
+  if (filter === "all") {
+    return true;
+  }
+  const resolvedType = isRemCapable || clientType?.trim().toLowerCase() === "rem" ? "rem" : "generic_lxmf";
+  return resolvedType === filter;
+};
+
 type IdentityWithAnnounce = {
   id?: string;
   announce_destination_hash?: string;
@@ -1644,7 +1688,7 @@ watch(clientPageCount, (count) => {
   }
 });
 
-watch(clientFilter, () => {
+watch([clientFilter, clientTypeFilter], () => {
   clientsPage.value = 1;
 });
 
@@ -1654,7 +1698,7 @@ watch(identityPageCount, (count) => {
   }
 });
 
-watch(identityFilter, () => {
+watch([identityFilter, identityTypeFilter], () => {
   identitiesPage.value = 1;
 });
 

--- a/ui/src/pages/styles/UsersPage.css
+++ b/ui/src/pages/styles/UsersPage.css
@@ -80,6 +80,48 @@
   color: rgba(209, 251, 255, 0.4);
 }
 
+.client-type-filter {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 4px;
+  margin-top: 8px;
+  padding: 4px;
+  border: 1px solid rgba(55, 242, 255, 0.22);
+  border-radius: 10px;
+  background: rgba(3, 11, 18, 0.72);
+}
+
+.client-type-filter__option {
+  min-width: 0;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  padding: 6px 4px;
+  background: transparent;
+  color: rgba(209, 251, 255, 0.52);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  transition: border-color 0.16s ease, background 0.16s ease, color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.client-type-filter__option:hover {
+  color: rgba(223, 252, 255, 0.9);
+  border-color: rgba(55, 242, 255, 0.24);
+}
+
+.client-type-filter__option:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
+}
+
+.client-type-filter__option.active {
+  border-color: rgba(55, 242, 255, 0.58);
+  background: rgba(55, 242, 255, 0.13);
+  color: var(--neon);
+  box-shadow: inset 0 0 12px rgba(55, 242, 255, 0.08), 0 0 10px rgba(55, 242, 255, 0.12);
+}
+
 .tree-note {
   margin-top: 14px;
   padding: 12px;

--- a/ui/tests/users-page.test.ts
+++ b/ui/tests/users-page.test.ts
@@ -39,6 +39,16 @@ const clientAlpha = {
   is_rem_capable: false
 };
 
+const clientRem = {
+  identity: "client-rem",
+  display_name: "Rescue Mobile",
+  last_seen: "2026-06-23T06:02:00Z",
+  metadata: {},
+  client_type: "rem",
+  announce_capabilities: ["r3akt", "emergencymessages"],
+  is_rem_capable: true
+};
+
 const identityAlpha = {
   Identity: "client-alpha",
   DisplayName: "Alpha Client",
@@ -126,6 +136,18 @@ const clickCardButton = async (cardText: string, label: string) => {
   await waitForUi();
 };
 
+const clickClientTypeFilter = async (groupLabel: string, label: string) => {
+  const group = document.querySelector(`[aria-label="${groupLabel}"]`);
+  const button = Array.from(group?.querySelectorAll("button") ?? []).find(
+    (entry) => (entry.textContent ?? "").trim() === label
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Client type filter not found: ${groupLabel} / ${label}`);
+  }
+  button.click();
+  await waitForUi();
+};
+
 const mountPage = async (): Promise<MountedPage> => {
   const root = document.createElement("div");
   document.body.appendChild(root);
@@ -156,7 +178,7 @@ const currentIdentities = () => [identityAlpha, identityBravo];
 const setupApiMocks = () => {
   getMock.mockImplementation((path: string) => {
     if (path === "/Client") {
-      return Promise.resolve([clientAlpha]);
+      return Promise.resolve([clientAlpha, clientRem]);
     }
     if (path === "/Identities") {
       return Promise.resolve(currentIdentities());
@@ -284,5 +306,28 @@ describe("users page", () => {
     expect(text()).toContain("Bravo Route");
     expect(text()).toContain("route-bravo");
     expect(text()).toContain("Joined");
+  });
+
+  it("filters users and identity announces by client type", async () => {
+    page = await mountPage();
+
+    expect(text()).toContain("Alpha Client");
+    expect(text()).toContain("Rescue Mobile");
+
+    await clickClientTypeFilter("Filter users by client type", "REM");
+
+    expect(text()).not.toContain("Alpha Client");
+    expect(text()).toContain("Rescue Mobile");
+
+    await clickButton("Identities", 1);
+    await clickClientTypeFilter("Filter announces by client type", "REM");
+
+    expect(text()).not.toContain("Alpha Client");
+    expect(text()).toContain("Bravo Identity");
+
+    await clickClientTypeFilter("Filter announces by client type", "LXMF");
+
+    expect(text()).toContain("Alpha Client");
+    expect(text()).not.toContain("Bravo Identity");
   });
 });


### PR DESCRIPTION
## Summary

- add All, REM, and LXMF client-type controls to the Users and identity-announces views
- combine client-type selection with the existing text filters and pagination
- match the existing cosmic UI styling and expose accessible pressed/focus states
- add coverage for filtering both users and identity announces

## Why

Operators need to separate REM clients from generic LXMF clients when reviewing announces, following the quick client-type filtering pattern used by Columba.

## Impact

The filter is local UI state and does not change announce ingestion, backend classification, or stored records. Existing behavior remains the default through the All selection.

## Validation

- `npm --prefix ui run test -- --run tests/users-page.test.ts`
- `npm --prefix ui run typecheck`
- `npm --prefix ui run lint`
- `npm --prefix ui run build`
- full UI suite from the implementation pass: 113 tests passed