### PR TITLE
Fix LXMF main compatibility checkout paths

### DIFF
--- a/.github/workflows/lxmf-main-compatibility.yml
+++ b/.github/workflows/lxmf-main-compatibility.yml
@@ -37,10 +37,10 @@ jobs:
           New-Item -ItemType Directory -Force .cargo | Out-Null
           @'
           [patch.crates-io]
-          lxmf-wire = { path = "../../LXMF-rs/crates/libs/lxmf-core" }
-          lxmf-sdk = { path = "../../LXMF-rs/crates/libs/lxmf-sdk" }
-          reticulum-rs-rpc = { path = "../../LXMF-rs/crates/libs/rns-rpc" }
-          reticulum-rs-core = { path = "../../LXMF-rs/crates/libs/rns-core" }
+          lxmf-wire = { path = "../LXMF-rs/crates/libs/lxmf-core" }
+          lxmf-sdk = { path = "../LXMF-rs/crates/libs/lxmf-sdk" }
+          reticulum-rs-rpc = { path = "../LXMF-rs/crates/libs/rns-rpc" }
+          reticulum-rs-core = { path = "../LXMF-rs/crates/libs/rns-core" }
           '@ | Set-Content -LiteralPath .cargo/config.toml -Encoding utf8
           $transportManifest = Get-Content -LiteralPath crates/r3akt-transport-rns/Cargo.toml -Raw
           $transportManifest = $transportManifest -replace 'version = "=0\.8\.0"', 'version = "*"'


### PR DESCRIPTION
## Summary
- correct compatibility-only Cargo patch paths for the sibling LXMF checkout
- keep the production dependency declarations and lockfile unchanged

## Root cause
The workflow checked out RCH at `rch` and LXMF-rs at the adjacent `LXMF-rs` directory, but generated patch paths beginning with `../../LXMF-rs`. Cargo therefore resolved outside the Actions checkout container and failed before compilation with a missing `lxmf-sdk/Cargo.toml`.

## Validation
- `git diff --check`
- `cargo check -p r3akt-transport-rns` against current FreeTAKTeam/LXMF-rs `main` (21a48e4f)