### PR TITLE
Prepare RCH v3.0.0-preview.10 against LXMF-rs 0.9.9

### DIFF
--- a/.github/workflows/rust-pr-quality.yml
+++ b/.github/workflows/rust-pr-quality.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  LXMF_REF: d61ed1171d07720e5cfba3d3b0a9c83496732221
+  LXMF_REF: 51fd3beebdace78d6c7f38748c6bcfe452032559
 
 jobs:
   msrv-docs:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -6,7 +6,7 @@ on:
       release_version:
         description: "Version label to embed in manually built artifacts"
         required: false
-        default: "v3.0.0-preview.9"
+        default: "v3.0.0-preview.10"
   release:
     types: [published]
   push:
@@ -29,7 +29,7 @@ permissions:
   contents: write
 
 env:
-  LXMF_REF: d61ed1171d07720e5cfba3d3b0a9c83496732221
+  LXMF_REF: 51fd3beebdace78d6c7f38748c6bcfe452032559
 
 jobs:
   server-package:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  LXMF_REF: d61ed1171d07720e5cfba3d3b0a9c83496732221
+  LXMF_REF: 51fd3beebdace78d6c7f38748c6bcfe452032559
 
 jobs:
   rust:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomicwrites"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef1bb8d1b645fe38d51dfc331d720fb5fc2c94b440c76cc79c80ff265ca33e3"
+dependencies = [
+ "rustix 0.38.44",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,7 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -870,6 +881,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -891,11 +908,14 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lxmf-reference"
-version = "0.9.6"
+version = "0.9.9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "lxmf-sdk"
-version = "0.9.6"
+version = "0.9.9"
 dependencies = [
  "hex",
  "hmac",
@@ -914,11 +934,12 @@ dependencies = [
 
 [[package]]
 name = "lxmf-wire"
-version = "0.9.6"
+version = "0.9.9"
 dependencies = [
  "base64",
  "ed25519-dalek",
  "hex",
+ "hkdf",
  "rand_core 0.6.4",
  "reticulum-rs-core",
  "rmp-serde",
@@ -966,7 +987,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1423,9 +1444,10 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reticulum-rs-core"
-version = "0.9.6"
+version = "0.9.9"
 dependencies = [
  "aes",
+ "atomicwrites",
  "cbc",
  "crypto-common",
  "ed25519-dalek",
@@ -1442,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "reticulum-rs-rpc"
-version = "0.9.6"
+version = "0.9.9"
 dependencies = [
  "base64",
  "ciborium",
@@ -1519,6 +1541,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1526,8 +1561,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1564,7 +1599,7 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1753,7 +1788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1804,8 +1839,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1862,7 +1897,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2165,12 +2200,94 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ r3akt-rch-server = { path = "crates/r3akt-rch-server" }
 r3akt-tak-connector = { path = "crates/r3akt-tak-connector" }
 r3akt-transport-rns = { path = "crates/r3akt-transport-rns" }
 rand_core = { version = "0.6.4", features = ["getrandom"] }
-rns-core = { package = "reticulum-rs-core", path = "../LXMF-rs/crates/libs/rns-core", version = "0.9.6" }
+rns-core = { package = "reticulum-rs-core", path = "../LXMF-rs/crates/libs/rns-core", version = "0.9.9" }
 base64 = "0.22"
 argon2 = "0.5"
 chrono = { version = "0.4.42", default-features = false, features = ["clock", "serde", "std"] }

--- a/apps/rch-desktop/README.md
+++ b/apps/rch-desktop/README.md
@@ -13,7 +13,7 @@ npm --prefix apps/rch-desktop install
 npm --prefix apps/rch-desktop run build
 ```
 
-The sidecar preparation step builds LXMF `0.9.5` `reticulumd`,
+The sidecar preparation step builds LXMF `0.9.9` `reticulumd`,
 `r3akt-rch-server`, and `r3akt-tak-service`, then copies them into `src-tauri/binaries/` with the
 host target-triple suffix required by Tauri.
 

--- a/apps/rch-desktop/package-lock.json
+++ b/apps/rch-desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rch-desktop-tauri",
-  "version": "3.0.0-preview.9",
+  "version": "3.0.0-preview.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rch-desktop-tauri",
-      "version": "3.0.0-preview.9",
+      "version": "3.0.0-preview.10",
       "devDependencies": {
         "@tauri-apps/cli": "^2.0.0"
       }

--- a/apps/rch-desktop/package.json
+++ b/apps/rch-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rch-desktop-tauri",
   "private": true,
-  "version": "3.0.0-preview.9",
+  "version": "3.0.0-preview.10",
   "type": "module",
   "scripts": {
     "build": "npm --prefix ../../ui run build && npm run prepare:sidecar && cargo build --release --locked --manifest-path src-tauri/Cargo.toml && tauri bundle --ci",

--- a/apps/rch-desktop/src-tauri/Cargo.lock
+++ b/apps/rch-desktop/src-tauri/Cargo.lock
@@ -2401,7 +2401,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rch-desktop"
-version = "3.0.0-preview.9"
+version = "3.0.0-preview.10"
 dependencies = [
  "tauri",
  "tauri-build",

--- a/apps/rch-desktop/src-tauri/Cargo.toml
+++ b/apps/rch-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rch-desktop"
-version = "3.0.0-preview.9"
+version = "3.0.0-preview.10"
 edition = "2024"
 rust-version = "1.88"
 license = "EPL-2.0"

--- a/apps/rch-desktop/src-tauri/tauri.conf.json
+++ b/apps/rch-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "RCH Desktop",
-  "version": "3.0.0-preview.9",
+  "version": "3.0.0-preview.10",
   "identifier": "org.freetakteam.rch",
   "build": {
     "frontendDist": "../../../ui/dist",

--- a/config/lxmf-runtime-baseline.json
+++ b/config/lxmf-runtime-baseline.json
@@ -1,7 +1,7 @@
 {
   "repository": "FreeTAKTeam/LXMF-rs",
-  "release_tag": "v0.9.5",
-  "sdk_version": "0.9.5",
+  "release_tag": "v0.9.9",
+  "sdk_version": "0.9.9",
   "daemon_package": "reticulumd",
   "daemon_features": ["zmq-pipeline-rpc"],
   "contract_version": 2,

--- a/crates/r3akt-transport-rns/Cargo.toml
+++ b/crates/r3akt-transport-rns/Cargo.toml
@@ -8,10 +8,10 @@ repository.workspace = true
 
 [dependencies]
 base64.workspace = true
-lxmf = { package = "lxmf-wire", path = "../../../LXMF-rs/crates/libs/lxmf-core", version = "0.9.6", default-features = false, features = ["std"] }
-lxmf-sdk = { path = "../../../LXMF-rs/crates/libs/lxmf-sdk", version = "0.9.6", default-features = false, features = ["zmq-pipeline-backend"] }
+lxmf = { package = "lxmf-wire", path = "../../../LXMF-rs/crates/libs/lxmf-core", version = "0.9.9", default-features = false, features = ["std"] }
+lxmf-sdk = { path = "../../../LXMF-rs/crates/libs/lxmf-sdk", version = "0.9.9", default-features = false, features = ["zmq-pipeline-backend"] }
 r3akt-protocol.workspace = true
-rns-rpc = { package = "reticulum-rs-rpc", path = "../../../LXMF-rs/crates/libs/rns-rpc", version = "0.9.6" }
+rns-rpc = { package = "reticulum-rs-rpc", path = "../../../LXMF-rs/crates/libs/rns-rpc", version = "0.9.9" }
 rmp-serde.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/r3akt-transport-rns/src/lib.rs
+++ b/crates/r3akt-transport-rns/src/lib.rs
@@ -4105,7 +4105,7 @@ mod tests {
                             "runtime_id": "test-runtime",
                             "contract_release": "v2.5",
                             "schema_namespace": "v2",
-                            "sdk_version": "0.9.5"
+                            "sdk_version": "0.9.9"
                         }),
                         "sdk_send_v2" => {
                             let message_id = format!("daemon-message-{sent_messages:05}");
@@ -4230,7 +4230,7 @@ mod tests {
             .or_insert_with(|| serde_json::json!("v2"));
         object
             .entry("sdk_version".to_string())
-            .or_insert_with(|| serde_json::json!("0.9.5"));
+            .or_insert_with(|| serde_json::json!("0.9.9"));
         response
     }
 
@@ -4404,7 +4404,7 @@ mod tests {
             vec![
                 serde_json::json!({
                     "runtime_id": "runtime-rch-zmq",
-                    "sdk_version": "0.9.5",
+                    "sdk_version": "0.9.9",
                     "active_contract_version": 2,
                     "contract_release": "sdk-v2",
                     "effective_capabilities": [

--- a/docs/operations-and-troubleshooting.md
+++ b/docs/operations-and-troubleshooting.md
@@ -112,7 +112,7 @@ RCH_RETICULUMD_BINARY=/absolute/path/to/reticulumd \
 npm --prefix apps/rch-desktop run build
 ```
 
-The path must name a trusted LXMF 0.9.5 binary built with
+The path must name a trusted LXMF 0.9.9 binary built with
 `zmq-pipeline-rpc`. Hosted release jobs do not use this override: they build
 the pinned LXMF commit in a clean checkout.
 

--- a/docs/release-notes-v3.0.0-preview.10.md
+++ b/docs/release-notes-v3.0.0-preview.10.md
@@ -1,0 +1,46 @@
+# RCH Rust v3.0.0-preview.10 release notes
+
+This prerelease moves the Rust 3.0 product line to the stable LXMF-rs 0.9.9
+baseline and includes the RCH improvements merged since preview.9. Python
+2.9.x remains the maintenance line on `rch-python`.
+
+## Highlights
+
+- Pins all release, CI, server, transport, and desktop package paths to the
+  immutable LXMF-rs `v0.9.9` release commit.
+- Restores inbound LXMF field commands and registers RCH as an independent
+  Reticulum service with distinct service identities.
+- Adds team-scoped REM directory routing and shared mesh delivery policy.
+- Prevents stale ZeroMQ control requests from accumulating after callers time
+  out, with operator-visible backpressure and expiry diagnostics.
+- Corrects topic subscription restoration and persistence while preserving
+  Python-compatible historical topicless rows.
+- Adds client-type filtering to the announces UI and repairs the hosted
+  compatibility workflow against the sibling LXMF checkout layout.
+- Refreshes the locked UI dependency graph so the production dependency audit
+  is clean before packaging.
+
+## LXMF-rs compatibility
+
+RCH preview.10 builds against stable LXMF-rs `v0.9.9`, commit
+`51fd3beebdace78d6c7f38748c6bcfe452032559`. The packaged `reticulumd` is
+built from that same immutable commit with `zmq-pipeline-rpc` enabled.
+
+LXMF-rs 0.9.9 targets Python Reticulum 1.4.2 software parity and ships its
+release interoperability, performance, package, checksum, SBOM, provenance,
+and OCI evidence separately. Hardware, public-network, and third-party-client
+validation remain separate evidence tracks.
+
+## Validation and artifacts
+
+See the [preview.10 stabilization report](stabilization-v3.0.0-preview.10.md)
+for the release-cut evidence. Server archives embed the RCH tag and commit,
+the exact LXMF-rs commit, and SHA-256 metadata.
+
+## Known boundaries
+
+- This is preview software, not stable `v3.0.0`.
+- External TAK and REM phone/deck checks require available infrastructure and
+  are disclosed separately when unavailable.
+- Operators should verify `/Status`, `/diagnostics/runtime`, processes,
+  listeners, and live ZeroMQ attachment for each deployment.

--- a/docs/release-readiness-audit.md
+++ b/docs/release-readiness-audit.md
@@ -5,11 +5,11 @@ It is intentionally stricter than a green CI badge: the initial Rust alpha is
 not release-ready until every required local, CI, server-package, ZeroMQ, REM,
 and Reticulum gate is either passed or recorded as an explicit alpha risk.
 
-Audit date: 2026-06-22; preview.9 supplement: 2026-07-19
+Audit date: 2026-06-22; preview.10 supplement: 2026-08-13
 
-The table retains historical evidence. Current preview.9 findings, validation,
+The table retains historical evidence. Current preview.10 findings, validation,
 limitations, and artifact identity are tracked in
-[`stabilization-v3.0.0-preview.9.md`](stabilization-v3.0.0-preview.9.md).
+[`stabilization-v3.0.0-preview.10.md`](stabilization-v3.0.0-preview.10.md).
 
 ## Objective
 

--- a/docs/rust-transition.md
+++ b/docs/rust-transition.md
@@ -84,9 +84,9 @@ capabilities.
 
 ## Current Validation Snapshot
 
-The dated evidence below is historical. The current preview.9 evidence and
+The dated evidence below is historical. The current preview.10 evidence and
 exact artifact metadata are maintained in
-[`stabilization-v3.0.0-preview.9.md`](stabilization-v3.0.0-preview.9.md).
+[`stabilization-v3.0.0-preview.10.md`](stabilization-v3.0.0-preview.10.md).
 
 Validated during the root Rust import and refreshed on 2026-05-11:
 
@@ -196,7 +196,7 @@ Release blockers cleared in the latest parity pass:
 - ZeroMQ is the permanent LXMF data plane for send, ordered batch acceptance,
   delivery status, and event traffic. RPC is an optional administration
   channel and must not be called from HTTP delivery or fanout hot paths.
-- Production dependencies use released LXMF `0.9.5`. The matching
+- Production dependencies use released LXMF `0.9.9`. The matching
   ZMQ-capable `reticulumd` is bundled and described by
   `config/lxmf-runtime-baseline.json`; sibling `main` is checked separately by
   the scheduled compatibility workflow.

--- a/docs/stabilization-v3.0.0-preview.10.md
+++ b/docs/stabilization-v3.0.0-preview.10.md
@@ -1,0 +1,46 @@
+# v3.0.0-preview.10 stabilization report
+
+## Scope
+
+This release cut validates RCH against the immutable stable LXMF-rs `v0.9.9`
+tag and includes the RCH changes merged after preview.9. The Python 2.9.x
+branch and shared-UI ownership contract are unchanged.
+
+## Release delta
+
+- Stable LXMF-rs 0.9.9 dependency, CI, package, and desktop-sidecar baseline.
+- Independent Reticulum service identities and restored inbound field commands.
+- Team-scoped REM routing and shared mesh delivery policy.
+- Expiring ZeroMQ control requests with backpressure diagnostics.
+- Python-compatible topic subscription persistence corrections.
+- Client-type announce filtering and repaired LXMF compatibility CI paths.
+
+## Validation evidence
+
+| Gate | Result |
+| --- | --- |
+| `cargo fmt --all -- --check` | Passed against LXMF-rs 0.9.9 |
+| strict workspace clippy | Passed with denied warnings |
+| workspace and release-critical crate tests | Workspace and separate server, core, transport, and TAK suites passed; 337 server tests passed and only the environment-gated load test was ignored |
+| committed `-ServerOnlyAlpha` release gate | Passed, including release build, documentation, and ZeroMQ-configured HTTP smoke |
+| UI dependency audit | Passed with zero production vulnerabilities after lockfile updates for `linkify-it`, `nanoid`, and `postcss` |
+| UI install, lint, type-check, tests, and production build | Passed; 35 files and 113 tests passed |
+| LXMF-rs 0.9.9 daemon build | Passed from the exact tag with `zmq-pipeline-rpc`; Windows binary SHA-256 `B1D9BB96EF5996A39FBF14091239B84191E4CF66B24A1EDE7F654446D3E7BB42` |
+| Windows desktop sidecar preparation and NSIS bundle | Passed with the exact LXMF-rs 0.9.9 daemon; emitted `RCH Desktop_3.0.0-preview.10_x64-setup.exe` |
+| published package workflow and asset audit | Pending publication |
+
+## External limitations
+
+External TAK infrastructure and REM phone/deck hardware are environment-gated.
+They are not implied by deterministic local or hosted package validation.
+
+## Release identity
+
+- Version/tag: `v3.0.0-preview.10`
+- Source branch: `main`
+- RCH release commit: pending
+- LXMF-rs baseline: `v0.9.9`, commit
+  `51fd3beebdace78d6c7f38748c6bcfe452032559`
+- Server archives: Windows x64, macOS x64, macOS arm64, Linux AMD64, Linux
+  Raspberry Pi 64
+- Desktop packages: Windows x64 NSIS, Linux x64 AppImage

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -3,7 +3,7 @@
 The Rust packaging line now has two release package shapes:
 
 - Server package: deployable `r3akt-rch-server` binary, `r3akt-tak-service`
-  binary, checksum-recorded LXMF `0.9.5` `reticulumd` binary with ZeroMQ
+  binary, checksum-recorded LXMF `0.9.9` `reticulumd` binary with ZeroMQ
   support, mandatory ZeroMQ southbound configuration, shared UI bundle, service
   helper files, config templates, and checksums. Current release CI builds
   Windows x64, macOS x64, macOS arm64, Linux AMD64, and Linux Raspberry Pi 64
@@ -21,9 +21,9 @@ The server-only alpha gate remains `scripts/release-readiness.ps1
 shape: manual workflow artifacts on `workflow_dispatch` and file attachment
 when a GitHub release is published. Server package names include the resolved
 release version, for example
-`rch-rust-full-windows-x64-v3.0.0-preview.9.zip`; the same version, Git ref,
+`rch-rust-full-windows-x64-v3.0.0-preview.10.zip`; the same version, Git ref,
 and commit SHA are written into `release-manifest.json` inside the archive.
-Manual workflow runs default to `v3.0.0-preview.9` and can override that label
+Manual workflow runs default to `v3.0.0-preview.10` and can override that label
 with the `release_version` input. While `main` remains the default branch,
 GitHub does not expose `workflow_dispatch` for workflows that only exist on
 `rust-next`, so the release workflow also runs on relevant `rust-next` pushes
@@ -37,11 +37,11 @@ passed on commit `8dc69773af38ced251138c007c6f0bdc9543ea02`. It uploaded
 artifacts matched their SHA-256 sidecars.
 
 Draft notes for the latest Rust preview are in
-`docs/release-notes-v3.0.0-preview.9.md`.
+`docs/release-notes-v3.0.0-preview.10.md`.
 
 Local desktop builds normally compile `reticulumd` from the sibling
 `LXMF-rs` checkout. Set `RCH_RETICULUMD_BINARY` to an absolute, validated
-LXMF 0.9.5 `reticulumd` path when that checkout is intentionally dirty; hosted
+LXMF 0.9.9 `reticulumd` path when that checkout is intentionally dirty; hosted
 packages always build the pinned clean LXMF commit.
 
 Pull request quality control is handled by

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3731,9 +3731,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",
@@ -4000,9 +4000,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -4316,9 +4316,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4335,7 +4335,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary
- prepare RCH Rust v3.0.0-preview.10
- pin CI, release packaging, Cargo dependencies, runtime metadata, and desktop sidecars to stable LXMF-rs v0.9.9 commit 51fd3beebdace78d6c7f38748c6bcfe452032559
- refresh desktop version metadata and release documentation
- remediate the production UI lockfile audit findings

## Validation
- .\scripts\release-readiness.ps1 -ServerOnlyAlpha
- cargo test -p r3akt-rch-server
- cargo test -p r3akt-rch-core
- cargo test -p r3akt-transport-rns
- cargo test -p r3akt-tak-connector
- npm --prefix ui ci / audit --omit=dev / lint / typecheck / test / build
- exact-tag reticulumd release build with zmq-pipeline-rpc
- Windows Tauri NSIS bundle with the exact v0.9.9 reticulumd sidecar