### PR TITLE
Restore RCH LXMF remote commands

### DIFF
--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -39,6 +39,7 @@
 
 mod auth;
 mod rem_team_routing;
+mod reticulumd_inbound;
 
 use rem_team_routing::{
     fanout_mission_sync_response_to_team, send_mission_sync_response_to_source,
@@ -96,7 +97,7 @@ use r3akt_transport_rns::{
     LxmfSdkSharedOutboundBatch, LxmfSdkSharedPayload, LxmfSdkSharedRecipient,
     RchServiceIdentityConfig, ReticulumdAnnounceRecord, ZmqDataPlane,
     delivery_snapshot_receipt_status, list_reticulumd_announces, lxmf_shared_batch_to_legacy_batch,
-    poll_reticulumd_events, reticulumd_event_to_envelope, reticulumd_message_to_envelope,
+    poll_reticulumd_events, reticulumd_message_to_envelope,
 };
 use rand_core::OsRng;
 use rns_core::identity::{PRIVATE_KEY_LENGTH, PrivateIdentity};
@@ -307,6 +308,7 @@ struct ReticulumdInboundWorkerStats {
     events_imported_total: u64,
     stream_gaps_total: u64,
     error_total: u64,
+    quarantined_total: u64,
     last_poll_ts_ms: Option<i64>,
     last_received_ts_ms: Option<i64>,
     last_announce_id: Option<String>,
@@ -316,6 +318,7 @@ struct ReticulumdInboundWorkerStats {
     last_event_type: Option<String>,
     last_cursor_reset_reason: Option<String>,
     last_error: Option<String>,
+    last_quarantine_error: Option<String>,
 }
 
 #[derive(Debug, Default)]
@@ -3703,8 +3706,8 @@ fn process_reticulumd_event_batch(
                 announce_events.push(announce);
             }
             "inbound" | "InboundMessageReceived" => {
-                if let Some(envelope) = reticulumd_event_to_envelope(event, source)
-                    .map_err(|error| ApiError::Internal(error.to_string()))?
+                if let Some(envelope) =
+                    reticulumd_inbound::decode_event_or_quarantine(state, event, source)?
                 {
                     envelopes.push(envelope);
                 }
@@ -3793,8 +3796,8 @@ fn process_reticulumd_list_messages_result(
         if !destination.eq_ignore_ascii_case(source) {
             continue;
         }
-        if let Some(envelope) = reticulumd_message_to_envelope(message, source)
-            .map_err(|error| ApiError::Internal(error.to_string()))?
+        if let Some(envelope) =
+            reticulumd_inbound::decode_message_or_quarantine(state, message, source)?
         {
             if reticulumd_inbound_was_already_processed(state, &envelope)? {
                 continue;
@@ -10995,6 +10998,7 @@ fn reticulumd_inbound_worker_diagnostics(state: &AppState) -> Value {
             "events_imported_total": stats.events_imported_total,
             "stream_gaps_total": stats.stream_gaps_total,
             "error_total": stats.error_total,
+            "quarantined_total": stats.quarantined_total,
             "last_poll_ts_ms": stats.last_poll_ts_ms,
             "last_poll_at": stats.last_poll_ts_ms.map(iso8601_from_unix_ms),
             "last_received_ts_ms": stats.last_received_ts_ms,
@@ -11006,6 +11010,7 @@ fn reticulumd_inbound_worker_diagnostics(state: &AppState) -> Value {
             "last_event_type": stats.last_event_type,
             "last_cursor_reset_reason": stats.last_cursor_reset_reason,
             "last_error": stats.last_error,
+            "last_quarantine_error": stats.last_quarantine_error,
         }),
         Err(error) => json!({
             "configured": reticulumd_inbound_worker_configured(state),

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -11462,6 +11462,12 @@ fn poll_reticulumd_delivery_receipts(state: &AppState) -> Result<(), ApiError> {
                 .and_then(|target| target.status.as_deref())
                 .unwrap_or("sent");
             mark_reticulumd_status_sent(state, &message_id, receipt_status)?;
+        } else if statuses.len() == targets.len()
+            && statuses
+                .iter()
+                .all(reticulumd_receipt_target_success_terminal)
+        {
+            mark_reticulumd_status_sent(state, &message_id, "sent")?;
         } else if statuses.len() == targets.len() {
             if let Some(receipt_status) =
                 propagated_fanout_partial_success_status(&message, &statuses)
@@ -12883,7 +12889,8 @@ fn command_help_text() -> String {
     let mut lines = vec![
         "# Command list".to_string(),
         String::new(),
-        "Use the `Command` field (`0`) for legacy/plugin payloads or `command_type` in mission-style envelopes carried in `FIELD_COMMANDS` (`0x09`).".to_string(),
+        "Use `FIELD_COMMANDS` (`0x09`) with `Command` or `0` for legacy/plugin payloads, or `command_type` with `args` for mission-style envelopes.".to_string(),
+        r#"Columba-compatible join: `{"9":[{"Command":"join"}]}` (numeric selector: `{"9":[{"0":"join"}]}`)."#.to_string(),
         "Tip: tag file/image attachments with a `TopicID` or send `AssociateTopicID` to link them to a topic.".to_string(),
         String::new(),
     ];
@@ -12914,15 +12921,21 @@ fn supported_commands_document() -> String {
         String::new(),
         "This document lists command families accepted by RCH over the LXMF southbound interface.".to_string(),
         String::new(),
-        "Legacy/plugin commands use `FIELD_COMMANDS` (`0x09`) with a `Command` value.".to_string(),
-        "Mission-sync, checklist, and REM registry commands use the mission envelope schema and select behavior with `command_type`.".to_string(),
+        "Legacy/plugin commands use `FIELD_COMMANDS` (`0x09`) with a `Command` or `0` selector; remaining fields in the first entry become command arguments.".to_string(),
+        "Mission-sync, checklist, and REM registry commands use the mission envelope schema and select behavior with `command_type` plus `args`.".to_string(),
         String::new(),
         "## Transport formats".to_string(),
         String::new(),
         "Legacy/plugin example:".to_string(),
         String::new(),
         "```json".to_string(),
-        r#"[{"Command":"ListTopic"}]"#.to_string(),
+        r#"{"9":[{"Command":"join"}]}"#.to_string(),
+        "```".to_string(),
+        String::new(),
+        "Legacy/plugin numeric selector example:".to_string(),
+        String::new(),
+        "```json".to_string(),
+        r#"{"9":[{"0":"leave"}]}"#.to_string(),
         "```".to_string(),
         String::new(),
         "Mission-style envelope example:".to_string(),
@@ -28333,6 +28346,7 @@ fn bearer_token(headers: &HeaderMap) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     mod auth;
+    mod field_commands;
     mod rem_team_directory;
 
     use crate::BASE64_STANDARD;
@@ -49090,6 +49104,11 @@ mod tests {
                 .get("receipt_pending")
                 .and_then(serde_json::Value::as_bool)
                 == Some(false)
+                && current
+                    .delivery_metadata
+                    .get("receipt_status")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some()
                 && receipt_targets.len() == destinations.len()
                 && receipt_targets.iter().all(|target| {
                     target

--- a/crates/r3akt-rch-server/src/reticulumd_inbound.rs
+++ b/crates/r3akt-rch-server/src/reticulumd_inbound.rs
@@ -1,0 +1,141 @@
+use super::{
+    ApiError, AppState, ProtocolEnvelope, Value, json, record_system_event_best_effort,
+    sha256_lower_hex, unix_now_ms,
+};
+
+pub(crate) fn decode_event_or_quarantine(
+    state: &AppState,
+    event: &r3akt_transport_rns::ReticulumdEventRecord,
+    source: &str,
+) -> Result<Option<ProtocolEnvelope>, ApiError> {
+    let quarantine_key = format!("event:{}", event.event_id);
+    if quarantine_was_recorded(state, &quarantine_key)? {
+        return Ok(None);
+    }
+    match r3akt_transport_rns::reticulumd_event_to_envelope(event, source) {
+        Ok(envelope) => Ok(envelope),
+        Err(error) => handle_decode_error(
+            state,
+            &quarantine_key,
+            source,
+            Some(event.event_id.as_str()),
+            event_message_id(event),
+            error.to_string().as_str(),
+        ),
+    }
+}
+
+pub(crate) fn decode_message_or_quarantine(
+    state: &AppState,
+    message: &Value,
+    source: &str,
+) -> Result<Option<ProtocolEnvelope>, ApiError> {
+    let quarantine_key = message_quarantine_key(message, source);
+    if quarantine_was_recorded(state, &quarantine_key)? {
+        return Ok(None);
+    }
+    match r3akt_transport_rns::reticulumd_message_to_envelope(message, source) {
+        Ok(envelope) => Ok(envelope),
+        Err(error) => handle_decode_error(
+            state,
+            &quarantine_key,
+            source,
+            None,
+            message_id(message),
+            error.to_string().as_str(),
+        ),
+    }
+}
+
+fn handle_decode_error(
+    state: &AppState,
+    quarantine_key: &str,
+    source: &str,
+    event_id: Option<&str>,
+    message_id: Option<&str>,
+    error: &str,
+) -> Result<Option<ProtocolEnvelope>, ApiError> {
+    if !is_malformed_field_commands_error(error) {
+        return Err(ApiError::Internal(error.to_string()));
+    }
+    quarantine_message(state, quarantine_key, source, event_id, message_id, error)?;
+    Ok(None)
+}
+
+fn is_malformed_field_commands_error(error: &str) -> bool {
+    error.contains("malformed LXMF FIELD_COMMANDS (0x09)")
+}
+
+fn event_message_id(event: &r3akt_transport_rns::ReticulumdEventRecord) -> Option<&str> {
+    event
+        .message_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| event.payload.get("message").and_then(message_id))
+}
+
+fn message_id(message: &Value) -> Option<&str> {
+    ["id", "message_id", "messageId"].iter().find_map(|key| {
+        message
+            .get(*key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    })
+}
+
+fn message_quarantine_key(message: &Value, source: &str) -> String {
+    message_id(message).map_or_else(
+        || {
+            format!(
+                "message:{source}:sha256:{}",
+                sha256_lower_hex(message.to_string().as_bytes())
+            )
+        },
+        |message_id| format!("message:{source}:{message_id}"),
+    )
+}
+
+fn quarantine_was_recorded(state: &AppState, quarantine_key: &str) -> Result<bool, ApiError> {
+    let events = state
+        .system_events
+        .read()
+        .map_err(|error| ApiError::Internal(error.to_string()))?;
+    Ok(events.iter().any(|event| {
+        event.event_type == "reticulumd_inbound_message_quarantined"
+            && event.metadata.get("quarantine_key").and_then(Value::as_str) == Some(quarantine_key)
+    }))
+}
+
+fn quarantine_message(
+    state: &AppState,
+    quarantine_key: &str,
+    source: &str,
+    event_id: Option<&str>,
+    message_id: Option<&str>,
+    error: &str,
+) -> Result<(), ApiError> {
+    if quarantine_was_recorded(state, quarantine_key)? {
+        return Ok(());
+    }
+    record_system_event_best_effort(
+        state,
+        "reticulumd_inbound_message_quarantined",
+        "Malformed LXMF inbound message quarantined",
+        json!({
+            "quarantine_key": quarantine_key,
+            "source": source,
+            "event_id": event_id,
+            "message_id": message_id,
+            "error": error,
+        }),
+    );
+    if let Ok(mut stats) = state.reticulumd_inbound_worker_stats.write() {
+        stats.quarantined_total = stats.quarantined_total.saturating_add(1);
+        stats.error_total = stats.error_total.saturating_add(1);
+        stats.last_poll_ts_ms = Some(unix_now_ms());
+        stats.last_error = Some(format!("reticulumd inbound message quarantined: {error}"));
+        stats.last_quarantine_error = Some(error.to_string());
+    }
+    Ok(())
+}

--- a/crates/r3akt-rch-server/src/tests/field_commands.rs
+++ b/crates/r3akt-rch-server/src/tests/field_commands.rs
@@ -1,0 +1,271 @@
+use super::*;
+
+use r3akt_rch_bridge::{ReticulumdRpc, ReticulumdRpcClient};
+use serde_json::{Value, json};
+use std::time::Duration;
+use uuid::Uuid;
+
+#[test]
+fn command_docs_show_legacy_and_mission_field_shapes() {
+    let help = crate::command_help_text();
+    assert!(help.contains("FIELD_COMMANDS"));
+    assert!(help.contains(r#"{"9":[{"Command":"join"}]}"#));
+    assert!(help.contains(r#"{"9":[{"0":"join"}]}"#));
+
+    let examples = crate::supported_commands_document();
+    assert!(examples.contains(r#"{"9":[{"Command":"join"}]}"#));
+    assert!(examples.contains(r#"{"9":[{"0":"leave"}]}"#));
+    assert!(examples.contains("remaining fields in the first entry become command arguments"));
+    assert!(examples.contains("command_type` plus `args`"));
+}
+
+#[test]
+fn list_messages_legacy_join_adds_source_replies_and_deduplicates() {
+    let (endpoint, rpc_server) = fake_reticulumd_rpc_server();
+    let state = crate::AppState::default().with_reticulumd_rpc(endpoint, "hub-source");
+    let source = "77b2539b72259af927e48c0f90721767";
+    let result = json!({
+        "messages": [{
+            "id": "field-command-join-1",
+            "direction": "in",
+            "source": source,
+            "destination": "hub-source",
+            "content": "",
+            "fields": {"9": [{"Command": "join"}]},
+            "timestamp": 1_775_000_001,
+            "title": ""
+        }]
+    });
+
+    let first = crate::process_reticulumd_list_messages_result(&state, "hub-source", &result)
+        .expect("first import");
+    let second = crate::process_reticulumd_list_messages_result(&state, "hub-source", &result)
+        .expect("duplicate import");
+
+    assert_eq!(first, 1);
+    assert_eq!(second, 0);
+    assert!(state.clients.read().expect("clients").contains_key(source));
+    let messages = state.messages.read().expect("messages");
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].content, "joined");
+    drop(messages);
+
+    let request = rpc_server.join().expect("rpc server");
+    assert_eq!(request.method, "sdk_send_v2");
+    let params = request.params.expect("params");
+    assert_eq!(params["destination"], source);
+    assert_eq!(params["content"], "joined");
+}
+
+#[test]
+fn list_messages_numeric_legacy_leave_removes_source_and_replies() {
+    let (endpoint, rpc_server) = fake_reticulumd_rpc_server();
+    let state = crate::AppState::default().with_reticulumd_rpc(endpoint, "hub-source");
+    let source = "88b2539b72259af927e48c0f90721767";
+    crate::upsert_roster_client(&state, source, |_| {}).expect("seed roster");
+
+    let imported = crate::process_reticulumd_list_messages_result(
+        &state,
+        "hub-source",
+        &json!({
+            "messages": [{
+                "id": "field-command-leave-1",
+                "direction": "inbound",
+                "source": source,
+                "destination": "hub-source",
+                "content": "",
+                "fields": {"9": [{"0": "leave"}]},
+                "timestamp": 1_775_000_002,
+                "title": ""
+            }]
+        }),
+    )
+    .expect("process list messages");
+
+    assert_eq!(imported, 1);
+    assert!(!state.clients.read().expect("clients").contains_key(source));
+    let messages = state.messages.read().expect("messages");
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].content, "left");
+    drop(messages);
+
+    let request = rpc_server.join().expect("rpc server");
+    assert_eq!(request.method, "sdk_send_v2");
+    let params = request.params.expect("params");
+    assert_eq!(params["destination"], source);
+    assert_eq!(params["content"], "left");
+}
+
+#[test]
+fn list_messages_mission_style_join_still_dispatches() {
+    let (endpoint, rpc_server) = fake_reticulumd_rpc_server();
+    let state = crate::AppState::default().with_reticulumd_rpc(endpoint, "hub-source");
+    let source = "99b2539b72259af927e48c0f90721767";
+
+    let imported = crate::process_reticulumd_list_messages_result(
+        &state,
+        "hub-source",
+        &json!({
+            "messages": [{
+                "id": "field-command-mission-join-1",
+                "direction": "in",
+                "source": source,
+                "destination": "hub-source",
+                "content": "",
+                "fields": {"9": [{
+                    "command_id": "mission-join-1",
+                    "command_type": "mission.join",
+                    "args": {}
+                }]},
+                "timestamp": 1_775_000_003,
+                "title": ""
+            }]
+        }),
+    )
+    .expect("process list messages");
+
+    assert_eq!(imported, 1);
+    assert!(state.clients.read().expect("clients").contains_key(source));
+    let messages = state.messages.read().expect("messages");
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].content, "joined");
+    drop(messages);
+
+    let request = rpc_server.join().expect("rpc server");
+    assert_eq!(request.method, "sdk_send_v2");
+    let params = request.params.expect("params");
+    assert_eq!(params["destination"], source);
+    assert_eq!(params["content"], "joined");
+}
+
+#[tokio::test]
+async fn live_reticulumd_field_command_join_reaches_rch_and_reply_is_delivered_when_configured() {
+    let receiver_endpoint = match std::env::var("R3AKT_RETICULUMD_RPC_ENDPOINT") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            eprintln!("skipping live field-command test: R3AKT_RETICULUMD_RPC_ENDPOINT is unset");
+            return;
+        }
+    };
+    let sender_endpoint = match std::env::var("R3AKT_RETICULUMD_FIELD_COMMAND_RPC_ENDPOINT") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            eprintln!(
+                "skipping live field-command test: R3AKT_RETICULUMD_FIELD_COMMAND_RPC_ENDPOINT is unset"
+            );
+            return;
+        }
+    };
+    let source = match std::env::var("R3AKT_RETICULUMD_FIELD_COMMAND_SOURCE") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            eprintln!(
+                "skipping live field-command test: R3AKT_RETICULUMD_FIELD_COMMAND_SOURCE is unset"
+            );
+            return;
+        }
+    };
+    let destination = match std::env::var("R3AKT_RETICULUMD_FIELD_COMMAND_DESTINATION") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            eprintln!(
+                "skipping live field-command test: R3AKT_RETICULUMD_FIELD_COMMAND_DESTINATION is unset"
+            );
+            return;
+        }
+    };
+    let poll_attempts = std::env::var("R3AKT_RETICULUMD_RECEIPT_POLL_ATTEMPTS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(120);
+    let poll_delay_ms = std::env::var("R3AKT_RETICULUMD_RECEIPT_POLL_DELAY_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(500);
+    let db_path = std::env::temp_dir().join(format!(
+        "r3akt-rch-live-reticulumd-field-command-{}.db",
+        Uuid::new_v4()
+    ));
+    let state = crate::AppState::from_sqlite_path(&db_path)
+        .expect("state")
+        .with_reticulumd_rpc(receiver_endpoint.clone(), destination.clone());
+    let command_id = format!("r3akt-live-field-command-{}", Uuid::new_v4());
+    let mut sender_rpc = ReticulumdRpcClient::new(sender_endpoint.clone());
+    let response = sender_rpc
+        .call(
+            "send_message_v2",
+            Some(json!({
+                "id": command_id,
+                "source": source,
+                "destination": destination,
+                "title": "RCH",
+                "content": "",
+                "fields": {"9": [{"Command": "join"}]},
+                "method": "direct"
+            })),
+        )
+        .expect("send live field command");
+    assert!(
+        response.error.is_none(),
+        "field command send failed: {response:?}"
+    );
+
+    let mut joined = false;
+    for _ in 0..poll_attempts {
+        crate::process_reticulumd_list_message_worker_tick(
+            &state,
+            receiver_endpoint.as_str(),
+            destination.as_str(),
+        )
+        .expect("poll receiver messages");
+        joined = state.clients.read().expect("clients").contains_key(
+            crate::normalize_identity_key(source.as_str())
+                .as_deref()
+                .unwrap_or(source.as_str()),
+        );
+        if joined {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(poll_delay_ms)).await;
+    }
+    assert!(joined, "field-command join did not reach RCH");
+
+    let mut reply = None;
+    for _ in 0..poll_attempts {
+        let response = sender_rpc
+            .call("list_messages", Some(json!({"limit": 64})))
+            .expect("poll sender messages");
+        if response.error.is_none() {
+            reply = response
+                .result
+                .as_ref()
+                .and_then(|result| result.get("messages"))
+                .and_then(Value::as_array)
+                .and_then(|messages| {
+                    messages.iter().find(|message| {
+                        message.get("content").and_then(Value::as_str) == Some("joined")
+                            && message.get("source").and_then(Value::as_str)
+                                == Some(destination.as_str())
+                            && message.get("destination").and_then(Value::as_str)
+                                == Some(source.as_str())
+                    })
+                })
+                .cloned();
+        }
+        if reply.is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(poll_delay_ms)).await;
+    }
+    assert!(reply.is_some(), "field-command reply was not delivered");
+    assert!(
+        state
+            .messages
+            .read()
+            .expect("messages")
+            .iter()
+            .any(|message| message.content == "joined")
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}

--- a/crates/r3akt-rch-server/src/tests/field_commands.rs
+++ b/crates/r3akt-rch-server/src/tests/field_commands.rs
@@ -5,6 +5,40 @@ use serde_json::{Value, json};
 use std::time::Duration;
 use uuid::Uuid;
 
+fn inbound_event(
+    event_id: &str,
+    message_id: &str,
+    source: &str,
+    fields: Value,
+    content: &str,
+) -> r3akt_transport_rns::ReticulumdEventRecord {
+    r3akt_transport_rns::ReticulumdEventRecord {
+        event_id: event_id.to_string(),
+        runtime_id: None,
+        stream_id: None,
+        seq_no: None,
+        contract_version: None,
+        ts_ms: None,
+        event_type: "inbound".to_string(),
+        severity: None,
+        source_component: None,
+        operation_id: None,
+        message_id: Some(message_id.to_string()),
+        peer_id: None,
+        correlation_id: None,
+        trace_id: None,
+        payload: json!({
+            "message": {
+                "id": message_id,
+                "source": source,
+                "destination": "hub-source",
+                "content": content,
+                "fields": fields,
+            }
+        }),
+    }
+}
+
 #[test]
 fn command_docs_show_legacy_and_mission_field_shapes() {
     let help = crate::command_help_text();
@@ -136,6 +170,126 @@ fn list_messages_mission_style_join_still_dispatches() {
     let params = request.params.expect("params");
     assert_eq!(params["destination"], source);
     assert_eq!(params["content"], "joined");
+}
+
+#[test]
+fn malformed_event_is_quarantined_and_cursor_advances_to_later_messages() {
+    let db_path = std::env::temp_dir().join(format!(
+        "r3akt-rch-malformed-field-command-event-{}.db",
+        Uuid::new_v4()
+    ));
+    let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+    let report = crate::process_reticulumd_event_batch(
+        &state,
+        "hub-source",
+        r3akt_transport_rns::ReticulumdEventBatch {
+            events: vec![
+                inbound_event(
+                    "quarantine-event-1",
+                    "quarantine-message-1",
+                    "peer-field-command",
+                    json!({"9": [{"not_a_selector": "join"}]}),
+                    "",
+                ),
+                inbound_event(
+                    "after-quarantine-event-1",
+                    "after-quarantine-message-1",
+                    "peer-after-quarantine",
+                    json!({}),
+                    "after quarantine",
+                ),
+            ],
+            next_cursor: Some("stream:2".to_string()),
+            dropped_count: 0,
+            snapshot_high_watermark_seq_no: None,
+        },
+    )
+    .expect("process event batch");
+
+    assert_eq!(report.next_cursor.as_deref(), Some("stream:2"));
+    assert_eq!(
+        crate::load_reticulumd_event_cursor(&state).as_deref(),
+        Some("stream:2")
+    );
+    assert!(
+        state
+            .messages
+            .read()
+            .expect("messages")
+            .iter()
+            .any(|message| message.content == "after quarantine")
+    );
+    let diagnostics = crate::runtime_diagnostics_payload(&state).expect("diagnostics");
+    assert_eq!(diagnostics["reticulumd_inbound"]["quarantined_total"], 1);
+    assert!(
+        diagnostics["reticulumd_inbound"]["last_quarantine_error"]
+            .as_str()
+            .is_some_and(|error| error.contains("quarantine-message-1"))
+    );
+    assert!(
+        state
+            .system_events
+            .read()
+            .expect("system events")
+            .iter()
+            .any(|event| event.event_type == "reticulumd_inbound_message_quarantined")
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[test]
+fn malformed_list_message_is_quarantined_and_not_retried() {
+    let db_path = std::env::temp_dir().join(format!(
+        "r3akt-rch-malformed-field-command-list-{}.db",
+        Uuid::new_v4()
+    ));
+    let state = crate::AppState::from_sqlite_path(&db_path).expect("state");
+    let result = json!({
+        "messages": [
+            {
+                "id": "quarantine-list-1",
+                "direction": "in",
+                "source": "peer-field-command",
+                "destination": "hub-source",
+                "content": "",
+                "fields": {"9": [{"not_a_selector": "join"}]}
+            },
+            {
+                "id": "after-quarantine-list-1",
+                "direction": "in",
+                "source": "peer-after-quarantine",
+                "destination": "hub-source",
+                "content": "after quarantine",
+                "fields": {}
+            }
+        ]
+    });
+
+    assert_eq!(
+        crate::process_reticulumd_list_messages_result(&state, "hub-source", &result)
+            .expect("first list import"),
+        1
+    );
+    assert_eq!(
+        crate::process_reticulumd_list_messages_result(&state, "hub-source", &result)
+            .expect("second list import"),
+        0
+    );
+    let diagnostics = crate::runtime_diagnostics_payload(&state).expect("diagnostics");
+    assert_eq!(diagnostics["reticulumd_inbound"]["quarantined_total"], 1);
+    assert_eq!(
+        state
+            .system_events
+            .read()
+            .expect("system events")
+            .iter()
+            .filter(|event| event.event_type == "reticulumd_inbound_message_quarantined")
+            .count(),
+        1
+    );
+
+    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]

--- a/crates/r3akt-transport-rns/src/field_commands.rs
+++ b/crates/r3akt-transport-rns/src/field_commands.rs
@@ -1,0 +1,98 @@
+use r3akt_protocol::Command;
+use serde_json::{Map, Value};
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum DirectLxmfCommandResult {
+    NoCommand,
+    Valid(Command),
+    Malformed(String),
+}
+
+pub(crate) fn direct_lxmf_command(fields: Option<&Map<String, Value>>) -> DirectLxmfCommandResult {
+    let Some(fields) = fields else {
+        return DirectLxmfCommandResult::NoCommand;
+    };
+    let Some(commands) = field_value(fields, &["9", "FIELD_COMMANDS"]) else {
+        return DirectLxmfCommandResult::NoCommand;
+    };
+    let command = match commands {
+        Value::Array(commands) => {
+            let Some(command) = commands.first() else {
+                return DirectLxmfCommandResult::Malformed(
+                    "field 0x09 command list is empty".to_string(),
+                );
+            };
+            command
+        }
+        command => command,
+    };
+    let Some(command) = command.as_object() else {
+        return DirectLxmfCommandResult::Malformed(
+            "first field 0x09 command entry must be an object".to_string(),
+        );
+    };
+    let selector = if command.contains_key("command_type") {
+        "command_type"
+    } else if command.contains_key("Command") {
+        "Command"
+    } else if command.contains_key("0") {
+        "0"
+    } else {
+        return DirectLxmfCommandResult::Malformed(
+            "first field 0x09 command entry has no command_type, Command, or 0 selector"
+                .to_string(),
+        );
+    };
+    let Some(name) = command
+        .get(selector)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return DirectLxmfCommandResult::Malformed(format!(
+            "field 0x09 selector {selector:?} must be a non-empty string"
+        ));
+    };
+    let correlation_id = command
+        .get("command_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+    let args = if matches!(selector, "Command" | "0") {
+        let mut args = Map::new();
+        if let Some(Value::Object(explicit_args)) = command.get("args") {
+            args.extend(explicit_args.clone());
+        } else if let Some(explicit_args) = command.get("args") {
+            args.insert("args".to_string(), explicit_args.clone());
+        }
+        for (key, value) in command {
+            if !matches!(key.as_str(), "Command" | "0" | "command_id" | "args") {
+                args.insert(key.clone(), value.clone());
+            }
+        }
+        Value::Object(args)
+    } else {
+        command
+            .get("args")
+            .cloned()
+            .filter(Value::is_object)
+            .unwrap_or_else(|| serde_json::json!({}))
+    };
+    DirectLxmfCommandResult::Valid(Command {
+        name: name.to_string(),
+        args,
+        correlation_id,
+    })
+}
+
+fn field_value<'a>(fields: &'a Map<String, Value>, keys: &[&str]) -> Option<&'a Value> {
+    keys.iter().find_map(|key| {
+        fields.get(*key).or_else(|| {
+            fields
+                .iter()
+                .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+                .map(|(_, value)| value)
+        })
+    })
+}

--- a/crates/r3akt-transport-rns/src/lib.rs
+++ b/crates/r3akt-transport-rns/src/lib.rs
@@ -10,6 +10,9 @@
 )]
 
 mod actor_helpers;
+mod field_commands;
+
+use field_commands::{DirectLxmfCommandResult, direct_lxmf_command};
 
 use std::collections::{BTreeMap, VecDeque};
 use std::future::Future;
@@ -36,8 +39,8 @@ use lxmf_sdk::{
     ZmqPipelineBackendClient, ZmqPipelineBackendConfig,
 };
 use r3akt_protocol::{
-    Command, Destination, NodeId, Payload, ProtocolEnvelope, TelemetrySample, Topic,
-    TopicAttachment, TopicMessage,
+    Destination, NodeId, Payload, ProtocolEnvelope, TelemetrySample, Topic, TopicAttachment,
+    TopicMessage,
 };
 use rns_rpc::rpc::zmq;
 #[cfg(test)]
@@ -710,14 +713,15 @@ impl LxmfRsAdapter for ReticulumdRpcLxmfRsAdapter<'_> {
                     base64::engine::general_purpose::STANDARD
                         .decode(payload_b64)
                         .map_err(|error| TransportError::Receive(error.to_string()))?
-                } else if let Some(envelope) =
-                    direct_lxmf_message_envelope(message, self.source.as_str())
-                {
+                } else {
+                    let Some(envelope) =
+                        direct_lxmf_message_envelope(message, self.source.as_str())?
+                    else {
+                        continue;
+                    };
                     envelope
                         .encode_msgpack()
                         .map_err(|error| TransportError::Receive(error.to_string()))?
-                } else {
-                    continue;
                 };
                 self.remember_seen(message_id);
                 let destination = message
@@ -2492,36 +2496,64 @@ fn lxmf_sdk_event_to_reticulumd_event_record(event: LxmfSdkEvent) -> ReticulumdE
 fn direct_lxmf_message_envelope(
     message: &JsonValue,
     local_source: &str,
-) -> Option<ProtocolEnvelope> {
+) -> Result<Option<ProtocolEnvelope>, TransportError> {
     let fields = message.get("fields").and_then(JsonValue::as_object);
     let source = optional_message_string(message, &["source", "source_hash", "source_id"])
         .unwrap_or("unknown");
-    if let Some(mut command) = direct_lxmf_mission_command(fields) {
-        if let Some(team_uid) = fields.and_then(|fields| {
-            optional_field_string(fields, &["11", "FIELD_GROUP", "group", "Group"])
-        }) {
-            if let Some(args) = command.args.as_object_mut() {
-                args.insert(
-                    "_rem_team_uid".to_string(),
-                    JsonValue::String(team_uid.to_string()),
-                );
+    match direct_lxmf_command(fields) {
+        DirectLxmfCommandResult::NoCommand => {}
+        DirectLxmfCommandResult::Valid(mut command) => {
+            if let Some(team_uid) = fields.and_then(|fields| {
+                optional_field_string(fields, &["11", "FIELD_GROUP", "group", "Group"])
+            }) {
+                if let Some(args) = command.args.as_object_mut() {
+                    args.insert(
+                        "_rem_team_uid".to_string(),
+                        JsonValue::String(team_uid.to_string()),
+                    );
+                }
             }
+            let mut envelope = ProtocolEnvelope::new(
+                NodeId::new(source),
+                Destination::Node(NodeId::new(local_source)),
+                Topic::new("rem-directory"),
+                Payload::Command(command),
+            );
+            if let Some(message_id) = message
+                .get("id")
+                .and_then(JsonValue::as_str)
+                .filter(|value| !value.trim().is_empty())
+            {
+                envelope = envelope.with_dedupe_key(message_id);
+            }
+            return Ok(Some(envelope));
         }
-        let mut envelope = ProtocolEnvelope::new(
-            NodeId::new(source),
-            Destination::Node(NodeId::new(local_source)),
-            Topic::new("rem-directory"),
-            Payload::Command(command),
-        );
-        if let Some(message_id) = message
-            .get("id")
-            .and_then(JsonValue::as_str)
-            .filter(|value| !value.trim().is_empty())
-        {
-            envelope = envelope.with_dedupe_key(message_id);
+        DirectLxmfCommandResult::Malformed(reason) => {
+            let message_id = message
+                .get("id")
+                .and_then(JsonValue::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or("unknown");
+            return Err(TransportError::Receive(format!(
+                "malformed LXMF FIELD_COMMANDS (0x09) in message {message_id} from {source}: {reason}"
+            )));
         }
-        return Some(envelope);
     }
+    Ok(direct_lxmf_fallback_envelope(
+        fields,
+        message,
+        source,
+        local_source,
+    ))
+}
+
+fn direct_lxmf_fallback_envelope(
+    fields: Option<&serde_json::Map<String, JsonValue>>,
+    message: &JsonValue,
+    source: &str,
+    local_source: &str,
+) -> Option<ProtocolEnvelope> {
     if let Some(telemetry) = direct_lxmf_telemetry(fields, message) {
         let topic = Topic::new("telemetry");
         return Some(
@@ -2587,36 +2619,6 @@ fn direct_lxmf_message_envelope(
     )
 }
 
-fn direct_lxmf_mission_command(
-    fields: Option<&serde_json::Map<String, JsonValue>>,
-) -> Option<Command> {
-    let commands = fields?.get("9")?;
-    let command = commands
-        .as_array()
-        .and_then(|commands| commands.first())
-        .unwrap_or(commands);
-    let command_type = command
-        .get("command_type")
-        .and_then(JsonValue::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())?;
-    let command_id = command
-        .get("command_id")
-        .and_then(JsonValue::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToString::to_string);
-    Some(Command {
-        name: command_type.to_string(),
-        args: command
-            .get("args")
-            .cloned()
-            .filter(JsonValue::is_object)
-            .unwrap_or_else(|| serde_json::json!({})),
-        correlation_id: command_id,
-    })
-}
-
 pub fn reticulumd_message_to_envelope(
     message: &JsonValue,
     local_source: &str,
@@ -2633,7 +2635,7 @@ pub fn reticulumd_message_to_envelope(
             .map_err(|error| TransportError::Receive(error.to_string()))?;
         return Ok(Some(envelope));
     }
-    Ok(direct_lxmf_message_envelope(message, local_source))
+    direct_lxmf_message_envelope(message, local_source)
 }
 
 pub fn reticulumd_event_to_envelope(

--- a/crates/r3akt-transport-rns/tests/field_commands.rs
+++ b/crates/r3akt-transport-rns/tests/field_commands.rs
@@ -1,0 +1,148 @@
+use r3akt_protocol::Payload;
+use r3akt_transport_rns::{
+    TransportError, reticulumd_event_to_envelope, reticulumd_message_to_envelope,
+};
+use serde_json::{Value, json};
+
+fn message(fields: &Value) -> Value {
+    json!({
+        "id": "field-command-test-1",
+        "source": "peer-field-command",
+        "destination": "local-destination",
+        "content": "",
+        "fields": fields,
+    })
+}
+
+fn command_from_message(fields: &Value) -> r3akt_protocol::Command {
+    let envelope = reticulumd_message_to_envelope(&message(fields), "local-destination")
+        .expect("decode message")
+        .expect("envelope");
+    let Payload::Command(command) = envelope.payload else {
+        panic!("expected command payload");
+    };
+    command
+}
+
+#[test]
+fn legacy_command_selector_decodes_join() {
+    let command = command_from_message(&json!({"9": [{"Command": "join"}]}));
+
+    assert_eq!(command.name, "join");
+    assert_eq!(command.args, json!({}));
+    assert_eq!(command.correlation_id, None);
+}
+
+#[test]
+fn numeric_legacy_selector_decodes_leave() {
+    let command = command_from_message(&json!({"9": [{"0": "leave"}]}));
+
+    assert_eq!(command.name, "leave");
+    assert_eq!(command.args, json!({}));
+}
+
+#[test]
+fn only_first_field_command_entry_is_used() {
+    let command = command_from_message(&json!({
+        "9": [{"Command": "join"}, {"Command": "leave"}]
+    }));
+
+    assert_eq!(command.name, "join");
+}
+
+#[test]
+fn legacy_named_fields_become_command_arguments() {
+    let command = command_from_message(&json!({
+        "9": [{
+            "Command": "CreateTopic",
+            "command_id": "legacy-topic-1",
+            "TopicID": "ops",
+            "TopicName": "Operations",
+            "TopicPath": "ops",
+        }]
+    }));
+
+    assert_eq!(command.name, "CreateTopic");
+    assert_eq!(command.correlation_id.as_deref(), Some("legacy-topic-1"));
+    assert_eq!(
+        command.args,
+        json!({
+            "TopicID": "ops",
+            "TopicName": "Operations",
+            "TopicPath": "ops",
+        })
+    );
+}
+
+#[test]
+fn mission_command_envelope_remains_unchanged() {
+    let command = command_from_message(&json!({
+        "9": [{
+            "command_id": "mission-1",
+            "command_type": "mission.registry.team_peers.list",
+            "source": {"rns_identity": "peer-field-command"},
+            "timestamp": "2026-08-02T12:00:00Z",
+            "args": {"team_uid": "team-1"},
+        }]
+    }));
+
+    assert_eq!(command.name, "mission.registry.team_peers.list");
+    assert_eq!(command.correlation_id.as_deref(), Some("mission-1"));
+    assert_eq!(command.args, json!({"team_uid": "team-1"}));
+}
+
+#[test]
+fn malformed_field_commands_are_reported_with_context() {
+    let error = reticulumd_message_to_envelope(
+        &message(&json!({"9": [{"not_a_selector": "join"}]})),
+        "local-destination",
+    )
+    .expect_err("malformed field commands should not become chat");
+
+    let TransportError::Receive(error) = error else {
+        panic!("expected receive error");
+    };
+    assert!(error.contains("FIELD_COMMANDS (0x09)"));
+    assert!(error.contains("field-command-test-1"));
+    assert!(error.contains("peer-field-command"));
+}
+
+#[test]
+fn ordinary_messages_without_commands_remain_chat() {
+    let mut ordinary = message(&json!({"content_type": "text/plain"}));
+    ordinary["content"] = Value::String("ordinary chat".to_string());
+    let envelope = reticulumd_message_to_envelope(&ordinary, "local-destination")
+        .expect("decode message")
+        .expect("chat envelope");
+
+    let Payload::TopicMessage(message) = envelope.payload else {
+        panic!("expected topic message");
+    };
+    assert_eq!(message.body, "ordinary chat");
+}
+
+#[test]
+fn event_message_uses_the_same_field_command_decoder() {
+    let event = r3akt_transport_rns::ReticulumdEventRecord {
+        event_id: "event-field-command-1".to_string(),
+        runtime_id: None,
+        stream_id: None,
+        seq_no: None,
+        contract_version: None,
+        ts_ms: None,
+        event_type: "inbound".to_string(),
+        severity: None,
+        source_component: None,
+        operation_id: None,
+        message_id: None,
+        peer_id: None,
+        correlation_id: None,
+        trace_id: None,
+        payload: json!({"message": message(&json!({"9": [{"Command": "join"}]}))}),
+    };
+
+    let envelope = reticulumd_event_to_envelope(&event, "local-destination")
+        .expect("decode event")
+        .expect("command envelope");
+    assert!(matches!(envelope.payload, Payload::Command(command) if command.name == "join"));
+}

--- a/scripts/local-reticulum-live-gate.ps1
+++ b/scripts/local-reticulum-live-gate.ps1
@@ -142,6 +142,9 @@ $processes = @()
 $savedEnv = @{
     R3AKT_RETICULUMD_RPC_ENDPOINT = [Environment]::GetEnvironmentVariable("R3AKT_RETICULUMD_RPC_ENDPOINT")
     R3AKT_RETICULUMD_SOURCE = [Environment]::GetEnvironmentVariable("R3AKT_RETICULUMD_SOURCE")
+    R3AKT_RETICULUMD_FIELD_COMMAND_RPC_ENDPOINT = [Environment]::GetEnvironmentVariable("R3AKT_RETICULUMD_FIELD_COMMAND_RPC_ENDPOINT")
+    R3AKT_RETICULUMD_FIELD_COMMAND_SOURCE = [Environment]::GetEnvironmentVariable("R3AKT_RETICULUMD_FIELD_COMMAND_SOURCE")
+    R3AKT_RETICULUMD_FIELD_COMMAND_DESTINATION = [Environment]::GetEnvironmentVariable("R3AKT_RETICULUMD_FIELD_COMMAND_DESTINATION")
     R3AKT_RETICULUMD_RECEIPT_DESTINATION = [Environment]::GetEnvironmentVariable("R3AKT_RETICULUMD_RECEIPT_DESTINATION")
     R3AKT_RETICULUMD_FANOUT_DESTINATIONS = [Environment]::GetEnvironmentVariable("R3AKT_RETICULUMD_FANOUT_DESTINATIONS")
     R3AKT_RETICULUMD_RECEIPT_POLL_ATTEMPTS = [Environment]::GetEnvironmentVariable("R3AKT_RETICULUMD_RECEIPT_POLL_ATTEMPTS")
@@ -258,6 +261,9 @@ try {
 
     $env:R3AKT_RETICULUMD_RPC_ENDPOINT = "127.0.0.1:$($rpcPorts[0])"
     $env:R3AKT_RETICULUMD_SOURCE = $destinations[0]
+    $env:R3AKT_RETICULUMD_FIELD_COMMAND_RPC_ENDPOINT = "127.0.0.1:$($rpcPorts[1])"
+    $env:R3AKT_RETICULUMD_FIELD_COMMAND_SOURCE = $destinations[1]
+    $env:R3AKT_RETICULUMD_FIELD_COMMAND_DESTINATION = $destinations[0]
     $env:R3AKT_RETICULUMD_RECEIPT_DESTINATION = $destinations[1]
     $env:R3AKT_RETICULUMD_FANOUT_DESTINATIONS = ($destinations[1..($NodeCount - 1)] -join ",")
     $env:R3AKT_RETICULUMD_RECEIPT_POLL_ATTEMPTS = "$ReceiptPollAttempts"
@@ -283,6 +289,11 @@ try {
     }
 
     if (-not $ZmqLoadOnly) {
+        $cargoExit = Invoke-CargoGate -Arguments @("+$RustToolchain", "test", "-p", "r3akt-rch-server", "live_reticulumd_field_command_join_reaches_rch_and_reply_is_delivered_when_configured", "--", "--nocapture")
+        if ($cargoExit -ne 0) {
+            exit $cargoExit
+        }
+
         $cargoExit = Invoke-CargoGate -Arguments @("+$RustToolchain", "test", "-p", "r3akt-rch-server", "live_reticulumd_direct_send_receipt_is_delivered_when_configured", "--", "--nocapture")
         if ($cargoExit -ne 0) {
             exit $cargoExit


### PR DESCRIPTION
## What changed

- Normalize LXMF `FIELD_COMMANDS` (0x09) into the existing RCH command dispatcher.
- Accept mission-style `command_type`, `args`, and `command_id`.
- Restore Columba-compatible legacy `Command` and `0` selectors.
- Preserve named legacy fields as command arguments and keep first-entry behavior.
- Classify malformed field-command payloads for contextual transport errors.
- Synchronize `/Help` and `/Examples`, and add transport/server/live-daemon coverage.

## Why

The inbound decoder only recognized mission envelopes containing `command_type`. Legacy LXMF commands such as `{"9":[{"Command":"join"}]}` were therefore treated as empty-body messages and discarded before reaching the existing server dispatcher.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- Focused transport and server tests
- `scripts/local-reticulum-live-gate.ps1` with three sibling LXMF-rs daemons
- `scripts/release-readiness.ps1 -ServerOnlyAlpha`

The live gate verified field-command join delivery, reply delivery, roster mutation, direct receipts, and fanout receipts.