### PR TITLE
Prevent stale LXMF ZeroMQ queue buildup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,17 +80,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atomicwrites"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef1bb8d1b645fe38d51dfc331d720fb5fc2c94b440c76cc79c80ff265ca33e3"
-dependencies = [
- "rustix 0.38.44",
- "tempfile",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,7 +457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -881,12 +870,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -909,9 +892,6 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 [[package]]
 name = "lxmf-reference"
 version = "0.9.6"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "lxmf-sdk"
@@ -939,7 +919,6 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "hex",
- "hkdf",
  "rand_core 0.6.4",
  "reticulum-rs-core",
  "rmp-serde",
@@ -987,7 +966,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1447,7 +1426,6 @@ name = "reticulum-rs-core"
 version = "0.9.6"
 dependencies = [
  "aes",
- "atomicwrites",
  "cbc",
  "crypto-common",
  "ed25519-dalek",
@@ -1541,19 +1519,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1561,8 +1526,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1599,7 +1564,7 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1788,7 +1753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1839,8 +1804,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1897,7 +1862,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2200,94 +2165,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomicwrites"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef1bb8d1b645fe38d51dfc331d720fb5fc2c94b440c76cc79c80ff265ca33e3"
+dependencies = [
+ "rustix 0.38.44",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,7 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -870,6 +881,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -892,6 +909,9 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 [[package]]
 name = "lxmf-reference"
 version = "0.9.6"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "lxmf-sdk"
@@ -919,6 +939,7 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "hex",
+ "hkdf",
  "rand_core 0.6.4",
  "reticulum-rs-core",
  "rmp-serde",
@@ -966,7 +987,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1426,6 +1447,7 @@ name = "reticulum-rs-core"
 version = "0.9.6"
 dependencies = [
  "aes",
+ "atomicwrites",
  "cbc",
  "crypto-common",
  "ed25519-dalek",
@@ -1519,6 +1541,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1526,8 +1561,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1564,7 +1599,7 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1753,7 +1788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1804,8 +1839,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1862,7 +1897,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2165,12 +2200,94 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/r3akt-rch-server/src/lib.rs
+++ b/crates/r3akt-rch-server/src/lib.rs
@@ -10460,6 +10460,7 @@ fn lxmf_sdk_diagnostics_payload(
             "queue_max_depth": data_plane.map(|stats| stats.queue_max_depth),
             "enqueued_total": data_plane.map(|stats| stats.enqueued_total),
             "rejected_total": data_plane.map(|stats| stats.backpressure_total),
+            "expired_total": data_plane.map(|stats| stats.expired_total),
             "completed_total": data_plane.map(|stats| stats.completed_total),
             "failed_total": data_plane.map(|stats| stats.failed_total),
             "last_queue_wait_ms": data_plane.map(|stats| stats.last_queue_wait_ms),

--- a/crates/r3akt-transport-rns/src/actor_request_expiry.rs
+++ b/crates/r3akt-transport-rns/src/actor_request_expiry.rs
@@ -1,0 +1,35 @@
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use super::*;
+
+#[test]
+fn zmq_data_plane_drops_expired_requests_before_session_startup() {
+    let (send_tx, send_rx) = mpsc::sync_channel(1);
+    let (control_tx, control_rx) = mpsc::sync_channel(1);
+    let (response_tx, response_rx) = mpsc::channel();
+    send_tx
+        .send(ZmqSdkActorRequest {
+            payload: ZmqSdkActorPayload::Status("stale-status".to_string()),
+            response: response_tx,
+            queued_at: Instant::now()
+                .checked_sub(Duration::from_secs(2))
+                .expect("instant subtraction"),
+        })
+        .expect("queue stale request");
+    drop(send_tx);
+    drop(control_tx);
+
+    let mut config = rch_local_zmq_pipeline_config("tcp://127.0.0.1:1", "tcp://127.0.0.1:2");
+    config.request_timeout = Duration::from_millis(50);
+    let metrics = ZmqDataPlaneMetrics::default();
+    run_zmq_data_plane_actor(&config, &send_rx, &control_rx, &metrics);
+
+    let stats = metrics.snapshot();
+    assert_eq!(stats.expired_total, 1);
+    assert_eq!(stats.queue_depth, 0);
+    assert!(matches!(
+        response_rx.try_recv(),
+        Err(mpsc::TryRecvError::Disconnected)
+    ));
+}

--- a/crates/r3akt-transport-rns/src/lib.rs
+++ b/crates/r3akt-transport-rns/src/lib.rs
@@ -69,6 +69,7 @@ const RETICULUMD_RPC_TIMEOUT: Duration = Duration::from_secs(30);
 const LXMF_ZMQ_SEND_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const LXMF_ZMQ_SEND_QUEUE_CAPACITY: usize = 20_000;
 const LXMF_ZMQ_CONTROL_QUEUE_CAPACITY: usize = 1_024;
+const LXMF_ZMQ_ACTOR_QUEUE_GRACE: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
 pub struct ZmqDataPlaneStats {
@@ -80,6 +81,7 @@ pub struct ZmqDataPlaneStats {
     pub queue_max_depth: usize,
     pub enqueued_total: u64,
     pub backpressure_total: u64,
+    pub expired_total: u64,
     pub completed_total: u64,
     pub failed_total: u64,
     pub last_queue_wait_ms: u64,
@@ -112,6 +114,7 @@ struct ZmqDataPlaneMetrics {
     queue_max_depth: AtomicUsize,
     enqueued_total: AtomicU64,
     backpressure_total: AtomicU64,
+    expired_total: AtomicU64,
     completed_total: AtomicU64,
     failed_total: AtomicU64,
     last_queue_wait_ms: AtomicU64,
@@ -143,6 +146,10 @@ impl ZmqDataPlaneMetrics {
 
     fn record_backpressure(&self) {
         self.backpressure_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_expired(&self) {
+        self.expired_total.fetch_add(1, Ordering::Relaxed);
     }
 
     fn rollback_enqueued(&self, queued_at: Instant, is_send_lane: bool) {
@@ -254,6 +261,7 @@ impl ZmqDataPlaneMetrics {
             queue_max_depth: self.queue_max_depth.load(Ordering::Relaxed),
             enqueued_total: self.enqueued_total.load(Ordering::Relaxed),
             backpressure_total: self.backpressure_total.load(Ordering::Relaxed),
+            expired_total: self.expired_total.load(Ordering::Relaxed),
             completed_total: self.completed_total.load(Ordering::Relaxed),
             failed_total: self.failed_total.load(Ordering::Relaxed),
             last_queue_wait_ms: self.last_queue_wait_ms.load(Ordering::Relaxed),
@@ -1890,6 +1898,10 @@ fn run_zmq_data_plane_actor(
         recv_prioritized_actor_request(send_receiver, control_receiver, &mut send_burst)
     {
         metrics.record_dequeued(request.queued_at, request.payload.is_send_lane());
+        if actor_request_expired(request.queued_at, config.request_timeout) {
+            metrics.record_expired();
+            continue;
+        }
         let response_started = Instant::now();
         let shutting_down = matches!(request.payload, ZmqSdkActorPayload::Shutdown);
         if shutting_down && session.is_none() {
@@ -1987,6 +1999,9 @@ fn run_zmq_sdk_actor(
 ) {
     let mut session: Option<ZmqSdkActorSession> = None;
     while let Ok(request) = receiver.recv() {
+        if actor_request_expired(request.queued_at, config.request_timeout) {
+            continue;
+        }
         let shutting_down = matches!(request.payload, ZmqSdkActorPayload::Shutdown);
         if shutting_down && session.is_none() {
             send_actor_response(
@@ -2024,6 +2039,13 @@ fn run_zmq_sdk_actor(
             break;
         }
     }
+}
+
+fn actor_request_expired(queued_at: Instant, request_timeout: Duration) -> bool {
+    // The synchronous caller gives up after request_timeout plus the
+    // one-second receive grace. Replaying work after that deadline only
+    // consumes the single actor and fills the control queue again.
+    queued_at.elapsed() >= request_timeout.saturating_add(LXMF_ZMQ_ACTOR_QUEUE_GRACE)
 }
 
 fn open_zmq_sdk_actor_session(
@@ -4465,6 +4487,37 @@ mod tests {
             .expect("control request");
         assert!(matches!(control.payload, ZmqSdkActorPayload::Status(_)));
         assert_eq!(burst, 0);
+    }
+
+    #[test]
+    fn zmq_data_plane_drops_expired_requests_before_session_startup() {
+        let (send_tx, send_rx) = mpsc::sync_channel(1);
+        let (control_tx, control_rx) = mpsc::sync_channel(1);
+        let (response_tx, response_rx) = mpsc::channel();
+        send_tx
+            .send(ZmqSdkActorRequest {
+                payload: ZmqSdkActorPayload::Status("stale-status".to_string()),
+                response: response_tx,
+                queued_at: Instant::now()
+                    .checked_sub(Duration::from_secs(2))
+                    .expect("instant subtraction"),
+            })
+            .expect("queue stale request");
+        drop(send_tx);
+        drop(control_tx);
+
+        let mut config = rch_local_zmq_pipeline_config("tcp://127.0.0.1:1", "tcp://127.0.0.1:2");
+        config.request_timeout = Duration::from_millis(50);
+        let metrics = ZmqDataPlaneMetrics::default();
+        run_zmq_data_plane_actor(&config, &send_rx, &control_rx, &metrics);
+
+        let stats = metrics.snapshot();
+        assert_eq!(stats.expired_total, 1);
+        assert_eq!(stats.queue_depth, 0);
+        assert!(matches!(
+            response_rx.try_recv(),
+            Err(mpsc::TryRecvError::Disconnected)
+        ));
     }
 
     #[test]

--- a/crates/r3akt-transport-rns/src/lib.rs
+++ b/crates/r3akt-transport-rns/src/lib.rs
@@ -3807,6 +3807,9 @@ mod tests {
     #[path = "rem_team_scope.rs"]
     mod rem_team_scope;
 
+    #[path = "../actor_request_expiry.rs"]
+    mod actor_request_expiry;
+
     #[derive(Debug, Clone)]
     struct RecordedRpcCall {
         method: String,
@@ -4487,37 +4490,6 @@ mod tests {
             .expect("control request");
         assert!(matches!(control.payload, ZmqSdkActorPayload::Status(_)));
         assert_eq!(burst, 0);
-    }
-
-    #[test]
-    fn zmq_data_plane_drops_expired_requests_before_session_startup() {
-        let (send_tx, send_rx) = mpsc::sync_channel(1);
-        let (control_tx, control_rx) = mpsc::sync_channel(1);
-        let (response_tx, response_rx) = mpsc::channel();
-        send_tx
-            .send(ZmqSdkActorRequest {
-                payload: ZmqSdkActorPayload::Status("stale-status".to_string()),
-                response: response_tx,
-                queued_at: Instant::now()
-                    .checked_sub(Duration::from_secs(2))
-                    .expect("instant subtraction"),
-            })
-            .expect("queue stale request");
-        drop(send_tx);
-        drop(control_tx);
-
-        let mut config = rch_local_zmq_pipeline_config("tcp://127.0.0.1:1", "tcp://127.0.0.1:2");
-        config.request_timeout = Duration::from_millis(50);
-        let metrics = ZmqDataPlaneMetrics::default();
-        run_zmq_data_plane_actor(&config, &send_rx, &control_rx, &metrics);
-
-        let stats = metrics.snapshot();
-        assert_eq!(stats.expired_total, 1);
-        assert_eq!(stats.queue_depth, 0);
-        assert!(matches!(
-            response_rx.try_recv(),
-            Err(mpsc::TryRecvError::Disconnected)
-        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Expire RCH actor requests that already outlived the caller timeout.
- Expose expired actor work in runtime diagnostics.
- Refresh `Cargo.lock` for the path-linked LXMF-rs 0.9.6 dependency set.

## Root cause

A blocked ZeroMQ send could outlive the RCH caller. Timed-out callers dropped response receivers while the single actor continued replaying stale control work, eventually filling the 1024-entry control queue. This PR complements [FreeTAKTeam/LXMF-rs#558](https://github.com/FreeTAKTeam/LXMF-rs/pull/558), which bounds the SDK send itself.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

The change was also deployed and observed with zero queue-full/receiver-dropped errors during the post-restart verification window.